### PR TITLE
fix: Visit Downloads page without docs prefix #159

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,6 +56,7 @@ module.exports={
           "showLastUpdateAuthor": true,
           "showLastUpdateTime": true,
           "path": "docs",
+          "routeBasePath":'/',
           "editUrl": "https://github.com/apache/apisix-website/edit/master/website",
           "sidebarPath": "../website/sidebars.json"
         },
@@ -88,12 +89,12 @@ module.exports={
           "position": "left"
         },
         {
-          "to": "docs/downloads",
+          "to": "/downloads",
           "label": "Downloads",
           "position": "left"
         },
         {
-          "to": "docs/team",
+          "to": "/team",
           "label": "Team",
           "position": "left"
         },


### PR DESCRIPTION
Fixes: #159

Changes:
update docusaurus.config.js

Screenshots of the change:

![Screenshot (105)](https://user-images.githubusercontent.com/53715187/107115580-a3a65400-6893-11eb-9f24-e23bded2f876.png)
![Screenshot (106)](https://user-images.githubusercontent.com/53715187/107115582-a99c3500-6893-11eb-8bd9-150c37febde0.png)

