### PR TITLE
docs: fix typos

### DIFF
--- a/website/blog/2021-07-06-celebrate-200-contributors.md
+++ b/website/blog/2021-07-06-celebrate-200-contributors.md
@@ -26,7 +26,7 @@ Welcome to join the Apache APISIX community, welcome to use Apache APISIX!
 
 ## Contributors Say
 
-When reaching 200 contributors, the controbutors in the community sent their blessings to Apache APISIX. Here are what they want to say to Apache APISIX.
+When reaching 200 contributors, the contributors in the community sent their blessings to Apache APISIX. Here are what they want to say to Apache APISIX.
 
 [juzhiyuan](https://github.com/juzhiyuan): The Apache APISIX open source community is extremely active, and the monthly release rhythm always brings new features that are hotly discussed in the community. Bless Apache APISIX, and hope that more contributors will participate, learn the spirit of open source, and participate in open source projects.
 

--- a/website/blog/2021-07-14-the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
+++ b/website/blog/2021-07-14-the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
@@ -124,7 +124,7 @@ tags: [technology, practical case]
 
 除了在管理页面支持创建路由之外，很多运维同学还是比较习惯使用脚本导入。我们有大量的 HTTP API 服务，这些服务要是一个一个手动录入，会非常耗时。如果通过脚本导入，则能够降低很多服务迁移阻力。
 
-通过为管理后台暴露出 Go Impport HTTP API，运维同学可以在现成的 Bash Script 脚本文件中填写分配的 token、SaaS ID 以及相关的 UID 等，从而较为快速地导入服务到管理后台中。导入服务后续操作依然还是需要在管理后台 H5 界面上完成。
+通过为管理后台暴露出 Go Import HTTP API，运维同学可以在现成的 Bash Script 脚本文件中填写分配的 token、SaaS ID 以及相关的 UID 等，从而较为快速地导入服务到管理后台中。导入服务后续操作依然还是需要在管理后台 H5 界面上完成。
 
 ![xinlang13](https://user-images.githubusercontent.com/23514812/125597641-54bf1649-0238-4973-8501-48c1cead328e.png)
 


### PR DESCRIPTION
Changes:

fix typos in 2 documents

- "controbutors" should be "contributors" in 'Apache APISIX has over 200 contributors in GitHub main repo!'
- "impport" should be "import" in '基于 Apache APISIX，新浪微博 API 网关的定制化开发之路'