### PR TITLE
docs: update the link to blog guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The website of [Apache APISIX®](https://apisix.apache.org/), a cloud-native microservices api gateway.
 
-If you want to write a blog or fix some blog-related issues, please read [Apache APISIX Blog Contributing Guide](/website/docs/general/blog-contributing-guide.md) first. Then create a pull request.
+If you want to write a blog or fix some blog-related issues, please read [Apache APISIX Blog Contributing Guide](http://apisix.apache.org/docs/general/blog) first. Then create a pull request.
 
 ## Usage
 


### PR DESCRIPTION
Changes:
The link to Blog Guidelines is linked to the markdown file, now we need to change it to website link.
