### PR TITLE
feat: support jsDelivr CDN to speedup static files

### DIFF
--- a/scripts/sync-docs.js
+++ b/scripts/sync-docs.js
@@ -296,7 +296,7 @@ const replaceMDElements = (project, path, branch = "master") => {
     from: /(\.\.\/)+assets\/images\/[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]/g,
     to: (match) => {
       const imgPath = match.replace(/\(|\)|\.\.\/*/g, "");
-      const newUrl = `https://raw.githubusercontent.com/apache/${project}/${branch}/docs/${imgPath}`;
+      const newUrl = `https://cdn.jsdelivr.net/gh/apache/${project}@${branch}/docs/${imgPath}`;
       //console.log(`${project}: ${match} 👉 ${newUrl}`);
       return newUrl;
     },


### PR DESCRIPTION
resolve #504

Changes:

Use jsDelivr CDN to host static files, example: 

From `https://raw.githubusercontent.com/apache/apisix/master/docs/assets/images/requesturl.jpg` to 
`https://cdn.jsdelivr.net/gh/apache/apisix@master/docs/assets/images/requesturl.jpg`

It also supports something like `https://cdn.jsdelivr.net/gh/apache/apisix@release/2.10.0/docs/assets/images/requesturl.jpg`

jsDelivr: https://www.jsdelivr.com/?docs=gh