### PR TITLE
chore: support CDN to load all JS bundle files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           cd website && yarn build
           cp ../.asf.yaml ./build
           # NOTE: Use jsDelivr to load JS files from the asf-site branch
-          sed -i '' 's/return"assets\/js\/"/return"https:\/\/cdn.jsdelivr.net\/gh\/apache\/apisix-website@asf-site\/assets\/js\/"/g' ./build/assets/js/runtime~main.**.js
+          sed -i 's/return"assets\/js\/"/return"https:\/\/cdn.jsdelivr.net\/gh\/apache\/apisix-website@asf-site\/assets\/js\/"/g' ./build/assets/js/runtime~main.**.js
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           cd website && yarn build
           cp ../.asf.yaml ./build
+          # NOTE: Use jsDelivr to load JS files from the asf-site branch
+          sed -i '' 's/return"assets\/js\/"/return"https:\/\/cdn.jsdelivr.net\/gh\/apache\/apisix-website@asf-site\/assets\/js\/"/g' ./build/assets/js/runtime~main.**.js
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ module.exports = {
   baseUrl: "/",
   organizationName: "Apache",
   projectName: "apisix-website",
-  favicon: "img/favicon.png",
+  favicon: "https://cdn.jsdelivr.net/gh/apache/apisix-website@asf-site/img/favicon.png",
   customFields: {
     tagline2:
       "Apache APISIX software provides rich traffic management features such as load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, and more.",
@@ -421,7 +421,7 @@ module.exports = {
       hideOnScroll: true,
       title: "Apache APISIX®",
       logo: {
-        src: "img/logo2.svg",
+        src: "https://cdn.jsdelivr.net/gh/apache/apisix-website@asf-site/img/logo2.svg",
       },
       items: [
         {
@@ -594,7 +594,7 @@ module.exports = {
       ],
       logo: {
         alt: "Apache Software Foundation",
-        src: "img/asf_logo_wide_small.png",
+        src: "https://cdn.jsdelivr.net/gh/apache/apisix-website@asf-site/img/asf_logo_wide_small.png",
         href: "https://www.apache.org/",
       },
 
@@ -623,7 +623,7 @@ module.exports = {
       disableSwitch: false,
       respectPrefersColorScheme: false,
     },
-    image: 'img/favicon.png',
+    image: 'https://cdn.jsdelivr.net/gh/apache/apisix-website@asf-site/img/favicon.png',
     metadatas: [
       {
         name: "description",


### PR DESCRIPTION
Changes:

- [x] Use sed to replace JS public path (jsDelivr)

Screenshots of the change:

![image](https://user-images.githubusercontent.com/2106987/138565656-0cf89096-5f52-47cd-ad63-9a313e475f9a.png)

From `assets/js` to `CDN/assets/js`

![image](https://user-images.githubusercontent.com/2106987/138565559-f68d5a99-fc0b-4e16-be92-350adba80343.png)
