### PR TITLE
Fix the "Add your company" link

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -142,7 +142,7 @@ const Showcase = () => {
           <br />
           Are you using this project?{" "}
           <a
-            href="https://github.com/apache/apisix/blob/master/doc/powered-by.md"
+            href="https://github.com/apache/apisix/blob/master/docs/en/latest/powered-by.md"
             target="_blank"
             rel="noopener"
           >


### PR DESCRIPTION
Fixes: https://github.com/apache/apisix/issues/3679

Changes: Update the "Add your company" link

Screenshots of the change:

<img width="487" alt="image" src="https://user-images.githubusercontent.com/1284465/109175153-7842c500-77c0-11eb-8121-9eb6da8dfd23.png">
