### PR TITLE
feat: add contirbutor over time image in team page

### DIFF
--- a/website/src/pages/team.js
+++ b/website/src/pages/team.js
@@ -291,6 +291,9 @@ function Team(props) {
       </SectionSubtitle>
       <RepoCardsContainer>{repoComponents}</RepoCardsContainer>
       <SectionTitle>Contributor Over Time</SectionTitle>
+      <SectionSubtitle>
+        Note: This graph contains contributors from all repos under Apache APISIX
+      </SectionSubtitle>
       <img src="https://contributor-graph-api.apiseven.com/contributors-svg?repo=apache/apisix&merge=true" alt="Contributor Over Time"/>
       <ContributeCard>
         <ContributeCardLeftSide>

--- a/website/src/pages/team.js
+++ b/website/src/pages/team.js
@@ -290,6 +290,8 @@ function Team(props) {
         list.
       </SectionSubtitle>
       <RepoCardsContainer>{repoComponents}</RepoCardsContainer>
+      <SectionTitle>Contributor Over Time</SectionTitle>
+      <img src="https://contributor-graph-api.apiseven.com/contributors-svg?repo=apache/apisix&merge=true" alt="Contributor Over Time"/>
       <ContributeCard>
         <ContributeCardLeftSide>
           <ContributeCardTitle>🛠 Become A Committer </ContributeCardTitle>


### PR DESCRIPTION
Changes:
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
feat: add contributor over time image in team page

Screenshots of the change:
![image](https://user-images.githubusercontent.com/31329157/116047529-bf591380-a6a6-11eb-8695-fa584f4fe2ac.png)