### PR TITLE
fix: change the download links for  hash and sig

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -24,7 +24,7 @@ Use the links below to download the Apache APISIX™ from one of our mirrors.
 
 | Version | Release Date | Downloads                                                                                                                                                                                                                                                                                                       |
 | ------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.0     | 24/12/2020   | [source](https://www.apache.org/dyn/closer.cgi/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz) ([asc](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.asc) [sha512](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.sha512)) |
+| 0.1.0     | 24/12/2020   | [source](https://www.apache.org/dyn/closer.cgi/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz) ([asc](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.asc) [sha512](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.sha512)) |
 
 ## Verify the releases
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -24,7 +24,7 @@ Use the links below to download the Apache APISIX™ from one of our mirrors.
 
 | Version | Release Date | Downloads                                                                                                                                                                                                                                                                                                       |
 | ------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.0     | 24/12/2020   | [source](https://www.apache.org/dyn/closer.cgi/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz) ([asc](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz.asc) [sha512](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz.sha512)) |
+| 0.1.0     | 24/12/2020   | [source](https://www.apache.org/dyn/closer.cgi/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz) ([asc](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.asc) [sha512](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.sha512)) |
 
 ## Verify the releases
 


### PR DESCRIPTION
Related to apache/apisix-ingress-controller#146