### PR TITLE
docs: fix typos in text and cover image

### DIFF
--- a/website/blog/2021/11/12/apisix-datadog.md
+++ b/website/blog/2021/11/12/apisix-datadog.md
@@ -16,7 +16,7 @@ tags: [Technology]
 
 <!--truncate-->
 
-![cover picture](https://static.apiseven.com/202108/1636684696018-960c797e-67b8-4daa-ba64-1957a07bc5e2.png)
+![cover picture](https://static.apiseven.com/202108/1636955062917-28911d71-0d56-48ec-85e5-a7908195da2f.png)
 
 As the complexity of IT products and consumer-facing application development increases, monitoring becomes an integral part of any application delivery. Additionally, to meet the endless demand of rapid upgrade cycles while ensuring stability, streamlined performance and keeping a perfect balance between service level indicators (SLI) with Service-level objectives (SLO) and Service-level agreement (SLA) - effective monitoring is immensely important.
 
@@ -82,7 +82,7 @@ If you are using Kubernetes in your production environment, you can deploy `dogs
 
 ### Activate the APISIX-Datadog plugin
 
-The following is an example on how to activate the datadog plugin for a specific route. We are assumming your `dogstatsd` agent is already up an running.
+The following is an example on how to activate the datadog plugin for a specific route. We are assuming your `dogstatsd` agent is already up an running.
 
 ```shell
 # enable plugin for a specific route

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/12/apisix-datadog.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/12/apisix-datadog.md
@@ -16,7 +16,7 @@ tags: [Technology]
 
 <!--truncate-->
 
-![APISIX-Datadog 插件封面图](https://static.apiseven.com/202108/1636684696018-960c797e-67b8-4daa-ba64-1957a07bc5e2.png)
+![APISIX-Datadog 插件封面图](https://static.apiseven.com/202108/1636955062917-28911d71-0d56-48ec-85e5-a7908195da2f.png)
 
 随着应用开发的复杂度增加，监控成为了应用的一个重要组成部分。及时、准确的监控既能满足快速迭代的周期性需求，又能够确保应用的稳定性和流畅性。如何选择一个适合的监控，以提升应用的可观测性，成为了每个开发者都必须面临的一道难题。
 


### PR DESCRIPTION
Changes:

Fix typos in text and cover image.

- In the cover image, "Enhencement" should be "Enhancement". Thus updated the image.
- "assumming" should be "assuming"