### PR TITLE
docs: update English docs from Oct to Nov

### DIFF
--- a/website/blog/2021/10/13/celebrating-300-contributors-of-apisix.md
+++ b/website/blog/2021/10/13/celebrating-300-contributors-of-apisix.md
@@ -50,4 +50,4 @@ Past recommendations.
 
 What kind of events do you want the Apache APISIX community to organize? Or want to be an organizer/volunteer for an event, feel free to discuss it on the [mailing list](https://apisix.apache.org/zh/docs/general/subscribe-guide)!
 
-**The Apache APISIX community is thankful to have you, and we are looking forward to more people joining the Apache APISIX community. The Apache APISIX community is grateful to have you.
+Apache APISIX community is thankful to have you, and we are looking forward to more people joining the Apache APISIX community. The Apache APISIX community is grateful to have you.

--- a/website/blog/2021/10/14/weekly-report-1014.md
+++ b/website/blog/2021/10/14/weekly-report-1014.md
@@ -46,7 +46,7 @@ We've also put together some issues for those new to the community!
 
 ## Feature highlights of the week
 
-- [Dashboard support for configuring the host field in Service to provide routing defaults](https://github.com/apache/apisix-dashboard/pull/2149) (Contributor: [bzp2010](https://github.com/ bzp2010))
+- [Dashboard support for configuring the host field in Service to provide routing defaults](https://github.com/apache/apisix-dashboard/pull/2149) (Contributor: [bzp2010](https://github.com/bzp2010))
 
 - [APISIX support test profile](https://github.com/apache/apisix/pull/5171) (Contributor: [nic-chen](https://github.com/nic-chen))
 
@@ -54,7 +54,7 @@ We've also put together some issues for those new to the community!
 
 ## Recommended blog posts for this week
 
-- [New milestone for the Apache APISIX community - topping 300 contributors worldwide!] (https://apisix.apache.org/zh/blog/2021/10/13/celebrating-300-contributors-of-apisix).
+- [New milestone for the Apache APISIX community - topping 300 contributors worldwide!](https://apisix.apache.org/zh/blog/2021/10/13/celebrating-300-contributors-of-apisix).
 
   The Apache APISIX community has reached a new milestone, surpassing 300 global contributors to projects related to Apache APISIX! Just 3 months after the Apache APISIX main repository reached the 200 contributor milestone! Thank you to our community contributors for their outstanding contributions in all aspects of code, documentation, operations, and more.
 
@@ -62,6 +62,6 @@ We've also put together some issues for those new to the community!
 
   Zexuan Luo and Ming Wen from the Apache APISIX community contributed to the first community innovation release of openEuler (openEuler 21.09) on September 30, which allowed OpenResty to run smoothly and efficiently on the Euler open source operating system. The stable operation of OpenResty also means that Apache APISIX can run smoothly on the openEuler system, and the underlying Apache APISIX is based on OpenResty for some development.
 
-- [Apache APISIX 2.10.0 is released, bringing the first LTS version!] (https://apisix.apache.org/zh/blog/2021/09/29/release-apache-apisix-2.10)
+- [Apache APISIX 2.10.0 is released, bringing the first LTS version!](https://apisix.apache.org/zh/blog/2021/09/29/release-apache-apisix-2.10)
 
   Apache APISIX version 2.10 is officially released! 🎉 This is the first LTS release of Apache APISIX, with support for 10+ new features and new plugins. Have a quick read about the new features in version 2.10!

--- a/website/blog/2021/10/29/Extension-guide.md
+++ b/website/blog/2021/10/29/Extension-guide.md
@@ -207,5 +207,5 @@ After the request is finished, we can also do some cleanup work with the `log` m
 
 If you are interested, you can take a look at how the `log` method of these two plugins is implemented:
 
-- [`prometheus` plugin documentation](https://apisix.apache.org/zh/docs/apisix/plugins/prometheus/)
-- [`http-logger` plugin documentation](https://apisix.apache.org/zh/docs/apisix/plugins/http-logger/)
+- [`prometheus` plugin documentation](https://apisix.apache.org/docs/apisix/plugins/prometheus/)
+- [`http-logger` plugin documentation](https://apisix.apache.org/docs/apisix/plugins/http-logger/)


### PR DESCRIPTION
Changes:

Update English docs from Oct to Nov.

1. Fixed links displayed incorrectly
2. Fix links direct to Chinese doc, replaced them with English docs' links
3. Other minor fix: deleted "**" because there is no need to add it here.
