### PR TITLE
docs: remove redundant step in release-guide.md

### DIFF
--- a/website/docs/release-guide.md
+++ b/website/docs/release-guide.md
@@ -208,9 +208,6 @@ git clone -b v$APISIX_VERSION git@github.com:apache/apisix.git apache-apisix-$AP
 # check version
 $ cd apache-apisix-$APISIX_VERSION && ./utils/check-version.sh $APISIX_VERSION && cd ..
 
-# delete .git
-$ rm -rf apache-apisix-$APISIX_VERSION/.git
-
 # make tar package / asc / sha512
 $ cd apache-apisix-$APISIX_VERSION && make release-src VERSION=$APISIX_VERSION
 $ mv ./release/* ../ && cd ..


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

Hello, now the apisix and apisix-dashboard project's `Makefile` will exclude the `.git` file.
So I think we don't do this step in the release-guide.

See: https://github.com/apache/apisix-dashboard/blob/fda123c28dda7e4f4ae5d649b286ffcaebc568ae/Makefile#L114
See: https://github.com/apache/apisix/blob/c895cdf4ff008c13dec8197e9f0a0407be144517/Makefile#L226

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
