### PR TITLE
docs: fix brief description for Apache APISIX Meetup recap

### DIFF
--- a/website/blog/2021-08-24-shanghai-meetup-recap.md
+++ b/website/blog/2021-08-24-shanghai-meetup-recap.md
@@ -11,7 +11,7 @@ description: 活动回顾：Apache APISIX Meetup 上海站议题分享及视频�
 tags: [technology]
 ---
 
-活动回顾：Apache APISIX Meetup 上海站议题分享及视频回顾。
+> 活动回顾：Apache APISIX Meetup 上海站议题分享及视频回顾。
 
 <!--truncate-->
 


### PR DESCRIPTION
Changes:

Fixed brief description for Apache APISIX Meetup recap, https://github.com/apache/apisix-website/pull/606 missed a small part.

![image](https://user-images.githubusercontent.com/36651058/133882521-4c24ab6e-1d19-45b5-b202-24e3f1c97741.png)

