### PR TITLE
fix: update blog incorrect words

### DIFF
--- a/website/blog/2021/12/01/apisix-supports-azure-functions.md
+++ b/website/blog/2021/12/01/apisix-supports-azure-functions.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX's intergration with Azure Serverless"
+title: "Apache APISIX's integration with Azure Serverless"
 author: "Bisakh Mondal"
 authorURL: "https://github.com/bisakhmondal"
 authorImageURL: "https://avatars.githubusercontent.com/u/41498427?v=4"
@@ -16,7 +16,7 @@ tags: [Technology]
 
 <!--truncate-->
 
-![Apache APISIX's intergration with Azure Serverless](https://static.apiseven.com/202108/1638431191799-e1202fc7-d3b5-48db-a222-0c70a8b70da0.png)
+![Apache APISIX's integration with Azure Serverless](https://static.apiseven.com/202108/1638431191799-e1202fc7-d3b5-48db-a222-0c70a8b70da0.png)
 
 Apache APISIX provides support for serverless frameworks for popular cloud vendors (more coming on the way). Instead of hardcoding the function URL into the application, Apache APISIX suggests defining a route with the serverless plugin enabled. It gives the developers the flexibility to hot update the function URI along with completely changing the faas vendor to a different cloud provider with zero hassle. Also, this approach mitigates authorization and authentication concerns from application logic as Apache APISIX has very strong authentication support that could be used to identify and authorize client consumers to access the particular route with the faas. This article talks about the recent addition of a new plugin `azure-functions`, and gives detailed instructions on how to integrate Azure Functions, which is a widely used serverless solution, into the Apache APISIX serverless suite.
 

--- a/website/blog/2021/12/07/apisix-integrate-skywalking-plugin.md
+++ b/website/blog/2021/12/07/apisix-integrate-skywalking-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX Integrates with SkyWalking to Create a Full Fange of Log Processing"
+title: "Apache APISIX Integrates with SkyWalking to Create a Full Range of Log Processing"
 authors: 
   - name: "Haochao Zhuang"
     title: "Author"
@@ -38,7 +38,7 @@ Obviously, the above way of handling the process is tedious and complicated, and
 
 ## Introduction of the New Plugins
 
-### SkyWalking Logger Pulgin
+### SkyWalking Logger Plugin
 
 The SkyWalking Logger plugin parses the SkyWalking Tracing Context Header and prints the relevant Tracing Context information to the log, thus enabling the log to be associated with the call chain.
 

--- a/website/blog/2021/12/20/weekly-report-1215.md
+++ b/website/blog/2021/12/20/weekly-report-1215.md
@@ -127,7 +127,7 @@ The Apache APISIX project website and the Github issue have accumulated a wealth
 
   This article will introduce the latest integration of Apache APISIX and Apache RocketMQ rocketmq-logger plug-in features and use. With this plug-in, you can connect to the RocketMQ cluster more easily when using Apache APISIX.
   
-- [Apache APISIX Integrates with SkyWalking to Create a Full Fange of Log Processing](https://apisix.apache.org/blog/2021/12/07/apisix-integrate-skywalking-plugin)：
+- [Apache APISIX Integrates with SkyWalking to Create a Full Range of Log Processing](https://apisix.apache.org/blog/2021/12/07/apisix-integrate-skywalking-plugin)：
 
   This paper mainly introduces two Apache APISIX integrated SkyWalking log plug-ins to provide a more convenient operation and environment for log processing in Apache APISIX.
   

--- a/website/blog/2021/12/22/google-logging.md
+++ b/website/blog/2021/12/22/google-logging.md
@@ -203,6 +203,6 @@ If you have a need to interface to other logs, visit Apache APISIX's [GitHub](ht
 
 ## Related articles
 
-[Apache APISIX Integrates with SkyWalking to Create a Full Fange of Log Processing](https://apisix.apache.org/blog/2021/12/07/apisix-integrate-skywalking-plugin/)
+[Apache APISIX Integrates with SkyWalking to Create a Full Range of Log Processing](https://apisix.apache.org/blog/2021/12/07/apisix-integrate-skywalking-plugin/)
 
 [Apache APISIX & RocketMQ Helps User API Log Monitoring Capabilities](https://apisix.apache.org/blog/2021/12/08/apisix-integrate-rocketmq-logger-plugin/)


### PR DESCRIPTION
Fixes: update [blog](https://apisix.apache.org/blog/2021/12/07/apisix-integrate-skywalking-plugin/) title word and other quotes words 


