### PR TITLE
fix: show shanghai meetup events

### DIFF
--- a/website/static/data/events.json
+++ b/website/static/data/events.json
@@ -1,5 +1,9 @@
 [
   {
+    "title": "8.21 Apache APISIX Meetup (Shanghai)",
+    "fileName": "2021-08-21-shanghai-meetup"
+  },
+  {
     "title": "Release Apache APISIX Dashboard 2.7",
     "fileName": "2021-06-15-release-apache-apisix-dashboard-2.7"
   },


### PR DESCRIPTION
Fixes: #464 

Changes:

Add a link to meetup in the events list.

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
