### PR TITLE
fix: image URL in the Help page

### DIFF
--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -22,7 +22,7 @@ function Help(props) {
         <div class="card">
           <div className="header">
             <h2>
-              <img src="../../static/img/documents.png" id="documents-icon" />
+              <img src="/img/documents.png" id="documents-icon" />
               Browse Docs
             </h2>
           </div>
@@ -39,7 +39,7 @@ function Help(props) {
         <div class="card">
           <div className="header">
             <h2>
-              <img src="../../static/img/community.png" />
+              <img src="/img/community.png" />
               Join the community
             </h2>
           </div>


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

Use relative IMG link in the Help page

Screenshots of the change:

**Before**
![image](https://user-images.githubusercontent.com/2106987/107593146-a3b6a300-6c49-11eb-9f60-4e3b587eb1d8.png)

**After**
![image](https://user-images.githubusercontent.com/2106987/107593191-c21c9e80-6c49-11eb-9ff3-186f67f6db7e.png)
