### PR TITLE
feat: broken link checker script

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -33,5 +33,5 @@ jobs:
           node sync-docs.js && git status
 
       - name: Check Links
-          run: |
-            node link-checker.js && git status
+        run: |
+          node link-checker.js && git status

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -41,5 +41,5 @@ jobs:
         if: always()
         with:
           name: broken-links.json
-          path: brokenList.json
+          path: brokenLinks.json
           retention-days: 5

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  check:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -35,3 +35,11 @@ jobs:
       - name: Check Links
         run: |
           node link-checker.js && git status
+
+      - name: Archive Broken Links List
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: broken-links.json
+          path: brokenList.json
+          retention-days: 5

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Check broken links
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
+    - cron: "0 5 * * *"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+
+      - name: Pull Docs
+        run: |
+          node sync-docs.js && git status
+
+      - name: Check Links
+          run: |
+            node link-checker.js && git status

--- a/common.js
+++ b/common.js
@@ -1,0 +1,18 @@
+// NOTE: disable "apisix-docker" "apisix-helm-chart" currently
+const projects = ["apisix-ingress-controller", "apisix", "apisix-dashboard"];
+const languages = ["en", "zh", "es"];
+
+module.exports = {
+  projects,
+  languages,
+  projectPaths: () => projects.map((project) => {
+    return {
+      project: project,
+      pluginId: `docs-${project}`,
+      paths: {
+        en: `./website/docs/${project}`,
+        zh: `./website/i18n/zh/docusaurus-plugin-content-docs-docs-${project}/current`,
+      },
+    };
+  })
+}

--- a/link-checker.js
+++ b/link-checker.js
@@ -114,6 +114,6 @@ const linkValidate = (link) => {
 	let result = await Promise.all(externalLinkCheckPromises);
 	let brokenList = result.filter((item) => item.statusText !== "OK");
 
-	console.log("Write broken list to file");
-	fs.writeFileSync('./brokenLink.json', JSON.stringify(brokenList));
+	console.log("[Finish] Write broken list to file");
+	fs.writeFileSync('./brokenLinks.json', JSON.stringify(brokenList));
 })();

--- a/link-checker.js
+++ b/link-checker.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+const path = require("path");
+const childProcess = require("child_process");
+const mdLinks = require("markdown-links-validator").mdLinks;
+
+const projects = ["apisix-ingress-controller", "apisix", "apisix-dashboard"];
+
+const scanFolder = (tarDir) => {
+	let filePaths = [];
+	let files = fs.readdirSync(tarDir);
+	files.forEach((file) => {
+		const tarPath = path.join(tarDir, file);
+		let stats = fs.statSync(tarPath);
+		if (stats.isDirectory()) {
+			filePaths.push(...scanFolder(tarPath));
+		} else {
+			filePaths.push(tarPath);
+		}
+	});
+
+	return filePaths;
+}
+
+(async function main() {
+	console.log("Start link-checker.js");
+	console.log("Install dependencies");
+	childProcess.execSync("npm i --save markdown-links-validator");
+
+	console.log("Scan all documents");
+	let allDocPaths = [];
+	projects.map((project) => {
+		let latestDocs = {
+			en: `./website/docs/${project}`,
+			zh: `./website/i18n/zh/docusaurus-plugin-content-docs-docs-${project}/current`,
+		};
+
+		Object.values(latestDocs).forEach((docPath) => {
+			if (!fs.existsSync(docPath)) return;
+			allDocPaths.push(...scanFolder(docPath))
+		});
+	});
+
+	console.log("Scan broken links");
+	let brokenLinks = [];
+	for (const file of allDocPaths) {
+		try {
+			let links = await mdLinks(file, {validate: true});
+			links.forEach((link) => {
+				if (link.statusText === "FAIL") {
+					brokenLinks.push(link);
+				}
+				console.log(`[Check Link] check "${link.url}", result is ${link.statusText}`);
+			});
+		} catch (e) {
+
+		}
+	}
+
+	console.log("Write broken list to file");
+	fs.writeFileSync('./brokenLink.json', JSON.stringify(brokenLinks));
+})();

