### PR TITLE
fix: Wrong doc url (#231)

### DIFF
--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -47,7 +47,7 @@ function Help(props) {
           <p>Learn more using the documentation on this site.</p>
           <div className="buttons">
             <a
-              href="https://github.com/apache/apisix/tree/master/doc"
+              href="https://apisix.apache.org/docs/"
               target="_blank"
             >
               Read Documents


### PR DESCRIPTION
Fixes: #231 

Changes:

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
The wrong doc link in https://apisix.apache.org/help is replaced by correct one.

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->

Screenshot of wrong url:
![image](https://user-images.githubusercontent.com/55776390/109657481-8eb79a80-7b8b-11eb-8755-66132c4ea375.png)

Screenshot of correct url:
![image](https://user-images.githubusercontent.com/55776390/109657696-ccb4be80-7b8b-11eb-8f81-95d4f0d94fa3.png)

