### PR TITLE
docs: fix typo in previous blogs

### DIFF
--- a/website/blog/2021/12/01/release-apache-apisix-2.11.md
+++ b/website/blog/2021/12/01/release-apache-apisix-2.11.md
@@ -23,7 +23,7 @@ tags: [Release]
 
 <!--truncate-->
 
-Apache APISIX 2.11.0 is the first release with new features since the last 2.10.0 LTS release. It not only enriches the plugin library, but also brings fresh ecological support. Specific feature details you can scroll down to see oh.
+Apache APISIX 2.11.0 is the first release with new features since the last 2.10.0 LTS release. It not only enriches the plugin library, but also brings fresh ecological support.
 
 ## New feature: New LDAP-based authentication plugin
 

--- a/website/blog/2021/12/15/deploy-apisix-in-kubernetes.md
+++ b/website/blog/2021/12/15/deploy-apisix-in-kubernetes.md
@@ -15,11 +15,11 @@ keywords:
 - APISIX Dashboard
 - Deployment
 - Cluster
-description: Apache APISIX currently supports multiple ways to install and deploy. This article focuses on how to deploy Apach APISIX and APISIX-Dashboard in a Kubernetes environment.
+description: Apache APISIX currently supports multiple ways to install and deploy. This article focuses on how to deploy Apache APISIX and APISIX-Dashboard in a Kubernetes environment.
 tags: [Technology]
 ---
 
-> Apache APISIX currently supports multiple ways to install and deploy. This article focuses on how to deploy Apach APISIX and APISIX-Dashboard in a Kubernetes environment.
+> Apache APISIX currently supports multiple ways to install and deploy. This article focuses on how to deploy Apache APISIX and APISIX-Dashboard in a Kubernetes environment.
 
 <!--truncate-->
 
@@ -36,7 +36,7 @@ Here, we recommend using Kind to build the K8s cluster test environment locally,
 kind create cluster
 ```
 
-### Option 1: Installation via Helm
+## Option 1: Installation via Helm
 
 Helm is mainly used to manage applications in Kubernetes. Helm is also known as the package manager in Kubernetes, similar to apt, yum, and pacman, which are package managers in Linux.
 

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2021/12/15/deploy-apisix-in-kubernetes.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2021/12/15/deploy-apisix-in-kubernetes.md
@@ -15,11 +15,11 @@ keywords:
 - APISIX Dashboard
 - 部署安装
 - 集群
-description: Apache APISIX 目前支持多种方式进行安装部署，本文主要介绍如何在 Kubernetes 环境中部署 Apach APISIX 以及 APISIX-Dashboard。
+description: Apache APISIX 目前支持多种方式进行安装部署，本文主要介绍如何在 Kubernetes 环境中部署 Apache APISIX 以及 APISIX-Dashboard。
 tags: [Technology]
 ---
 
-> Apache APISIX 目前支持多种方式进行安装部署，本文主要介绍如何在 Kubernetes 环境中部署 Apach APISIX 以及 APISIX-Dashboard。
+> Apache APISIX 目前支持多种方式进行安装部署，本文主要介绍如何在 Kubernetes 环境中部署 Apache APISIX 以及 APISIX-Dashboard。
 
 <!--truncate-->
 


### PR DESCRIPTION
Changes:

As I was syncing blogs to Medium yesterday, I found some typo in the recent published blogs. 

Part of them was fixed by @SylviaBABY in https://github.com/apache/apisix-website/pull/835, while I was syncing. The rest of them are included in this pull request.