### PR TITLE
fix: update ingress controller download link

### DIFF
--- a/website/config/downloads.js
+++ b/website/config/downloads.js
@@ -34,7 +34,7 @@ module.exports = [
     color: "#2563EB",
     githubRepo: "apache/apisix-ingress-controller",
     githubBranch: "master",
-    downloadPath: "apisix/ingress-controller/1.2.0/apache-apisix-ingress-controller-1.2.0-src",
+    downloadPath: "apisix/ingress-controller/1.3.0/apache-apisix-ingress-controller-1.3.0-src",
     version: "1.3.0",
     releaseDate: "2021-10-17",
     firstDocPath: "/getting-started",


### PR DESCRIPTION
Fixes: #765

Changes:

The current Ingress Controller version number does not match the download link, this has been corrected in this PR.
