### PR TITLE
fix: remove Recent posts index in blog page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -215,6 +215,7 @@ module.exports = {
         },
         blog: {
           path: "blog",
+          blogSidebarCount: 0,
         },
         theme: {
           customCss: "../src/css/customTheme.css",


### PR DESCRIPTION
part of: #490 

Changes:

try to remove the Recent posts index in blog page to make the page clean.


Screenshots of the change:

list page:

![image](https://user-images.githubusercontent.com/2561857/131721066-1526e02e-6847-4516-817c-a24d1bf5d7c8.png)

detail page:

![image](https://user-images.githubusercontent.com/2561857/131721145-eaaffce8-57d2-475a-a611-efe8ec73e6e9.png)

