### PR TITLE
fix: update docusaurus.config.js to fix navbar link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -343,7 +343,7 @@ module.exports = {
             },
             {
               label: "Apache™️ APISIX Java Plugin Runner",
-              to: "/docs/apisix-java-plugin-runner/development/"
+              to: "/docs/java-plugin-runner/development/"
             },
             {
               label: "General",


### PR DESCRIPTION
**Changes:**

This PR updates the correct doc link for java runner docs.

see https://apisix.apache.org/docs//development/

![image](https://user-images.githubusercontent.com/2106987/123189846-204b6f00-d4d1-11eb-943a-26b01d2ab3f6.png)
