### PR TITLE
chore: fix dark-mode switch on mobile devices

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -134,7 +134,7 @@ header h2 {
   color: var(--color-primary);
 }
 
-.navbar__title{
+.navbar__title {
   font-size: 18px;
   height: 30px;
 }

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -134,7 +134,7 @@ header h2 {
   color: var(--color-primary);
 }
 
-.navbar__title {
+.navbar__title{
   font-size: 18px;
   height: 30px;
 }

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -1077,7 +1077,7 @@ a:hover {
   }
   
   .add-margin {
-    margin: 30px 0;
+    margin: 30px 0 0 0;
   }
 
   .homeCanvas{
@@ -1244,8 +1244,10 @@ a:hover {
   }
 }
 
-.react-toggle {
-  display: none;
+@media only screen and (min-width: 768px) {
+  .react-toggle {
+    display: none;
+  }
 }
 
 .bottom-pos {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,4 +1,5 @@
-import React, { useState, useLayoutEffect } from "react";
+import React, { useState, useEffect, useLayoutEffect } from "react";
+import useThemeContext from '@theme/hooks/useThemeContext';
 import Layout from "@theme/Layout";
 
 import HeroSection from "./sections/heroSection";
@@ -24,6 +25,23 @@ const useWindowSize = () => {
   return size;
 }
 
+const ThemeResetComponent = () => {
+  const {isDarkTheme, setLightTheme, setDarkTheme} = useThemeContext();
+
+  useEffect(() => {    
+    const children = document.querySelector(".navbar__items--right").childElementCount;
+    document.querySelector(".navbar__items--right").childNodes[children-2].style.display = "none";
+
+    if(isDarkTheme) {
+      setLightTheme(true);
+    }    
+  }, [])
+
+  return (
+    <></>
+  );
+};
+
 const Index = () => {
 
   const [screenWidth, screenHeight] = useWindowSize();
@@ -39,6 +57,7 @@ const Index = () => {
       <HomeEventsSection />
       <EndCTA />
       <EventPosterCard />
+      <ThemeResetComponent/>
     </Layout>
   );
 };

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -37,9 +37,7 @@ const ThemeResetComponent = () => {
     }    
   }, [])
 
-  return (
-    <></>
-  );
+  return (null);
 };
 
 const Index = () => {

--- a/website/src/theme/DocPage/index.tsx
+++ b/website/src/theme/DocPage/index.tsx
@@ -48,7 +48,13 @@ function DocPageContent({
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   
   useEffect(() => {
-    document.querySelector(".react-toggle").style.display = "block";
+    const children = document.querySelector(".navbar__items--right").childElementCount;
+    if(window.innerWidth > 745) {
+      document.querySelector(".navbar__items--right").childNodes[children-2].style.display = "block";
+    }
+    else {
+      document.querySelector(".navbar__items--right").childNodes[children-2].style.display = "none";
+    }
     const currentPage = currentDocRoute.path.split("/")[2] || "";
     switch (currentPage) {
       case "general":
@@ -77,7 +83,7 @@ function DocPageContent({
         break;
     }
     return () => {
-      document.querySelector(".react-toggle").style.display = "none";
+      document.querySelector(".navbar__items--right").childNodes[children-2].style.display = "none"
     }
   }, []);
 


### PR DESCRIPTION
Changes:

Dark mode switch padding fixed on mobile devices and additional changes for dark mode switch from docs to homepage

Fixes
_originally posted by Xunzhuo in [comment](https://github.com/apache/apisix-website/issues/640#issuecomment-940952280)_
_One more thing, in mobile, two buttons (dark mode and search) are too closed._

Screenshot of changes 

![image](https://user-images.githubusercontent.com/57267960/137006180-0a726a9c-d1b8-4de8-becd-d35e9ca49595.png)

![image](https://user-images.githubusercontent.com/57267960/137006247-582b71dc-4229-41df-aabe-ad6dab57982d.png)

