### PR TITLE
docs: add 2.10 & 2.9 release notes

### DIFF
--- a/website/blog/2021-06-06-apisix-two-years.md
+++ b/website/blog/2021-06-06-apisix-two-years.md
@@ -7,7 +7,7 @@ keywords:
 - APISIX
 - opensource
 description: Apache APISIX is now two years old, thanks for all contributors.
-tags: [Release]
+tags: [Events]
 ---
 
 > Apache APISIX 开源 2 周年啦！

--- a/website/blog/2021-07-06-celebrate-200-contributors.md
+++ b/website/blog/2021-07-06-celebrate-200-contributors.md
@@ -8,7 +8,7 @@ keywords:
 - Apache APISIX
 - News
 Description: Apache APISIX has over 200 contributors in GitHub main repo!
-tags: [Release]
+tags: [Events]
 ---
 
 > Apache APISIX has over 200 contributors in GitHub main repo!

--- a/website/blog/2021-07-28-release-apache-apisix-2.8.md
+++ b/website/blog/2021-07-28-release-apache-apisix-2.8.md
@@ -8,7 +8,7 @@ keywords:
 - Release Notes
 - Apache APISIX 
 description: Apache APISIX 2.8 版本正式发布！
-tags: [Events]
+tags: [Release]
 ---
 
 > Apache APISIX 2.8 版本正式发布！

