### PR TITLE
chore:  descendant of <a>

### DIFF
--- a/website/src/pages/plugins.js
+++ b/website/src/pages/plugins.js
@@ -78,7 +78,7 @@ const SidebarContainer = styled.div`
   border-color: #ffffff #efeff5 #ffffff #ffffff ;
 `;
 
-const PluginCard = styled.a`
+const PluginCard = styled.div`
   border-radius: 0.75rem;
   border: 1px solid #eee;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Changes:
Replace styled `<a>` with `<div>` 

Screenshots of the change:
<img width="1242" alt="截屏2021-08-18 下午10 09 36" src="https://user-images.githubusercontent.com/13642747/129914141-88d22184-cee7-499d-a1b6-488a34bead3e.png">


<!-- Add screenshots depicting the changes. -->

In addition, maybe it would look better by placing the plugin icon image horizontal center