### PR TITLE
docs: fix Broken Image Link in Post Page

### DIFF
--- a/website/articles/The-Appeal-of-OpenSource.md
+++ b/website/articles/The-Appeal-of-OpenSource.md
@@ -26,4 +26,4 @@ Apache 软件基金会顶级项目 Apache APISIX 以及子项目，在过去 30 
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" width="200px" />

--- a/website/articles/The-Appeal-of-OpenSource.md
+++ b/website/articles/The-Appeal-of-OpenSource.md
@@ -26,4 +26,4 @@ Apache 软件基金会顶级项目 Apache APISIX 以及子项目，在过去 30 
 
 关注 Apache APISIX 公众号，回复“ApacheCon”下载 PPT。
 
-<img src="../img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />
+<img src="../static/img/blog_img/APISIX-wechat.png" alt="Apache APISIX WeChat" style={{width: "200px"}} />


### PR DESCRIPTION
Fixes: #579 

Changes:

updated link path

Screenshots of the change:

![my9](https://user-images.githubusercontent.com/53715187/133957935-9b453f68-6028-497c-8f8b-8bbd0e58df09.jpg)

