### PR TITLE
fix: replace trademark ™ to with R ®️

### DIFF
--- a/website/docs/general/contributor-guide.md
+++ b/website/docs/general/contributor-guide.md
@@ -41,7 +41,7 @@ git remote add upstream https://github.com/apache/apisix.git
 
 #### **Good First Issues**:
 
-Good First Issue curates easy pickings from this project, and helps you make your first contribution to Apache APISIX™.
+Good First Issue curates easy pickings from this project, and helps you make your first contribution to Apache APISIX®.
 
 - [Apache APISIX](https://github.com/apache/apisix/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [Apache APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  title: "Apache APISIX™",
+  title: "Apache APISIX®",
   tagline:
     "Apache APISIX is a dynamic, real-time, high-performance Cloud-Native API gateway, based on the Nginx library and etcd.",
   url: "https://apisix.apache.org/",
@@ -16,7 +16,7 @@ module.exports = {
     docsUrl: "",
     docs: [
       {
-        name: "APISIX™",
+        name: "APISIX®",
         nameInParamCase: "apisix",
         description: "A dynamic, real-time, high-performance API gateway.",
         shape: "triangle",
@@ -27,7 +27,7 @@ module.exports = {
         firstDocPath: "/getting-started",
       },
       {
-        name: "APISIX™ Dashboard",
+        name: "APISIX® Dashboard",
         nameInParamCase: "dashboard",
         description:
           "Designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.",
@@ -39,7 +39,7 @@ module.exports = {
         firstDocPath: "/USER_GUIDE",
       },
       {
-        name: "APISIX™ Ingress Controller",
+        name: "APISIX® Ingress Controller",
         nameInParamCase: "ingress-controller",
         description: "An Apache APISIX control plane component.",
         shape: "hexagon",
@@ -50,7 +50,7 @@ module.exports = {
         firstDocPath: "/getting-started",
       },
       {
-        name: "APISIX™ Helm Charts",
+        name: "APISIX® Helm Charts",
         nameInParamCase: "helm-chart",
         description: "An Apache APISIX Helm Charts provide the installation of Apache APISIX components for kubernetes.",
         shape: "pentagon",
@@ -61,7 +61,7 @@ module.exports = {
         firstDocPath: "/apisix",
       },
       {
-        name: "APISIX™ Docker",
+        name: "APISIX® Docker",
         nameInParamCase: "docker",
         description: "Docker tooling for Apache APISIX.",
         shape: "diamond",
@@ -72,7 +72,7 @@ module.exports = {
         firstDocPath: "/build",
       },
       {
-        name: "APISIX™ Java Plugin Runner",
+        name: "APISIX® Java Plugin Runner",
         nameInParamCase: "java-plugin-runner",
         description: "Runs Apache APISIX plugins written in Java. Implemented as a sidecar that accompanies Apache APISIX.",
         shape: "star",
@@ -83,7 +83,7 @@ module.exports = {
         firstDocPath: "/development",
       },
       {
-        name: "APISIX™ Go Plugin Runner",
+        name: "APISIX® Go Plugin Runner",
         nameInParamCase: "go-plugin-runner",
         description: "Runs Apache APISIX plugins written in Go. Implemented as a sidecar that accompanies Apache APISIX.",
         shape: "octagon",
@@ -96,7 +96,7 @@ module.exports = {
     ],
     downloads: [
       {
-        name: "APISIX™",
+        name: "APISIX®",
         nameInParamCase: "apisix",
         description: "A dynamic, real-time, high-performance API gateway.",
         shape: "triangle",
@@ -109,7 +109,7 @@ module.exports = {
         firstDocPath: "/getting-started",
       },
       {
-        name: "APISIX™ Dashboard",
+        name: "APISIX® Dashboard",
         nameInParamCase: "dashboard",
         description:
           "Designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.",
@@ -123,7 +123,7 @@ module.exports = {
         firstDocPath: "/USER_GUIDE",
       },
       {
-        name: "APISIX™ Ingress Controller",
+        name: "APISIX® Ingress Controller",
         nameInParamCase: "ingress-controller",
         description: "An Apache APISIX control plane component.",
         shape: "hexagon",
@@ -136,7 +136,7 @@ module.exports = {
         firstDocPath: "/getting-started",
       },
       {
-        name: "APISIX™ Java Plugin Runner",
+        name: "APISIX® Java Plugin Runner",
         nameInParamCase: "java-plugin-runner",
         description: "Runs Apache APISIX plugins written in Java. Implemented as a sidecar that accompanies Apache APISIX.",
         shape: "star",
@@ -149,7 +149,7 @@ module.exports = {
         firstDocPath: "/development",
       },
       {
-        name: "APISIX™ Go Plugin Runner",
+        name: "APISIX® Go Plugin Runner",
         nameInParamCase: "go-plugin-runner",
         description: "Runs Apache APISIX plugins written in Go. Implemented as a sidecar that accompanies Apache APISIX.",
         shape: "octagon",
@@ -375,7 +375,7 @@ module.exports = {
   themeConfig: {
     navbar: {
       hideOnScroll: true,
-      title: "Apache APISIX™",
+      title: "Apache APISIX®",
       logo: {
         src: "img/logo2.svg",
       },
@@ -386,31 +386,31 @@ module.exports = {
           to: "/docs",
           items: [
             {
-              label: "Apache APISIX™️",
+              label: "Apache APISIX®️",
               to: "/docs/apisix/getting-started",
             },
             {
-              label: "Apache APISIX™️ Dashboard",
+              label: "Apache APISIX®️ Dashboard",
               to: "/docs/dashboard/USER_GUIDE",
             },
             {
-              label: "Apache APISIX™️ Ingress Controller",
+              label: "Apache APISIX®️ Ingress Controller",
               to: "/docs/ingress-controller/getting-started/",
             },
             {
-              label: "Apache APISIX™️ Helm Charts",
+              label: "Apache APISIX®️ Helm Charts",
               to: "/docs/helm-chart/apisix/",
             },
             {
-              label: "Apache APISIX™️ Docker",
+              label: "Apache APISIX®️ Docker",
               to: "/docs/docker/build/",
             },
             {
-              label: "Apache APISIX™️ Java Plugin Runner",
+              label: "Apache APISIX®️ Java Plugin Runner",
               to: "/docs/java-plugin-runner/development/"
             },
             {
-              label: "Apache APISIX™️ Go Plugin Runner",
+              label: "Apache APISIX®️ Go Plugin Runner",
               to: "/docs/go-plugin-runner/getting-started/"
             },
             {
@@ -516,7 +516,7 @@ module.exports = {
       },
 
       copyright:
-        "Copyright © 2019-2021 The Apache Software Foundation. Apache APISIX, APISIX™, Apache, the Apache feather logo, and the Apache APISIX project logo are either registered trademarks or trademarks of the Apache Software Foundation.",
+        "Copyright © 2019-2021 The Apache Software Foundation. Apache APISIX, APISIX®, Apache, the Apache feather logo, and the Apache APISIX project logo are either registered trademarks or trademarks of the Apache Software Foundation.",
     },
     announcementBar: {
       id: 'query',

--- a/website/i18n/zh/docusaurus-plugin-content-docs-docs-apisix-dashboard/current.json
+++ b/website/i18n/zh/docusaurus-plugin-content-docs-docs-apisix-dashboard/current.json
@@ -3,8 +3,8 @@
     "message": "Next",
     "description": "The label for version current"
   },
-  "sidebar.docs.category.APISIX™️ Dashboard": {
-    "message": "APISIX™️ Dashboard",
-    "description": "The label for category APISIX™️ Dashboard in sidebar docs"
+  "sidebar.docs.category.APISIX®️ Dashboard": {
+    "message": "APISIX®️ Dashboard",
+    "description": "The label for category APISIX®️ Dashboard in sidebar docs"
   }
 }

--- a/website/i18n/zh/docusaurus-plugin-content-docs-docs-apisix-ingress-controller/current.json
+++ b/website/i18n/zh/docusaurus-plugin-content-docs-docs-apisix-ingress-controller/current.json
@@ -3,8 +3,8 @@
     "message": "Next",
     "description": "The label for version current"
   },
-  "sidebar.docs.category.APISIX™️ Ingress Controller": {
-    "message": "APISIX™️ Ingress Controller",
-    "description": "The label for category APISIX™️ Ingress Controller in sidebar docs"
+  "sidebar.docs.category.APISIX®️ Ingress Controller": {
+    "message": "APISIX®️ Ingress Controller",
+    "description": "The label for category APISIX®️ Ingress Controller in sidebar docs"
   }
 }

--- a/website/i18n/zh/docusaurus-plugin-content-docs-docs-apisix/current.json
+++ b/website/i18n/zh/docusaurus-plugin-content-docs-docs-apisix/current.json
@@ -3,8 +3,8 @@
     "message": "Next",
     "description": "The label for version current"
   },
-  "sidebar.docs.category.APISIX™️": {
-    "message": "APISIX™️",
-    "description": "The label for category APISIX™️ in sidebar docs"
+  "sidebar.docs.category.APISIX®️": {
+    "message": "APISIX®️",
+    "description": "The label for category APISIX®️ in sidebar docs"
   }
 }

--- a/website/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/website/i18n/zh/docusaurus-theme-classic/footer.json
@@ -52,7 +52,7 @@
     "description": "The label of footer link with label=Blog linking to https://apisix.apache.org/blog/"
   },
   "copyright": {
-    "message": "Copyright © 2019-2021 The Apache Software Foundation. Apache APISIX, APISIX™, Apache, the Apache feather logo, and the Apache APISIX project logo are either registered trademarks or trademarks of the Apache Software Foundation.",
+    "message": "Copyright © 2019-2021 The Apache Software Foundation. Apache APISIX, APISIX®, Apache, the Apache feather logo, and the Apache APISIX project logo are either registered trademarks or trademarks of the Apache Software Foundation.",
     "description": "The footer copyright"
   }
 }

--- a/website/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/website/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -1,6 +1,6 @@
 {
   "title": {
-    "message": "Apache APISIX™",
+    "message": "Apache APISIX®",
     "description": "The title in the navbar"
   },
   "item.label.Docs": {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -210,7 +210,7 @@ const ContributionSection = () => {
   return (
     <div className="contribution">
       <div className="center-elem contribution-text">
-        <h2>Make your first contribution to Apache APISIX™</h2>
+        <h2>Make your first contribution to Apache APISIX®</h2>
       </div>
       <div className="center-elem">
         <p>Find a good first issue to get you started !</p>
@@ -249,7 +249,7 @@ const NewsletterSection = () => {
         </svg>
       </div>
       <div className="center-elem news-text">
-        <h2>Stay up to date about all Apache APISIX™ News</h2>
+        <h2>Stay up to date about all Apache APISIX® News</h2>
       </div>
       <div className="center-elem">
         <a className="news-button" href="/docs/general/subscribe-guide">Subscribe</a>

--- a/website/src/theme/DocPage/index.js
+++ b/website/src/theme/DocPage/index.js
@@ -41,19 +41,19 @@ function DocPageContent({ currentDocRoute, versionMetadata, children }) {
     if(docsSidebars[sidebarName][0].label === pageId.general){
       document.querySelectorAll(".navbar__link--active")[0].text = "General";
     } else if (document.getElementById(pageId.apisix)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX®";
     } else if (document.getElementById(pageId.apisixDashboard)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™ Dashboard";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX® Dashboard";
     } else if (document.getElementById(pageId.apisixIngressController)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™ Ingress Controller";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX® Ingress Controller";
     } else if (document.getElementById(pageId.apisixHelmChart)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™ Helm Chart";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX® Helm Chart";
     } else if (document.getElementById(pageId.apisixDocker)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™ Docker";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX® Docker";
     } else if (document.getElementById(pageId.apisixJavaPluginRunner)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™ Java Plugin Runner";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX® Java Plugin Runner";
     } else if (document.getElementById(pageId.apisixGoRunner)) {
-      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX™ Go Plugin Runner";
+      document.querySelectorAll(".navbar__link--active")[0].text = "Apache APISIX® Go Plugin Runner";
     }
     return () => {
       console.log('\u{1F680} documentation changed')


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Changed the trademark ™ to R ®️, Apache APSIX™ is changed to Apache APSIX®️  in this pull request.
Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
![image](https://user-images.githubusercontent.com/36651058/126589903-1bd6ad31-c415-4935-bd22-406c681f43ef.png)
![image](https://user-images.githubusercontent.com/36651058/126589914-bd854718-0e8b-4c18-a899-d9148a2ad78d.png)