--- a/website/blog/2021-08-27-release-apache-apisix-2.9-en.md
+++ b/website/blog/2021-08-27-release-apache-apisix-2.9-en.md
@@ -1,0 +1,72 @@
+---
+title: "Release Apache APISIX 2.9"
+author: "Zexuan Luo"
+authorURL: "https://github.com/spacewander"
+authorImageURL: "https://avatars.githubusercontent.com/u/4161644?v=4"
+keywords:
+- APISIX
+- Apache APISIX
+- Release Notes
+description: Apache APISIX version 2.9 is released!
+tags: [Release]
+---
+
+> Apache APISIX version 2.9 is released!
+
+<!--truncate-->
+
+Apache APISIX version 2.9 is officially released! 🎉 This release has 30+ developers, 100+ PR submissions, 2 new features, and further improved support for plugins, come and learn about the new features in Apache APISIX 2.9!
+
+## New Plugin: authz-casbin
+
+The Casbin community has contributed [authz-casbin](https://github.com/apache/apisix/blob/d9b928321fcdd12eef024df8c7c410424c1e0c8b/docs/en/latest/) to APISIX plugins/authz-casbin.md) plugin to APISIX, and in the new APISIX 2.9 release, APISIX can combine Casbin to do granular permission management at the route level.
+
+Casbin is an open source access control framework that supports configuration to decide whether to allow a certain access operation. With the authz-casbin plugin, we can do multiple roles of access control in one route at the same time.
+
+This control can be set either through a configuration file or through the APISIX Control Plane; it can take effect for a given route or set global defaults. It is very flexible.
+
+If you are interested in this plugin, you are welcome to read [Authorization with Casbin in Apache APISIX](https://apisix.apache.org/blog/2021/08/25/Auth-with-Casbin-in-Apache-APISIX).
+
+## New Feature: Dynamic Configuration of real-ip at Route Level
+
+Apache APISIX version 2.9 now supports dynamic configuration of real-ip at the route level!
+
+The new version adds the [real-ip](https://apisix.apache.org/zh/docs/apisix/plugins/real-ip/) plugin, which dynamically changes the IP and port of the client seen by APISIX.
+
+We can use this plugin to dynamically set real-ip parameters.
+
+```JSON
+{
+    "plugins": {
+        "real-ip": {
+            "source": "http_x_forwarded_for",
+            "trusted_addresses": ["127.0.0.0/24"]
+        }
+    }
+}
+```
+
+## Improvement: External Plug-in Mechanism
+
+Apache APISIX version 2.9 further improves the support for external plugins with two major changes:
+
+1. When sending a plugin configuration to Plugin Runner, a unique key is sent. because APISIX is a multi-process architecture, in the past, a plugin configuration was sent several times, causing Plugin Runner to update the plugin configuration repeatedly. Now, with this unique key, Plugin Runner can identify duplicate configurations. This makes it possible to implement a plug-in inside Plugin Runner that limits flow!
+
+2. Add a mechanism to get APISIX information from Plugin Runner in the reverse direction. In addition to the request header and request path information sent from APISIX to Plugin Runner, Plugin Runner can also query information from APISIX in the reverse direction. The Var API has been implemented in the Go Plugin Runner implementation to use this mechanism to get information about Nginx variables such as the request_time of the request.
+
+The [Go Plugin Runner](https://github.com/apache/apisix-go-plugin-runner/tree/6f249010b83a124bc30e940635db7fa0838e2c4a), which includes this change, will be released next week Version 0.2.0 will be released next week, so stay tuned!
+
+## Improvement: Existing Plug-ins Enhancement
+
+APISIX version 2.9 improves the functionality of existing plugins with two major changes:
+
+1. the [request-id](https://apisix.apache.org/docs/apisix/plugins/request-id/) plugin supports ID generation via the snowflake algorithm. the snowflake ID generation algorithm is a distributed ID generation mechanism, which generates The snowflake ID generation algorithm is a distributed ID generation mechanism that combines machine IDs, timestamps, and generation sequences. We use etcd to ensure that each worker is assigned a unique machine ID.
+
+2. The [error-log-logger](https://apisix.apache.org/docs/apisix/plugins/error-log-logger/) plugin supports reporting error logs to skywalking, adding to the observability of APISIX. This adds to the observability of APISIX.
+
+## Download
+
+Download Apache APISIX 2.9
+
+- Source code: please visit [download page](https://apisix.apache.org/downloads/)
+- Binary installation package: please visit [Installation Guide](https://apisix.apache.org/docs/apisix/how-to-build/)

--- a/website/blog/2021-08-27-release-apache-apisix-2.9.md
+++ b/website/blog/2021-08-27-release-apache-apisix-2.9.md
@@ -11,7 +11,7 @@ keywords:
 - Nginx
 - APISIX 2.9
 description: Apache APISIX 2.9 版本正式发布！该版本新增了 2 个新功能，进一步完善了对插件的支持。
-tags: [Events]
+tags: [Release]
 ---
 
 > Apache APISIX 2.9 版本正式发布！

--- a/website/blog/2021-09-29-release-apache-apisix-2.10-en.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10-en.md
@@ -1,5 +1,5 @@
 ---
-title: "Release Apache APISIX 2.10.0"
+title: "Release Apache APISIX 2.10"
 author: "Zexuan Luo"
 authorURL: "https://github.com/spacewander"
 authorImageURL: "https://avatars.githubusercontent.com/u/4161644?v=4"
@@ -20,9 +20,9 @@ Apache APISIX 2.10 is officially released! 🎉 This is the first LTS release of
 
 ## Milestone: The First LTS Release
 
-This 2.10.0 release is a milestone for Apache APISIX, as Apache APISIX 2.10.0 is our first LTS (Long Time Support) release.
+This 2.10 release is a milestone for Apache APISIX, as Apache APISIX 2.10 is our first LTS (Long Time Support) release.
 
-We will be releasing subsequent patch versions on top of Apache APISIX 2.10.0, i.e. 2.10.1, 2.10.2, etc. These releases will backport bugfixes from the main branch.
+We will be releasing subsequent patch versions on top of Apache APISIX 2.10, i.e. 2.10.1, 2.10.2, etc. These releases will backport bugfixes from the main branch.
 
 In October, we plan to release the first patch for the first LTS version, Apache APISIX 2.10.1.
 
@@ -30,9 +30,9 @@ We will then release alternating version lines 2.10.x (e.g. 2.10.2) and 2.x (e.g
 
 ## New Feature: Add Hosts Attribute to Service
 
-In Apache APISIX 2.10.0, we added the `hosts` property to `service`. Like the other fields in `service`, `route` can inherit the `hosts` attribute from `service`.
+In Apache APISIX 2.10, we added the `hosts` property to `service`. Like the other fields in `service`, `route` can inherit the `hosts` attribute from `service`.
 
-For example, the following configurations are equivalent in Apache APISIX 2.10.0:
+For example, the following configurations are equivalent in Apache APISIX 2.10:
 
 ```json
 # services/1
@@ -104,7 +104,7 @@ In addition to the Python Plugin Runner, our community partners are also develop
 
 ## Download
 
-In addition to the above new features and components, the Apache APISIX 2.10.0 release introduces more than a dozen new features and plugins, for details please see the [Change log](https://github.com/apache/apisix/blob/release/2.10.0/) corresponding to this release CHANGELOG.md#2100).
+In addition to the above new features and components, the Apache APISIX 2.10 release introduces more than a dozen new features and plugins, for details please see the [Change log](https://github.com/apache/apisix/blob/release/2.10/) corresponding to this release CHANGELOG.md#2100).
 
 Download Apache APISIX 2.10
 

--- a/website/blog/2021-09-29-release-apache-apisix-2.10-en.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10-en.md
@@ -1,0 +1,112 @@
+---
+title: "Release Apache APISIX 2.10.0"
+author: "Zexuan Luo"
+authorURL: "https://github.com/spacewander"
+authorImageURL: "https://avatars.githubusercontent.com/u/4161644?v=4"
+keywords:
+- Apache APISIX
+- API Gateway
+- Release Notes
+- APISIX 2.10
+description: Apache APISIX 2.10 is released!
+tags: [Release]
+---
+
+> Apache APISIX 2.10 is released!
+
+<!--truncate-->
+
+Apache APISIX 2.10 is officially released! 🎉 This is the first LTS release of Apache APISIX with support for 10+ new features and new plugins. Have a quick read to learn about the new features in version 2.10!
+
+## Milestone: The First LTS Release
+
+This 2.10.0 release is a milestone for Apache APISIX, as Apache APISIX 2.10.0 is our first LTS (Long Time Support) release.
+
+We will be releasing subsequent patch versions on top of Apache APISIX 2.10.0, i.e. 2.10.1, 2.10.2, etc. These releases will backport bugfixes from the main branch.
+
+In October, we plan to release the first patch for the first LTS version, Apache APISIX 2.10.1.
+
+We will then release alternating version lines 2.10.x (e.g. 2.10.2) and 2.x (e.g. 2.11.0) to keep the features iterative while ensuring that the LTS version gets the newer bugfixes.
+
+## New Feature: Add Hosts Attribute to Service
+
+In Apache APISIX 2.10.0, we added the `hosts` property to `service`. Like the other fields in `service`, `route` can inherit the `hosts` attribute from `service`.
+
+For example, the following configurations are equivalent in Apache APISIX 2.10.0:
+
+```json
+# services/1
+{
+    "hosts": ["bar.com"]
+}
+# routes/1
+{
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "service_id": "1",
+    "uri": "/hello"
+}
+```
+
+```json
+# routes/1
+{
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "hosts": ["bar.com"],
+    "uri": "/hello"
+}
+```
+
+With this change, the relationship between `route` and `service` in Apache APISIX is becoming more and more similar to the relationship between `location` and `server` in Nginx. This change brings `service` back into the core Apache APISIX configuration: [Route](http://apisix.apache.org/docs/apisix/architecture-design/route), [Upstream](http://apisix.apache.org/docs/apisix/architecture-design/upstream), and [Service](http://apisix.apache.org/docs/apisix/architecture-design/service).
+
+## New Feature: Support Setting the Ratio of Mirror Requests
+
+The proxy-mirror plugin's support for setting the ratio of mirrored requests is a feature users have been waiting for, and we support it on Apache APISIX 2.10.
+
+By setting `sample_ratio`, you can control the number of requests that are mirrored to the test service. For example, the following configuration with `sample_ratio` set to 0.5 will mirror half of the requests to the test service.
+
+```json
+{
+    "plugins": {
+        "proxy-mirror": {
+            "host": "http://127.0.0.1:1986",
+            "sample_ratio": 0.5
+        }
+    },
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "uri": "/hello"
+}
+```
+
+## New Plugin: APISIX Python Plugin Runner
+
+Following [Java Plugin Runner](https://apisix.apache.org/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins/) and [Go Plugin Runner](https://apisix.apache.org/blog/2021/08/19/go-makes-Apache-APISIX-better/), there is a new Plugin Runner for Apache APISIX.
+
+The [Apache APISIX Python Plugin Runner](https://github.com/apache/apisix-python-plugin-runner) has been released in version 0.1.0 on September 6.
+
+Python is a popular programming language that has always been known for its ease of use and flexibility. Now you and I can use the language to write plugins for Apache APISIX.
+
+In addition to the Python Plugin Runner, our community partners are also developing Plugin Runners for other programming languages, such as the [JavaScript Plugin Runner](https://github.com/zenozeng/apisix-javascript-plugin-runner), and everyone is welcome to participate in the development.
+
+## Download
+
+In addition to the above new features and components, the Apache APISIX 2.10.0 release introduces more than a dozen new features and plugins, for details please see the [Change log](https://github.com/apache/apisix/blob/release/2.10.0/) corresponding to this release CHANGELOG.md#2100).
+
+Download Apache APISIX 2.10
+
+- Source code: Please visit [Download page](https://apisix.apache.org/downloads/)
+- Binary installation package: Please visit [Installation Guide](https://apisix.apache.org/docs/apisix/how-to-build/)

--- a/website/blog/2021-09-29-release-apache-apisix-2.10-en.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10-en.md
@@ -1,5 +1,5 @@
 ---
-title: "Release Apache APISIX 2.10"
+title: "Release Apache APISIX 2.10.0"
 author: "Zexuan Luo"
 authorURL: "https://github.com/spacewander"
 authorImageURL: "https://avatars.githubusercontent.com/u/4161644?v=4"
@@ -8,21 +8,21 @@ keywords:
 - API Gateway
 - Release Notes
 - APISIX 2.10
-description: Apache APISIX 2.10 is released!
+description: Apache APISIX 2.10.0 is released! This is the first LTS release of Apache APISIX.
 tags: [Release]
 ---
 
-> Apache APISIX 2.10 is released!
+> Apache APISIX 2.10.0 is released!
 
 <!--truncate-->
 
-Apache APISIX 2.10 is officially released! 🎉 This is the first LTS release of Apache APISIX with support for 10+ new features and new plugins. Have a quick read to learn about the new features in version 2.10!
+Apache APISIX 2.10.0 is officially released! 🎉 This is the first LTS release of Apache APISIX with support for 10+ new features and new plugins. Have a quick read to learn about the new features in version 2.10.0!
 
 ## Milestone: The First LTS Release
 
-This 2.10 release is a milestone for Apache APISIX, as Apache APISIX 2.10 is our first LTS (Long Time Support) release.
+This 2.10.0 release is a milestone for Apache APISIX, as Apache APISIX 2.10.0 is our first LTS (Long Time Support) release.
 
-We will be releasing subsequent patch versions on top of Apache APISIX 2.10, i.e. 2.10.1, 2.10.2, etc. These releases will backport bugfixes from the main branch.
+We will be releasing subsequent patch versions on top of Apache APISIX 2.10.0, i.e. 2.10.1, 2.10.2, etc. These releases will backport bugfixes from the main branch.
 
 In October, we plan to release the first patch for the first LTS version, Apache APISIX 2.10.1.
 
@@ -30,9 +30,9 @@ We will then release alternating version lines 2.10.x (e.g. 2.10.2) and 2.x (e.g
 
 ## New Feature: Add Hosts Attribute to Service
 
-In Apache APISIX 2.10, we added the `hosts` property to `service`. Like the other fields in `service`, `route` can inherit the `hosts` attribute from `service`.
+In Apache APISIX 2.10.0, we added the `hosts` property to `service`. Like the other fields in `service`, `route` can inherit the `hosts` attribute from `service`.
 
-For example, the following configurations are equivalent in Apache APISIX 2.10:
+For example, the following configurations are equivalent in Apache APISIX 2.10.0:
 
 ```json
 # services/1
@@ -104,9 +104,9 @@ In addition to the Python Plugin Runner, our community partners are also develop
 
 ## Download
 
-In addition to the above new features and components, the Apache APISIX 2.10 release introduces more than a dozen new features and plugins, for details please see the [Change log](https://github.com/apache/apisix/blob/release/2.10/) corresponding to this release CHANGELOG.md#2100).
+In addition to the above new features and components, the Apache APISIX 2.10.0 release introduces more than a dozen new features and plugins, for details please see the [Change log](https://github.com/apache/apisix/blob/release/2.10/) corresponding to this release CHANGELOG.md#2100).
 
-Download Apache APISIX 2.10
+Download Apache APISIX 2.10.0
 
 - Source code: Please visit [Download page](https://apisix.apache.org/downloads/)
 - Binary installation package: Please visit [Installation Guide](https://apisix.apache.org/docs/apisix/how-to-build/)

--- a/website/blog/2021-09-29-release-apache-apisix-2.10.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX 2.10 正式发布，带来第一个 LTS 版本！"
+title: "Apache APISIX 2.10.0 正式发布，带来第一个 LTS 版本！"
 author: "罗泽轩"
 authorURL: "https://github.com/spacewander"
 authorImageURL: "https://avatars.githubusercontent.com/u/4161644?v=4"
@@ -7,12 +7,12 @@ keywords:
 - Apache APISIX
 - API 网关
 - Release Notes
-- APISIX 2.10
-description: Apache APISIX 2.10 版本正式发布！这是 Apache APISIX 首个 LTS 版本，同时支持 10+ 个新功能和新插件。
+- APISIX 2.10.0
+description: Apache APISIX 2.10.0 版本正式发布！这是 Apache APISIX 首个 LTS 版本，同时支持 10+ 个新功能和新插件。
 tags: [Release]
 ---
 
-> Apache APISIX 2.10 版本正式发布！
+> Apache APISIX 2.10.0 版本正式发布！
 
 <!--truncate-->
 
@@ -20,9 +20,9 @@ Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版
 
 ## 里程碑：第一个 LTS 版本
 
-对于 Apache APISIX 来说，本次发布的 2.10 是一个具有里程碑意义的版本，因为 Apache APISIX 2.10 是我们的第一个 LTS （Long Time Support）的版本。
+对于 Apache APISIX 来说，本次发布的 2.10.0 是一个具有里程碑意义的版本，因为 Apache APISIX 2.10.0 是我们的第一个 LTS （Long Time Support）的版本。
 
-我们会在 Apache APISIX 2.10 的基础上发布后续的 patch 版本，也就是 2.10.1、2.10.2 等版本。这些版本会从主分支上 backport bugfix。
+我们会在 Apache APISIX 2.10.0 的基础上发布后续的 patch 版本，也就是 2.10.1、2.10.2 等版本。这些版本会从主分支上 backport bugfix。
 
 按计划，10 月份我们会发布首个 LTS 版本的首个 patch 版本，也就是 Apache APISIX 2.10.1。
 
@@ -30,7 +30,7 @@ Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版
 
 ## 新功能：service 增加 hosts 属性
 
-在 Apache APISIX 2.10 版本里面，我们给 `service` 加上了 `hosts` 属性。就像 `service` 里面其他字段一样，`route` 可以从 `service` 中继承 `hosts` 属性。
+在 Apache APISIX 2.10.0 版本里面，我们给 `service` 加上了 `hosts` 属性。就像 `service` 里面其他字段一样，`route` 可以从 `service` 中继承 `hosts` 属性。
 
 下面的配置：
 
@@ -72,7 +72,7 @@ Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版
 
 ## 新功能：支持设置镜像请求的比例
 
-proxy-mirror 插件支持设置镜像请求的比例，是用户们一直在期待的功能，我们在 Apache APISIX 2.10 上支持了这个功能。
+proxy-mirror 插件支持设置镜像请求的比例，是用户们一直在期待的功能，我们在 Apache APISIX 2.10.0 上支持了这个功能。
 
 通过设置 `sample_ratio`，可以控制被镜像到测试服务的请求数量。比如，下述的配置将 `sample_ratio` 设置为 0.5，会将一半的请求镜像到测试服务上：
 
@@ -106,9 +106,9 @@ Python 是一门有着深厚群众基础的编程语言，一直以容易上手�
 
 ## 下载
 
-除了上述新功能和组件外，Apache APISIX 2.10 版本还引入了十余个新功能和插件，详情请查看本次发布对应的 [Change log](https://github.com/apache/apisix/blob/release/2.10/CHANGELOG.md#2100)。
+除了上述新功能和组件外，Apache APISIX 2.10.0 版本还引入了十余个新功能和插件，详情请查看本次发布对应的 [Change log](https://github.com/apache/apisix/blob/release/2.10/CHANGELOG.md#2100)。
 
-下载 Apache APISIX 2.10
+下载 Apache APISIX 2.10.0
 
 - 源代码：请访问[下载页面](https://apisix.apache.org/downloads/)
 - 二进制安装包：请访问[安装指南](https://apisix.apache.org/zh/docs/apisix/how-to-build/)

--- a/website/blog/2021-09-29-release-apache-apisix-2.10.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10.md
@@ -72,7 +72,7 @@ Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版
 
 ## 新功能：支持设置镜像请求的比例
 
-proxy-mirror 插件支持设置镜像请求的比例，是用户们一直在期待的功能，我们在 Apache APISIX 2.10上支持了这个功能。
+proxy-mirror 插件支持设置镜像请求的比例，是用户们一直在期待的功能，我们在 Apache APISIX 2.10 上支持了这个功能。
 
 通过设置 `sample_ratio`，可以控制被镜像到测试服务的请求数量。比如，下述的配置将 `sample_ratio` 设置为 0.5，会将一半的请求镜像到测试服务上：
 

--- a/website/blog/2021-09-29-release-apache-apisix-2.10.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10.md
@@ -1,0 +1,114 @@
+---
+title: "Apache APISIX 2.10 正式发布，带来第一个 LTS 版本！"
+author: "罗泽轩"
+authorURL: "https://github.com/spacewander"
+authorImageURL: "https://avatars.githubusercontent.com/u/4161644?v=4"
+keywords:
+- Apache APISIX
+- API 网关
+- Release Notes
+- APISIX 2.10
+description: Apache APISIX 2.10 版本正式发布！这是 Apache APISIX 首个 LTS 版本，同时支持 10+ 个新功能和新插件。
+tags: [Release]
+---
+
+> Apache APISIX 2.10 版本正式发布！
+
+<!--truncate-->
+
+Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版本，同时支持 10+ 个新功能和新插件。快速阅读了解 2.10 版本的新特性吧！
+
+## 里程碑：第一个 LTS 版本
+
+对于 Apache APISIX 来说，本次发布的 2.10.0 是一个具有里程碑意义的版本，因为 Apache APISIX 2.10.0 是我们的第一个 LTS （Long Time Support）的版本。
+
+我们会在 Apache APISIX 2.10.0 的基础上发布后续的 patch 版本，也就是 2.10.1、2.10.2 等版本。这些版本会从主分支上 backport bugfix。
+
+按计划，10 月份我们会发布首个 LTS 版本的首个 patch 版本，也就是 Apache APISIX 2.10.1。
+
+之后我们会交替发布 2.10.x（例如 2.10.2 ） 和 2.x（例如 2.11.0）两个版本线，保持功能迭代的同时，确保 LTS 版本能够得到较新的 bugfix。
+
+## 新功能：service 增加 hosts 属性
+
+在 Apache APISIX 2.10.0 版本里面，我们给 `service` 加上了 `hosts` 属性。就像 `service` 里面其他字段一样，`route` 可以从 `service` 中继承 `hosts` 属性。
+
+下面的配置：
+
+```json
+# services/1
+{
+    "hosts": ["bar.com"]
+}
+# routes/1
+{
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "service_id": "1",
+    "uri": "/hello"
+}
+```
+
+相当于：
+
+```json
+# routes/1
+{
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "hosts": ["bar.com"],
+    "uri": "/hello"
+}
+```
+
+这么修改之后，Apache APISIX 里面的 `route` 和 `service` 的关系与 Nginx 里面的 `location` 和 `server` 的关系越来越相似。 可以这么说，本次修改让 `service` 从鸡肋变成了鸡腿，把 `service` 又拉回了 Apache APISIX 配置核心三角：[Route](http://apisix.apache.org/zh/docs/apisix/architecture-design/route)、 [Upstream](http://apisix.apache.org/zh/docs/apisix/architecture-design/upstream)、[Service](http://apisix.apache.org/zh/docs/apisix/architecture-design/service) 之中。
+
+## 新功能：支持设置镜像请求的比例
+
+proxy-mirror 插件支持设置镜像请求的比例，是用户们一直在期待的功能，我们在 Apache APISIX 2.10上支持了这个功能。
+
+通过设置 `sample_ratio`，可以控制被镜像到测试服务的请求数量。比如，下述的配置将 `sample_ratio` 设置为 0.5，会将一半的请求镜像到测试服务上：
+
+```json
+{
+    "plugins": {
+        "proxy-mirror": {
+            "host": "http://127.0.0.1:1986",
+            "sample_ratio": 0.5
+        }
+    },
+    "upstream": {
+        "nodes": {
+            "127.0.0.1:1980": 1
+        },
+        "type": "roundrobin"
+    },
+    "uri": "/hello"
+}
+```
+
+## 新组件：APISIX Python Plugin Runner
+
+继 [Java Plugin Runner](https://apisix.apache.org/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins/) 和 [Go Plugin Runner](https://apisix.apache.org/blog/2021/08/19/go-makes-Apache-APISIX-better/) 之后，Apache APISIX 又迎来了新的 Plugin Runner。
+
+[Apache APISIX Python Plugin Runner](https://github.com/apache/apisix-python-plugin-runner) 已于 9 月 6 日发布了 0.1.0 版本。
+
+Python 是一门有着深厚群众基础的编程语言，一直以容易上手和灵活多变而著称。如今你我也能用这门语言，给 Apache APISIX 编写插件了。
+
+除了 Python Plugin Runner 之外，社区的伙伴也在开发其他编程语言的 Plugin Runner，比如 [JavaScript Plugin Runner](https://github.com/zenozeng/apisix-javascript-plugin-runner)，欢迎大家参与开发。
+
+## 下载
+
+除了上述新功能和组件外，Apache APISIX 2.10.0 版本还引入了十余个新功能和插件，详情请查看本次发布对应的 [Change log](https://github.com/apache/apisix/blob/release/2.10.0/CHANGELOG.md#2100)。
+
+下载 Apache APISIX 2.10
+
+- 源代码：请访问[下载页面](https://apisix.apache.org/downloads/)
+- 二进制安装包：请访问[安装指南](https://apisix.apache.org/zh/docs/apisix/how-to-build/)

--- a/website/blog/2021-09-29-release-apache-apisix-2.10.md
+++ b/website/blog/2021-09-29-release-apache-apisix-2.10.md
@@ -20,9 +20,9 @@ Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版
 
 ## 里程碑：第一个 LTS 版本
 
-对于 Apache APISIX 来说，本次发布的 2.10.0 是一个具有里程碑意义的版本，因为 Apache APISIX 2.10.0 是我们的第一个 LTS （Long Time Support）的版本。
+对于 Apache APISIX 来说，本次发布的 2.10 是一个具有里程碑意义的版本，因为 Apache APISIX 2.10 是我们的第一个 LTS （Long Time Support）的版本。
 
-我们会在 Apache APISIX 2.10.0 的基础上发布后续的 patch 版本，也就是 2.10.1、2.10.2 等版本。这些版本会从主分支上 backport bugfix。
+我们会在 Apache APISIX 2.10 的基础上发布后续的 patch 版本，也就是 2.10.1、2.10.2 等版本。这些版本会从主分支上 backport bugfix。
 
 按计划，10 月份我们会发布首个 LTS 版本的首个 patch 版本，也就是 Apache APISIX 2.10.1。
 
@@ -30,7 +30,7 @@ Apache APISIX 2.10 版本正式发布！🎉 这是 Apache APISIX 首个 LTS 版
 
 ## 新功能：service 增加 hosts 属性
 
-在 Apache APISIX 2.10.0 版本里面，我们给 `service` 加上了 `hosts` 属性。就像 `service` 里面其他字段一样，`route` 可以从 `service` 中继承 `hosts` 属性。
+在 Apache APISIX 2.10 版本里面，我们给 `service` 加上了 `hosts` 属性。就像 `service` 里面其他字段一样，`route` 可以从 `service` 中继承 `hosts` 属性。
 
 下面的配置：
 
@@ -106,7 +106,7 @@ Python 是一门有着深厚群众基础的编程语言，一直以容易上手�
 
 ## 下载
 
-除了上述新功能和组件外，Apache APISIX 2.10.0 版本还引入了十余个新功能和插件，详情请查看本次发布对应的 [Change log](https://github.com/apache/apisix/blob/release/2.10.0/CHANGELOG.md#2100)。
+除了上述新功能和组件外，Apache APISIX 2.10 版本还引入了十余个新功能和插件，详情请查看本次发布对应的 [Change log](https://github.com/apache/apisix/blob/release/2.10/CHANGELOG.md#2100)。
 
 下载 Apache APISIX 2.10
 


### PR DESCRIPTION
Changes:

1. Added Apache APISIX 2.10 release notes in zh-hans and en
2. Added Apache APISIX 2.9 release notes in en, it seems like we forgot to add it back in August
3. Modified tags in some docs, most are switching from Events to Release, or from Release to Events
