### PR TITLE
chore: adjust branch protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,5 +38,11 @@ github:
     squash: true
     merge: false
     rebase: false
+  protected_branches:
+    master:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        required_approving_review_count: 2
 publish:
   whoami: asf-site


### PR DESCRIPTION
**Changes:**

Due to asf-site branch's protection setting, we need to adjust settings to allow force-push.

see https://github.com/apache/apisix-website/runs/4500450580?check_suite_focus=true

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
