### PR TITLE
docs: update topic to avoid displaying issue

### DIFF
--- a/website/blog/2021/11/23/cve-2021-43557-research-report.md
+++ b/website/blog/2021/11/23/cve-2021-43557-research-report.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX Path traversal in request_uri variable(CVE-2021-43557)"
+title: "Apache APISIX request_uri variable is not properly controlled, with risk of path penetration"
 author: "Marcin Niemiec"
 authorURL: "https://github.com/xvnpw"
 authorImageURL: "https://avatars.githubusercontent.com/u/17719543?v=4"


### PR DESCRIPTION
Fixes: #771

Changes:

Currently, the website displays two identical articles on the first page of blog. 

After some researching and testing, I find the cause of this problem. While it is completely fine to post multiple articles in the same date directory, the `title` of articles under the same directory must be identical and unique. 

In other words, when adding two or more articles in the same date directory, you need to make sure each article's `title` must be different.

This problem is caused by two articles with the same `title`. 

![image](https://user-images.githubusercontent.com/36651058/143372791-0b8bb7bf-9ec0-447e-9873-f42056deb88b.png)

![image](https://user-images.githubusercontent.com/36651058/143372842-0aaf8cb7-f9c4-465e-a0dc-8659a1049cbf.png)

After updating the title of an article, then `yarn start` run it locally, it works out fine.

![image](https://user-images.githubusercontent.com/36651058/143372443-89b215a1-1e29-4a03-9e6b-81ae5aa963bd.png)

In addition, I also checked the files in `apisix-website/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/23/` directory and run it locally. It works fine, so there is no need to modify files in this directory.

For future changes, if you are adding two or more articles in the same date directory, please make sure they have different `title`. Use `yarn start` to run it locally before submission is also suggested.