### PR TITLE
fix: extract docs from target branch

### DIFF
--- a/scripts/sync-docs.js
+++ b/scripts/sync-docs.js
@@ -80,7 +80,8 @@ const tasks = new listr([
                     {
                       title: "Replace elements inside MD files",
                       task: () => {
-                        replaceMDElements(project.name, [`${tempPath}/${project.name}/docs`], project.branch);
+                        const branchName = `release/${version}`;
+                        replaceMDElements(project.name, [`${tempPath}/${project.name}/docs`], branchName);
                         copyAllDocs(project);
                       }
                     },
@@ -117,6 +118,7 @@ const tasks = new listr([
     }
   },
   {
+    // NOTE: Extract docs from the master branch
     title: "Extract next version documents",
     task: () => {
       const nextVersionTasks = projectPaths.map((project) => {


### PR DESCRIPTION
Changes:

Currently, the `sync-docs.js` only load images from the master branch, we need to load contents from target branch.

Wrong: https://cdn.jsdelivr.net/gh/apache/apisix@master/docs/assets/images/plugin/skywalking-2.png
Correct: https://cdn.jsdelivr.net/gh/apache/apisix@2.9/docs/assets/images/plugin/skywalking-2.png