### PR TITLE
feat: Announcement bar added for `Slack invitation`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -416,21 +416,12 @@ module.exports = {
         "Copyright © 2019-2021 The Apache Software Foundation. Apache APISIX, APISIX™, Apache, the Apache feather logo, and the Apache APISIX project logo are either registered trademarks or trademarks of the Apache Software Foundation.",
     },
     announcementBar: {
-      id: 'apisix-2.6-Release',
-      backgroundColor: "#e8433e",
-      textColor: 'white',
-      content:
-        '➡️ Apache APISIX v2.6.0 released, users can view Changelogs <a target="_blank" rel="noopener noreferrer" href="https://github.com/apache/apisix/blob/2.6/CHANGELOG.md#260">APISIX 2.6.0 release</a>! 🔄',
-    },
-    /*
-    announcementBar: {
       id: 'query',
       backgroundColor: "#e8433e",
       textColor: 'white',
       content:
-        '❓ have queries regarding apache APISIX, Join slack channel to discuss them <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/the-asf/shared_invite/zt-mrougyeu-2aG7BnFaV0VnAT9_JIUVaA">join #apisix channel</a>! ⭐️',
+        '\u{1F914} Have queries regarding apache APISIX, Join slack channel to discuss them <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/the-asf/shared_invite/zt-mrougyeu-2aG7BnFaV0VnAT9_JIUVaA">join #apisix channel</a>! ⭐️',
     },
-     */
     algolia: {
       apiKey: "287206c9872faf0e77b7c5228d4c3789",
       indexName: "apache_apisix",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -417,12 +417,16 @@ module.exports = {
     },
     announcementBar: {
       id: 'apisix-2.6-Release',
+      backgroundColor: "#e8433e",
+      textColor: 'white',
       content:
-        '➡️ Apache APISIX v2.6.0 released, users can view Changelogs <a target="_blank" rel="noopener noreferrer" href="https://github.com/apache/apisix/blob/release/2.6/CHANGELOG.md">APISIX 2.6.0 release</a>! 🔄',
+        '➡️ Apache APISIX v2.6.0 released, users can view Changelogs <a target="_blank" rel="noopener noreferrer" href="https://github.com/apache/apisix/blob/2.6/CHANGELOG.md#260">APISIX 2.6.0 release</a>! 🔄',
     },
     /*
     announcementBar: {
       id: 'query',
+      backgroundColor: "#e8433e",
+      textColor: 'white',
       content:
         '❓ have queries regarding apache APISIX, Join slack channel to discuss them <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/the-asf/shared_invite/zt-mrougyeu-2aG7BnFaV0VnAT9_JIUVaA">join #apisix channel</a>! ⭐️',
     },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -388,7 +388,7 @@ module.exports = {
             },
             {
               label: "Slack",
-              to: "https://apisix.slack.com/",
+              to: "https://join.slack.com/t/the-asf/shared_invite/zt-nggtva4i-hDCsW1S35MuZ2g_2DgVDGg",
             },
             {
               label: "Twitter",
@@ -420,7 +420,7 @@ module.exports = {
       backgroundColor: "#e8433e",
       textColor: 'white',
       content:
-        '\u{1F914} Have queries regarding apache APISIX, Join slack channel to discuss them <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/the-asf/shared_invite/zt-mrougyeu-2aG7BnFaV0VnAT9_JIUVaA">join #apisix channel</a>! ⭐️',
+        '\u{1F914} Have queries regarding apache APISIX, Join slack channel to discuss them <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/the-asf/shared_invite/zt-nggtva4i-hDCsW1S35MuZ2g_2DgVDGg">join #apisix channel</a>! ⭐️',
     },
     algolia: {
       apiKey: "287206c9872faf0e77b7c5228d4c3789",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -415,6 +415,18 @@ module.exports = {
       copyright:
         "Copyright © 2019-2021 The Apache Software Foundation. Apache APISIX, APISIX™, Apache, the Apache feather logo, and the Apache APISIX project logo are either registered trademarks or trademarks of the Apache Software Foundation.",
     },
+    announcementBar: {
+      id: 'apisix-2.6-Release',
+      content:
+        '➡️ Apache APISIX v2.6.0 released, users can view Changelogs <a target="_blank" rel="noopener noreferrer" href="https://github.com/apache/apisix/blob/release/2.6/CHANGELOG.md">APISIX 2.6.0 release</a>! 🔄',
+    },
+    /*
+    announcementBar: {
+      id: 'query',
+      content:
+        '❓ have queries regarding apache APISIX, Join slack channel to discuss them <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/the-asf/shared_invite/zt-mrougyeu-2aG7BnFaV0VnAT9_JIUVaA">join #apisix channel</a>! ⭐️',
+    },
+     */
     algolia: {
       apiKey: "287206c9872faf0e77b7c5228d4c3789",
       indexName: "apache_apisix",
@@ -425,6 +437,7 @@ module.exports = {
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },
+    image: 'img/favicon.png',
     metadatas: [
       {
         name: "description",


### PR DESCRIPTION
Changes:
added a feature - announcement bar whih will notify users for new releases and after some days we can use next announcement for join slack channel

Screenshots of the change:
![announcemnet](https://user-images.githubusercontent.com/40708551/119257788-7b452a00-bbe4-11eb-88ec-4d7c683e6ba0.png)

