### PR TITLE
fix: use empty docsUri

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -111,7 +111,8 @@ const siteConfig = {
   gaTrackingId: '',
   twitterUsername: 'ApacheAPISIX',
   scrollToTop: true,
-  docsSideNavCollapsible: true
+  docsSideNavCollapsible: true,
+  docsUrl: ''
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
resolve https://github.com/apache/apisix-website/issues/81
resolve https://github.com/apache/apisix/issues/2647

according to https://docusaurus.io/docs/en/site-config

Note: this change will lead to `apisix.apache.org/docs/downloads` to 404, but it's ok for me due to we will use `apisix.apache.org/downloads` in the future.