### PR TITLE
feat: apisix-go-plugin-runner download block added

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -148,6 +148,19 @@ module.exports = {
         releaseDate: "2021-06-23",
         firstDocPath: "/development",
       },
+      {
+        name: "APISIX™ Go Plugin Runner",
+        nameInParamCase: "go-plugin-runner",
+        description: "Runs Apache APISIX plugins written in Go. Implemented as a sidecar that accompanies Apache APISIX.",
+        shape: "octagon",
+        color: "#3B14A7",
+        githubRepo: "apache/apisix-go-plugin-runner",
+        githubBranch: "master",
+        downloadPath: "apisix/go-plugin-runner/0.1.0/apisix-go-plugin-runner-0.1.0-src",
+        version: "0.1.0",
+        releaseDate: "2021-07-6",
+        firstDocPath: "/getting-started",
+      }
     ],
 
     team: require("./static/data/team.json"),

--- a/website/src/pages/downloads/ProjectCard.js
+++ b/website/src/pages/downloads/ProjectCard.js
@@ -10,6 +10,7 @@ import IconTriangle from "../../assets/icons/triangle.svg";
 import IconSquare from "../../assets/icons/square.svg";
 import IconHexagon from "../../assets/icons/hexagon.svg";
 import IconStarSolid from "../../assets/icons/star-solid.svg";
+import IconOctagon from "../../assets/icons/octagon.svg";
 
 const Dropdown = (props) => {
   const ref = useRef();
@@ -51,8 +52,10 @@ const ProjectCard = (props) => {
       <IconSquare />
     ) : shape === "hexagon" ? (
       <IconHexagon />
-    ) : (
+    ) : shape === "star" ? (
       <IconStarSolid />
+    ) : (
+      <IconOctagon />
     );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

added download card block for go plugin runner

Screenshots of the change:

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/40708551/125984073-fefb3176-92d6-417f-9641-9d17061ed845.png">
