### PR TITLE
docs: add 'gpg --import KEYS' to release guide

### DIFF
--- a/website/docs/release-guide.md
+++ b/website/docs/release-guide.md
@@ -248,7 +248,80 @@ Committed revision 37435.
 
 ### Send VOTE thread to the dev mailing list
 
-Click [here](https://lists.apache.org/thread.html/rf534952a6b2d23ed6efdd61f15b40fa9e4de230164a1ccf168176734%40%3Cdev.apisix.apache.org%3E) to view the reference email. There is a minimum wait of 72 hours before statistical voting results. If you get -1 vote, you need to solve the problem before you can continue.
+There is a minimum wait of 72 hours before statistical voting results. If you get -1 vote, you need to solve the problem before you can continue. The reference email is as shown below.
+
+```
+Hello, Community,
+This is a call for the vote to release Apache APISIX version 2.0.
+
+Release notes:
+
+https://github.com/apache/apisix/blob/2.0/CHANGELOG.md#200
+
+The release candidates:
+
+https://dist.apache.org/repos/dist/dev/apisix/2.0/
+<https://dist.apache.org/repos/dist/dev/apisix/1.5-rc1/>
+
+Git tag for the release:
+
+https://github.com/apache/apisix/tree/2.0
+<https://github.com/apache/apisix/tree/v1.5>
+
+Release Commit ID:
+
+https://github.com/apache/apisix/commit/79be83dd8adfbd5a1d98e0685c5db67166adac3f
+
+Keys to verify the Release Candidate:
+
+https://dist.apache.org/repos/dist/release/apisix/KEYS
+<https://dist.apache.org/repos/dist/dev/apisix/KEYS>
+
+Steps to validating the release:
+
+1. Download the release
+
+wget
+https://dist.apache.org/repos/dist/dev/apisix/2.0/apache-apisix-2.0-src.tgz
+
+
+2. Checksums and signatures
+
+wget https://dist.apache.org/repos/dist/release/apisix/KEYS
+
+wget
+https://dist.apache.org/repos/dist/dev/apisix/2.0/apache-apisix-2.0-src.tgz.asc
+
+wget
+https://dist.apache.org/repos/dist/dev/apisix/2.0/apache-apisix-2.0-src.tgz.sha512
+
+gpg --import KEYS
+
+shasum -c apache-apisix-2.0-src.tgz.sha512
+
+gpg --verify apache-apisix-2.0-src.tgz.asc apache-apisix-2.0-src.tgz
+
+3. Unzip and Check files
+
+tar zxvf apache-apisix-2.0-src.tgz
+
+4. Build Apache APISIX:
+
+https://github.com/apache/apisix/blob/2.0/doc/how-to-build.md#installation-via-source-release
+
+The vote will be open for at least 72 hours or until necessary number of
+votes are reached.
+
+Please vote accordingly:
+
+[ ] +1 approve
+[ ] +0 no opinion
+[ ] -1 disapprove with the reason
+
+Thanks,
+Ming Wen, Apache APISIX & Apache SkyWalking
+Twitter: _WenMing
+```
 
 ### Send VOTE RESULT thread to the dev mailing list
 

--- a/website/docs/release-guide.md
+++ b/website/docs/release-guide.md
@@ -261,12 +261,10 @@ https://github.com/apache/apisix/blob/2.0/CHANGELOG.md#200
 The release candidates:
 
 https://dist.apache.org/repos/dist/dev/apisix/2.0/
-<https://dist.apache.org/repos/dist/dev/apisix/1.5-rc1/>
 
 Git tag for the release:
 
 https://github.com/apache/apisix/tree/2.0
-<https://github.com/apache/apisix/tree/v1.5>
 
 Release Commit ID:
 
@@ -274,8 +272,7 @@ https://github.com/apache/apisix/commit/79be83dd8adfbd5a1d98e0685c5db67166adac3f
 
 Keys to verify the Release Candidate:
 
-https://dist.apache.org/repos/dist/release/apisix/KEYS
-<https://dist.apache.org/repos/dist/dev/apisix/KEYS>
+https://dist.apache.org/repos/dist/dev/apisix/KEYS
 
 Steps to validating the release:
 
@@ -287,7 +284,7 @@ https://dist.apache.org/repos/dist/dev/apisix/2.0/apache-apisix-2.0-src.tgz
 
 2. Checksums and signatures
 
-wget https://dist.apache.org/repos/dist/release/apisix/KEYS
+wget https://dist.apache.org/repos/dist/dev/apisix/KEYS
 
 wget
 https://dist.apache.org/repos/dist/dev/apisix/2.0/apache-apisix-2.0-src.tgz.asc
@@ -318,9 +315,6 @@ Please vote accordingly:
 [ ] +0 no opinion
 [ ] -1 disapprove with the reason
 
-Thanks,
-Ming Wen, Apache APISIX & Apache SkyWalking
-Twitter: _WenMing
 ```
 
 ### Send VOTE RESULT thread to the dev mailing list


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

Changes:

Currently in release guide, users are told to download gpg KEYS file but not use it. 
Since the original template is an immutable email, the template was copied from the email to the board so we could easily fix it.

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
