### PR TITLE
style: add max-width to doc-container

### DIFF
--- a/website/src/theme/DocPage/styles.module.css
+++ b/website/src/theme/DocPage/styles.module.css
@@ -52,6 +52,7 @@
 
   .docMainContainer {
     flex-grow: 1;
+    max-width: calc(100% - var(--doc-sidebar-width));
   }
 
   .docItemWrapperEnhanced {


### PR DESCRIPTION
Fixes: #288

Changes:

Previously (See the x-scroll bar due to overflow in document main container (.docMainContainer))

![image](https://user-images.githubusercontent.com/57267960/119016291-633c9300-b9b7-11eb-9d59-385ce02dd689.png)

Screenshots of the change:

Later (After setting max-width of container)

![image](https://user-images.githubusercontent.com/57267960/119016337-6fc0eb80-b9b7-11eb-8938-1ed5ce25eacd.png)
