### PR TITLE
fix: Ingress-controller version number changed back to 0.1.0-rc2

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -24,7 +24,7 @@ Use the links below to download the Apache APISIX™ from one of our mirrors.
 
 | Version | Release Date | Downloads                                                                                                                                                                                                                                                                                                       |
 | ------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.0     | 24/12/2020   | [source](https://www.apache.org/dyn/closer.cgi/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz) ([asc](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.asc) [sha512](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-src.tar.gz.sha512)) |
+| 0.1.0-rc2     | 24/12/2020   | [source](https://www.apache.org/dyn/closer.cgi/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz) ([asc](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz.asc) [sha512](https://downloads.apache.org/apisix/apisix-ingress-controller-0.1.0/apache-apisix-ingress-controller-0.1.0-rc2-src.tar.gz.sha512)) |
 
 ## Verify the releases
 


### PR DESCRIPTION
Fixes: https://github.com/apache/apisix-ingress-controller/issues/146

In my In the [voting email](https://lists.apache.org/thread.html/r4d55e4f94bf46fb4edc9243c1db37b8cdaed850630d7637e20e4e6a6%40%3Cdev.apisix.apache.org%3E), I always use the name 0.1.0-rc2.

But when I was updating svn, because of some understanding errors, I manually removed rc2, which caused sha512 to break.

In order to remedy my mistake, I think I should point all download links to the 0.1.0-rc2 address and delete the 0.1.0 download link.Ensure that hash and sig are consistent with the mailing list.