### PR TITLE
fix: remove global shadow on mobile

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -51,6 +51,9 @@ header h2 {
 .navbar__link--active {
   color: var(--color-primary);
 }
+.navbar-sidebar {
+  box-shadow: unset;
+}
 
 /* home splash */
 .home-splash {
@@ -269,7 +272,7 @@ a:hover {
   opacity: 0.88;
 }
 
-/* 
+/*
   Animations
 */
 


### PR DESCRIPTION
**Fixes:** #185

**Changes:**

Add a new stylesheet entry to prevent the display of global shadows.

**Screenshots of the change:**

![image](https://user-images.githubusercontent.com/8078418/107845069-c8f70d00-6e13-11eb-8b8e-80a73b22ea85.png)

