### PR TITLE
Add GitHub Actions to auto-deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      
+    - name: Hugo setup
+      uses: peaceiris/actions-hugo@v2.4.11
+    
+    - name: Build
+      run: hugo
+      
+    - name: Copy files
+      run: cd public && cp ../README.md ./ && cp ../.asf.yaml ./
+      
+    - name: GitHub Pages
+      uses: crazy-max/ghaction-github-pages@v2.0.1
+      with:
+        build_dir: public
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub Actions to auto-deploy master branch to gh-pages

Works fine on my fork. See:
- https://github.com/Rapiz1/incubator-apisix-website
- https://github.com/Rapiz1/incubator-apisix-website/tree/gh-pages

Resolves https://github.com/apache/incubator-apisix-dashboard/issues/213

@juzhiyuan Kindly review