### PR TITLE
fix: broken images in articles

### DIFF
--- a/website/articles/Apache-APISIX-From-OpenSource-Commercialization-by-Apache-Way.md
+++ b/website/articles/Apache-APISIX-From-OpenSource-Commercialization-by-Apache-Way.md
@@ -25,4 +25,4 @@ Apache Way 是被无数开源项目证实的社区成功之道，那么对于开
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Apache-APISIX-From-OpenSource-Commercialization.md
+++ b/website/articles/Apache-APISIX-From-OpenSource-Commercialization.md
@@ -24,4 +24,4 @@ Apache APISIX 从开源项目到商业化之路。
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Apache-APISIX-Incubator-Journey.md
+++ b/website/articles/Apache-APISIX-Incubator-Journey.md
@@ -23,4 +23,4 @@ Apache APISIX 的孵化过程。
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Apache-APISIX-Kubernetes-Ingress.md
+++ b/website/articles/Apache-APISIX-Kubernetes-Ingress.md
@@ -26,4 +26,4 @@ description: 介绍基于 Apache APISIX 的 Kubernetes Ingress 的优势以及 A
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Apache-APISIX-in-China-Mobile-Cloud.md
+++ b/website/articles/Apache-APISIX-in-China-Mobile-Cloud.md
@@ -25,4 +25,4 @@ description: 该演讲主题主要是讲述 Apache APISIX 在中国移动公有�
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/How-To-Extend-Apache-APISIX-into-a-Service-Mesh-Sidecar.md
+++ b/website/articles/How-To-Extend-Apache-APISIX-into-a-Service-Mesh-Sidecar.md
@@ -24,4 +24,4 @@ description: 在这个主题中将介绍 apisix-mesh-agent 项目，它有一些
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Relying-On-The-Community-To-Get-Apache-APISIX-Up-Speed.md
+++ b/website/articles/Relying-On-The-Community-To-Get-Apache-APISIX-Up-Speed.md
@@ -26,4 +26,4 @@ description: 在过去的一年里，APISIX 已经成为全世界最活跃的 AP
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Rendering-Community-Events-Using-ECharts.md
+++ b/website/articles/Rendering-Community-Events-Using-ECharts.md
@@ -25,4 +25,4 @@ description: 通过以下方式分析了开源资源库的情况：1.贡献者�
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Speed-Limiting-With-Apache-APISIX.md
+++ b/website/articles/Speed-Limiting-With-Apache-APISIX.md
@@ -27,4 +27,4 @@ description: 本次分享将带来如何使用 Apache APISIX 来实现动态、�
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Test-Apache-APISIX-Resilience-With-Chaos-Mesh.md
+++ b/website/articles/Test-Apache-APISIX-Resilience-With-Chaos-Mesh.md
@@ -28,4 +28,4 @@ Apache APISIX 是领先的 API 网关 OSS 之一。为了确保一切按计划�
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/The-Appeal-of-OpenSource.md
+++ b/website/articles/The-Appeal-of-OpenSource.md
@@ -26,4 +26,4 @@ Apache 软件基金会顶级项目 Apache APISIX 以及子项目，在过去 30 
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/The-Evolution-of-Apache-APISIX.md
+++ b/website/articles/The-Evolution-of-Apache-APISIX.md
@@ -25,4 +25,4 @@ Apache APISIX 是最受欢迎的 API 网关之一：https://github.com/apache/ap
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />

--- a/website/articles/Using-Apache-APISIX-To-Do-Authentication-and-Authorization.md
+++ b/website/articles/Using-Apache-APISIX-To-Do-Authentication-and-Authorization.md
@@ -24,4 +24,4 @@ description: 认证和授权是 API 网关中非常必要的功能。这样一�
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />


### PR DESCRIPTION
Changes:

Fix broken images URL in ApacheCon Asia 2021 articles.

Screenshots of the change:

![image](https://user-images.githubusercontent.com/8078418/130717170-947f486c-d576-441c-a580-77497b7bfd7a.png)
