### PR TITLE
fix: fix the version number in mobile size overflow

### DIFF
--- a/website/src/theme/DocSidebar/styles.module.css
+++ b/website/src/theme/DocSidebar/styles.module.css
@@ -21,16 +21,6 @@
     transition: opacity 50ms ease;
   }
 
-  .sidebarVersionSwitch {
-    display: flex;
-    align-items: center;
-    padding: 4px 1rem;
-    margin: 1rem;
-    border-radius: 0.5rem;
-    border: 1px solid #eee;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
-  }
-
   .sidebarWithHideableNavbar {
     padding-top: 0;
   }

--- a/website/src/theme/DocSidebar/styles.module.css
+++ b/website/src/theme/DocSidebar/styles.module.css
@@ -120,6 +120,20 @@
   width: 24px;
 }
 
+.sidebarVersionSwitch {
+  display: flex;
+  align-items: center;
+  padding: 4px 1rem;
+  margin: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #eee;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.03);
+}
+
+.sidebarVersionSwitch a {
+  display: inline-block;
+}
+
 :global(.menu__list) :global(.menu__list) {
   overflow-y: hidden;
   will-change: height;


### PR DESCRIPTION
Fixes: #224

Changes:
I adjust the `sidebarVersionSwitch` to outside and add the `sidebarVersionSwitch a` class to prevent when the screen size below 997px, the **a** tag will be adding `display: none` property.

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
![image](https://user-images.githubusercontent.com/22230889/110121706-af852780-7df9-11eb-90be-bc75bea90cfa.png)

![image](https://user-images.githubusercontent.com/22230889/110121732-b875f900-7df9-11eb-9717-2229c02d5a0d.png)
