### PR TITLE
chore: add meta robots value index,follow

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -579,6 +579,10 @@ module.exports = {
         content:
           "Apache APISIX is a dynamic, real-time, high-performance Cloud-Native API gateway, based on the Nginx library and etcd.",
       },
+      {
+        name: "robots",
+        content: "index,follow"
+      }
     ],
     gtag: {
       trackingID: "G-WQLBQL6GY3",


### PR DESCRIPTION
Background:
reference: https://stackoverflow.com/questions/51277433/what-is-the-difference-between-index-follow-or-follow

`<meta name="robots" content="index, follow">`
This tag tells the web crawler all pages will be indexed and to crawl them.


Changes:

add meta robots tag

Screenshots of the change:

![image](https://user-images.githubusercontent.com/2561857/129769594-3a26bcd3-3c69-4cae-9c66-cadc1f940624.png)