--- a/link-checker.js
+++ b/link-checker.js
@@ -20,7 +20,7 @@ const scanFolder = (tarDir) => {
 	return filePaths;
 }
 
-const scanLinkInMDFile = (filePath) => {
+const scanLinkInMDFile = (filePath, project) => {
 	const fileContent = fs.readFileSync(filePath, 'utf-8');
 	const regex = /\[[\s\S]*?\]\([\s\S]*?\)/g;
 	if (fileContent.match(regex)) {
@@ -29,31 +29,57 @@ const scanLinkInMDFile = (filePath) => {
 			const textHrefDivide = item.split('](');
 			const text = textHrefDivide[0].replace('[', '');
 			const url = textHrefDivide[1].replace(')', '');
-			if (!url.endsWith(".md")) return false;
 			return ({url, text, file: filePath});
 		});
 
 		// filter out links to other Markdown files
-		const filteredList = [];
-		const unfilteredList = links.filter((link) => {
-			if (!link) return false;
-			const result = link.url.startsWith("http://") || link.url.startsWith("https://");
-			if (!result) {
-				if (link.url.startsWith("#") || link.url.indexOf("#") > 0) {
-					let split = link.url.split("#");
-					if (split.length > 1) {
-						link.anchor = "#" + split[1];
-						link.url = path.normalize(path.dirname(filePath) + "/" + link.url);
-					} else {
-						link.anchor = link.url;
-						link.url = filePath;
-					}
-				} else {
-					link.url = path.normalize(path.dirname(filePath) + "/" + link.url);
-				}
-				filteredList.push(link)
+		const filteredList = []; // local files
+		const unfilteredList = links.filter((link) => { // web links
+			let url = link.url.trim();
+			if (url.startsWith("http://") || url.startsWith("https://")) {
+				link.url = url;
+				return true;
 			}
-			return result;
+
+			// url preprocess
+			if (url.startsWith("#") || url.indexOf("#") > 0) { // such as "#abcd"
+				let split = url.split("#").filter(item => item !== "");
+				if (split.length > 1) {
+					link.anchor = "#" + split[1];
+					url = path.normalize(path.dirname(filePath) + "/" + link.url);
+				} else {
+					link.anchor = link.url;
+					url = filePath;
+				}
+			} else if (url === "LICENSE" || url === 'logos/apache-apisix.png') {
+				url = "https://github.com/apache/" + project + "/blob/master/" + url;
+			} else if (!url.endsWith(".md")) { // not end with ".md"
+				let lang = filePath.startsWith("website\\docs") ? "en" : filePath.split("i18n\\")[1].split("\\")[0];
+				let subPath = filePath.startsWith("website\\docs") ? path.dirname(filePath.split("docs\\" + project + "\\")[1]) : path.dirname(filePath.split("docs-" + project + "\\current\\")[1]);
+				subPath = subPath !== "." ? subPath + "/" : "";
+				let originPath = path.normalize("docs/" + lang + "/latest/" + subPath + url).replace(/\\/g, '/');
+
+				url = "https://github.com/apache/" + project + "/blob/master/" + originPath;
+			} else { // such as "./abcd", "../abcd", "../../../abcd"
+				url = path.normalize(path.dirname(filePath) + "/" + url);
+			}
+
+			// set url
+			let originLink = link.url;
+			link.url = url;
+
+			// url postprocess
+			if (!url.startsWith("http://") && !url.startsWith("https://")) {
+				filteredList.push(link);
+				return false;
+			}
+
+			// replace the converted link with the original document
+			let documentContent = fs.readFileSync(filePath, 'utf8');
+			documentContent = documentContent.replace(new RegExp(originLink, "g"), link.url);
+			fs.writeFileSync(filePath, documentContent, 'utf8');
+
+			return true;
 		});
 		return {
 			links: unfilteredList,
@@ -96,7 +122,7 @@ const linkValidate = (link) => {
 	childProcess.execSync("npm i --save axios");
 
 	console.log("[Document Scanner] Scan all documents");
-	let allDocPaths = [];
+	let allDocuments = [];
 	projects.map((project) => {
 		let latestDocs = {
 			en: `./website/docs/${project}`,
@@ -105,23 +131,31 @@ const linkValidate = (link) => {
 
 		Object.values(latestDocs).forEach((docPath) => {
 			if (!fs.existsSync(docPath)) return;
-			allDocPaths.push(...scanFolder(docPath))
+			allDocuments.push({
+				files: scanFolder(docPath),
+				docPath,
+				project,
+			})
 		});
 	});
 
 	console.log("[Link Scanner] Scan all links");
 	let externalLinks = []; // links to other sites
 	let internalLinks = []; // links to other Markdown files or anchor
-	for (const file of allDocPaths) {
-		const scanResult = scanLinkInMDFile(file);
-		externalLinks.push(...scanResult.links);
-		internalLinks.push(...scanResult.filteredLinks);
+	for (const documents of allDocuments) {
+		documents.files.forEach((file) => {
+			const scanResult = scanLinkInMDFile(file, documents.project);
+			externalLinks.push(...scanResult.links);
+			internalLinks.push(...scanResult.filteredLinks);
+		});
 	}
 
+	//console.log(`[Link Scanner] External Links\n`, externalLinks.map(item => item.url).join("\n"));
+	//console.log(`[Link Scanner] Internal Links\n`, internalLinks.map(item => item.url).join("\n"));
 	console.log(`[Link Scanner] Scan result: ${externalLinks.length} external links, ${internalLinks.length} internal links`)
 
-	let externalBrokenList = [];
 	console.log(`[Link Checker] Start external link check`);
+	let externalBrokenList = [];
 	let externalLinkCheckPromises = [];
 	externalLinks.forEach((link) => {
 		externalLinkCheckPromises.push(linkValidate(link));
@@ -129,6 +163,7 @@ const linkValidate = (link) => {
 
 	let result = await Promise.all(externalLinkCheckPromises);
 	externalBrokenList.push(...result.filter((item) => item.status !== 200));
+	console.log(`[Link Checker] External link check finished`);
 
 	console.log(`[Link Checker] Start internal link check`);
 	let internalBrokenList = [];
@@ -140,6 +175,7 @@ const linkValidate = (link) => {
 		}
 		console.log(`[Link Checker] check "${link.url}", result is ${exist}`)
 	});
+	console.log(`[Link Checker] Internal link check finished`);
 
 	console.log("[Finish] Write broken list to file");
 	fs.writeFileSync('./brokenLinks.json', JSON.stringify({

--- a/link-checker.js
+++ b/link-checker.js
@@ -46,7 +46,7 @@ const scanLinkInMDFile = (filePath, project) => {
 				let split = url.split("#").filter(item => item !== "");
 				if (split.length > 1) {
 					link.anchor = "#" + split[1];
-					url = path.normalize(path.dirname(filePath) + "/" + link.url);
+					url = path.normalize(path.dirname(filePath) + path.sep + link.url);
 				} else {
 					link.anchor = link.url;
 					url = filePath;
@@ -54,14 +54,15 @@ const scanLinkInMDFile = (filePath, project) => {
 			} else if (url === "LICENSE" || url === 'logos/apache-apisix.png') {
 				url = "https://github.com/apache/" + project + "/blob/master/" + url;
 			} else if (!url.endsWith(".md")) { // not end with ".md"
-				let lang = filePath.startsWith("website\\docs") ? "en" : filePath.split("i18n\\")[1].split("\\")[0];
-				let subPath = filePath.startsWith("website\\docs") ? path.dirname(filePath.split("docs\\" + project + "\\")[1]) : path.dirname(filePath.split("docs-" + project + "\\current\\")[1]);
-				subPath = subPath !== "." ? subPath + "/" : "";
-				let originPath = path.normalize("docs/" + lang + "/latest/" + subPath + url).replace(/\\/g, '/');
+				console.log(filePath, link.url, filePath.startsWith("website\\docs"));
+				let lang = filePath.startsWith("website" + path.sep + "docs") ? "en" : filePath.split("i18n" + path.sep)[1].split(path.sep)[0];
+				let subPath = filePath.startsWith("website" + path.sep + "docs") ? path.dirname(filePath.split("docs" + path.sep + project + path.sep)[1]) : path.dirname(filePath.split("docs-" + project + path.sep + "current" + path.sep)[1]);
+				subPath = subPath !== "." ? subPath + path.sep : "";
+				let originPath = path.normalize("docs" + path.sep + lang + path.sep + "latest" + path.sep + subPath + url).replace(/\\/g, '/');
 
 				url = "https://github.com/apache/" + project + "/blob/master/" + originPath;
 			} else { // such as "./abcd", "../abcd", "../../../abcd"
-				url = path.normalize(path.dirname(filePath) + "/" + url);
+				url = path.normalize(path.dirname(filePath) + path.sep + url);
 			}
 
 			// set url

--- a/link-checker.js
+++ b/link-checker.js
@@ -56,7 +56,7 @@ const linkValidate = (link) => {
 		const axios = require("axios");
 		axios.get(link.url)
 				.then((res) => {
-					console.log(`[Link Checker] check ${link.url}, result is ${res.statusText}`)
+					console.log(`[Link Checker] check "${link.url}", result is ${res.statusText}`)
 					resolve({
 						...link,
 						status: res.status,
@@ -67,7 +67,7 @@ const linkValidate = (link) => {
 					console.log(`[Link Checker] check ${link.url}, result is FAIL`);
 					resolve({
 						...link,
-						status: 404,
+						status: err.response.status,
 						statusText: 'FAIL',
 					});
 				});
@@ -112,7 +112,7 @@ const linkValidate = (link) => {
 
 
 	let result = await Promise.all(externalLinkCheckPromises);
-	let brokenList = result.filter((item) => item.statusText !== "OK");
+	let brokenList = result.filter((item) => item.status !== 200);
 
 	console.log("[Finish] Write broken list to file");
 	fs.writeFileSync('./brokenLinks.json', JSON.stringify(brokenList));

--- a/link-checker.js
+++ b/link-checker.js
@@ -5,182 +5,182 @@ const childProcess = require("child_process");
 const projects = ["apisix-ingress-controller", "apisix", "apisix-dashboard"];
 
 const scanFolder = (tarDir) => {
-	let filePaths = [];
-	let files = fs.readdirSync(tarDir);
-	files.forEach((file) => {
-		const tarPath = path.join(tarDir, file);
-		let stats = fs.statSync(tarPath);
-		if (stats.isDirectory()) {
-			filePaths.push(...scanFolder(tarPath));
-		} else {
-			filePaths.push(tarPath);
-		}
-	});
+  let filePaths = [];
+  let files = fs.readdirSync(tarDir);
+  files.forEach((file) => {
+    const tarPath = path.join(tarDir, file);
+    let stats = fs.statSync(tarPath);
+    if (stats.isDirectory()) {
+      filePaths.push(...scanFolder(tarPath));
+    } else {
+      filePaths.push(tarPath);
+    }
+  });
 
-	return filePaths;
+  return filePaths;
 }
 
 const scanLinkInMDFile = (filePath, project) => {
-	const fileContent = fs.readFileSync(filePath, 'utf-8');
-	const regex = /\[[\s\S]*?\]\([\s\S]*?\)/g;
-	if (fileContent.match(regex)) {
-		const arrayOfLinks = fileContent.match(regex);
-		const links = arrayOfLinks.map((item) => {
-			const textHrefDivide = item.split('](');
-			const text = textHrefDivide[0].replace('[', '');
-			const url = textHrefDivide[1].replace(')', '');
-			return ({url, text, file: filePath});
-		});
+  const fileContent = fs.readFileSync(filePath, 'utf-8');
+  const regex = /\[[\s\S]*?\]\([\s\S]*?\)/g;
+  if (fileContent.match(regex)) {
+    const arrayOfLinks = fileContent.match(regex);
+    const links = arrayOfLinks.map((item) => {
+      const textHrefDivide = item.split('](');
+      const text = textHrefDivide[0].replace('[', '');
+      const url = textHrefDivide[1].replace(')', '');
+      return ({ url, text, file: filePath });
+    });
 
-		// filter out links to other Markdown files
-		const filteredList = []; // local files
-		const unfilteredList = links.filter((link) => { // web links
-			let url = link.url.trim();
-			if (url.startsWith("http://") || url.startsWith("https://")) {
-				link.url = url;
-				return true;
-			}
+    // filter out links to other Markdown files
+    const filteredList = []; // local files
+    const unfilteredList = links.filter((link) => { // web links
+      let url = link.url.trim();
+      if (url.startsWith("http://") || url.startsWith("https://")) {
+        link.url = url;
+        return true;
+      }
 
-			// url preprocess
-			if (url.startsWith("#") || url.indexOf("#") > 0) { // such as "#abcd"
-				let split = url.split("#").filter(item => item !== "");
-				if (split.length > 1) {
-					link.anchor = "#" + split[1];
-					url = path.normalize(path.dirname(filePath) + path.sep + link.url);
-				} else {
-					link.anchor = link.url;
-					url = filePath;
-				}
-			} else if (url === "LICENSE" || url === 'logos/apache-apisix.png') {
-				url = "https://github.com/apache/" + project + "/blob/master/" + url;
-			} else if (!url.endsWith(".md")) { // not end with ".md"
-				console.log(filePath, link.url, filePath.startsWith("website\\docs"));
-				let lang = filePath.startsWith("website" + path.sep + "docs") ? "en" : filePath.split("i18n" + path.sep)[1].split(path.sep)[0];
-				let subPath = filePath.startsWith("website" + path.sep + "docs") ? path.dirname(filePath.split("docs" + path.sep + project + path.sep)[1]) : path.dirname(filePath.split("docs-" + project + path.sep + "current" + path.sep)[1]);
-				subPath = subPath !== "." ? subPath + path.sep : "";
-				let originPath = path.normalize("docs" + path.sep + lang + path.sep + "latest" + path.sep + subPath + url).replace(/\\/g, '/');
+      // url preprocess
+      if (url.startsWith("#") || url.indexOf("#") > 0) { // such as "#abcd"
+        let split = url.split("#").filter(item => item !== "");
+        if (split.length > 1) {
+          link.anchor = "#" + split[1];
+          url = path.normalize(path.dirname(filePath) + path.sep + link.url);
+        } else {
+          link.anchor = link.url;
+          url = filePath;
+        }
+      } else if (url === "LICENSE" || url === 'logos/apache-apisix.png') {
+        url = "https://github.com/apache/" + project + "/blob/master/" + url;
+      } else if (!url.endsWith(".md")) { // not end with ".md"
+        console.log(filePath, link.url, filePath.startsWith("website\\docs"));
+        let lang = filePath.startsWith("website" + path.sep + "docs") ? "en" : filePath.split("i18n" + path.sep)[1].split(path.sep)[0];
+        let subPath = filePath.startsWith("website" + path.sep + "docs") ? path.dirname(filePath.split("docs" + path.sep + project + path.sep)[1]) : path.dirname(filePath.split("docs-" + project + path.sep + "current" + path.sep)[1]);
+        subPath = subPath !== "." ? subPath + path.sep : "";
+        let originPath = path.normalize("docs" + path.sep + lang + path.sep + "latest" + path.sep + subPath + url).replace(/\\/g, '/');
 
-				url = "https://github.com/apache/" + project + "/blob/master/" + originPath;
-			} else { // such as "./abcd", "../abcd", "../../../abcd"
-				url = path.normalize(path.dirname(filePath) + path.sep + url);
-			}
+        url = "https://github.com/apache/" + project + "/blob/master/" + originPath;
+      } else { // such as "./abcd", "../abcd", "../../../abcd"
+        url = path.normalize(path.dirname(filePath) + path.sep + url);
+      }
 
-			// set url
-			let originLink = link.url;
-			link.url = url;
+      // set url
+      let originLink = link.url;
+      link.url = url;
 
-			// url postprocess
-			if (!url.startsWith("http://") && !url.startsWith("https://")) {
-				filteredList.push(link);
-				return false;
-			}
+      // url postprocess
+      if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        filteredList.push(link);
+        return false;
+      }
 
-			// replace the converted link with the original document
-			let documentContent = fs.readFileSync(filePath, 'utf8');
-			documentContent = documentContent.replace(new RegExp(originLink, "g"), link.url);
-			fs.writeFileSync(filePath, documentContent, 'utf8');
+      // replace the converted link with the original document
+      let documentContent = fs.readFileSync(filePath, 'utf8');
+      documentContent = documentContent.replace(new RegExp(originLink, "g"), link.url);
+      fs.writeFileSync(filePath, documentContent, 'utf8');
 
-			return true;
-		});
-		return {
-			links: unfilteredList,
-			filteredLinks: filteredList,
-		};
-	} else {
-		return {
-			links: [],
-			filteredLinks: [],
-		};
-	}
+      return true;
+    });
+    return {
+      links: unfilteredList,
+      filteredLinks: filteredList,
+    };
+  } else {
+    return {
+      links: [],
+      filteredLinks: [],
+    };
+  }
 }
 
 const linkValidate = (link) => {
-	return new Promise((resolve) => {
-		const axios = require("axios");
-		axios.get(link.url)
-				.then((res) => {
-					console.log(`[Link Checker] check "${link.url}", result is ${res.statusText}`)
-					resolve({
-						...link,
-						status: res.status,
-						statusText: res.statusText,
-					});
-				})
-				.catch((err) => {
-					console.log(`[Link Checker] check "${link.url}", result is FAIL`);
-					resolve({
-						...link,
-						status: 0,
-						statusText: 'FAIL',
-					});
-				});
-	});
+  return new Promise((resolve) => {
+    const axios = require("axios");
+    axios.get(link.url)
+      .then((res) => {
+        console.log(`[Link Checker] check "${link.url}", result is ${res.statusText}`)
+        resolve({
+          ...link,
+          status: res.status,
+          statusText: res.statusText,
+        });
+      })
+      .catch((err) => {
+        console.log(`[Link Checker] check "${link.url}", result is FAIL`);
+        resolve({
+          ...link,
+          status: 0,
+          statusText: 'FAIL',
+        });
+      });
+  });
 }
 
 (async function main(values) {
-	console.log("Start link-checker.js");
-	console.log("Install dependencies");
-	childProcess.execSync("npm i --save axios");
+  console.log("Start link-checker.js");
+  console.log("Install dependencies");
+  childProcess.execSync("npm i --save axios");
 
-	console.log("[Document Scanner] Scan all documents");
-	let allDocuments = [];
-	projects.map((project) => {
-		let latestDocs = {
-			en: `./website/docs/${project}`,
-			zh: `./website/i18n/zh/docusaurus-plugin-content-docs-docs-${project}/current`,
-		};
+  console.log("[Document Scanner] Scan all documents");
+  let allDocuments = [];
+  projects.map((project) => {
+    let latestDocs = {
+      en: `./website/docs/${project}`,
+      zh: `./website/i18n/zh/docusaurus-plugin-content-docs-docs-${project}/current`,
+    };
 
-		Object.values(latestDocs).forEach((docPath) => {
-			if (!fs.existsSync(docPath)) return;
-			allDocuments.push({
-				files: scanFolder(docPath),
-				docPath,
-				project,
-			})
-		});
-	});
+    Object.values(latestDocs).forEach((docPath) => {
+      if (!fs.existsSync(docPath)) return;
+      allDocuments.push({
+        files: scanFolder(docPath),
+        docPath,
+        project,
+      })
+    });
+  });
 
-	console.log("[Link Scanner] Scan all links");
-	let externalLinks = []; // links to other sites
-	let internalLinks = []; // links to other Markdown files or anchor
-	for (const documents of allDocuments) {
-		documents.files.forEach((file) => {
-			const scanResult = scanLinkInMDFile(file, documents.project);
-			externalLinks.push(...scanResult.links);
-			internalLinks.push(...scanResult.filteredLinks);
-		});
-	}
+  console.log("[Link Scanner] Scan all links");
+  let externalLinks = []; // links to other sites
+  let internalLinks = []; // links to other Markdown files or anchor
+  for (const documents of allDocuments) {
+    documents.files.forEach((file) => {
+      const scanResult = scanLinkInMDFile(file, documents.project);
+      externalLinks.push(...scanResult.links);
+      internalLinks.push(...scanResult.filteredLinks);
+    });
+  }
 
-	//console.log(`[Link Scanner] External Links\n`, externalLinks.map(item => item.url).join("\n"));
-	//console.log(`[Link Scanner] Internal Links\n`, internalLinks.map(item => item.url).join("\n"));
-	console.log(`[Link Scanner] Scan result: ${externalLinks.length} external links, ${internalLinks.length} internal links`)
+  //console.log(`[Link Scanner] External Links\n`, externalLinks.map(item => item.url).join("\n"));
+  //console.log(`[Link Scanner] Internal Links\n`, internalLinks.map(item => item.url).join("\n"));
+  console.log(`[Link Scanner] Scan result: ${externalLinks.length} external links, ${internalLinks.length} internal links`)
 
-	console.log(`[Link Checker] Start external link check`);
-	let externalBrokenList = [];
-	let externalLinkCheckPromises = [];
-	externalLinks.forEach((link) => {
-		externalLinkCheckPromises.push(linkValidate(link));
-	});
+  console.log(`[Link Checker] Start external link check`);
+  let externalBrokenList = [];
+  let externalLinkCheckPromises = [];
+  externalLinks.forEach((link) => {
+    externalLinkCheckPromises.push(linkValidate(link));
+  });
 
-	let result = await Promise.all(externalLinkCheckPromises);
-	externalBrokenList.push(...result.filter((item) => item.status !== 200));
-	console.log(`[Link Checker] External link check finished`);
+  let result = await Promise.all(externalLinkCheckPromises);
+  externalBrokenList.push(...result.filter((item) => item.status !== 200));
+  console.log(`[Link Checker] External link check finished`);
 
-	console.log(`[Link Checker] Start internal link check`);
-	let internalBrokenList = [];
-	internalLinks.forEach((link) => {
-		let exist = true;
-		if (!fs.existsSync(link.url)) {
-			internalBrokenList.push(link);
-			exist = false;
-		}
-		console.log(`[Link Checker] check "${link.url}", result is ${exist}`)
-	});
-	console.log(`[Link Checker] Internal link check finished`);
+  console.log(`[Link Checker] Start internal link check`);
+  let internalBrokenList = [];
+  internalLinks.forEach((link) => {
+    let exist = true;
+    if (!fs.existsSync(link.url)) {
+      internalBrokenList.push(link);
+      exist = false;
+    }
+    console.log(`[Link Checker] check "${link.url}", result is ${exist}`)
+  });
+  console.log(`[Link Checker] Internal link check finished`);
 
-	console.log("[Finish] Write broken list to file");
-	fs.writeFileSync('./brokenLinks.json', JSON.stringify({
-		external: externalBrokenList,
-		internal: internalBrokenList,
-	}));
+  console.log("[Finish] Write broken list to file");
+  fs.writeFileSync('./brokenLinks.json', JSON.stringify({
+    external: externalBrokenList,
+    internal: internalBrokenList,
+  }));
 })();

--- a/link-checker.js
+++ b/link-checker.js
@@ -64,10 +64,10 @@ const linkValidate = (link) => {
 					});
 				})
 				.catch((err) => {
-					console.log(`[Link Checker] check ${link.url}, result is FAIL`);
+					console.log(`[Link Checker] check "${link.url}", result is FAIL`);
 					resolve({
 						...link,
-						status: err.response.status,
+						status: 0,
 						statusText: 'FAIL',
 					});
 				});


### PR DESCRIPTION
Fixes: #255 

Changes:

A broken link checking script is implemented using NodeJS. It can scan the link and send an HTTP request to check if the link is available.

Problem:

Currently, markdown link detection uses an external library, which will have problems in link identification when checking links without title. Then consider refactoring this part of the code.