### PR TITLE
docs: Updated Contributor Guide page and Committer Guide page

### DIFF
--- a/website/docs/general/committer-guide.md
+++ b/website/docs/general/committer-guide.md
@@ -13,13 +13,13 @@ description: This article is a set of guidelines for Apache APISIX committers. I
 
 All forms of contributions are accepted, for example:
 
-1. Take a look at issues with tag called Good first issue or Help wanted.
+1. Take a look at issues with a tag called Good first issue or Help wanted.
 
-2. Join the discussion on mailing list.
+2. Join the discussion on the mailing list.
 
 3. Answer questions on issues.
 
-4. Fix bugs reported on issues, and send us pull request.
+4. Fix bugs reported on issues, and send us a pull request.
 
 5. Review the existing pull request.
 
@@ -33,25 +33,25 @@ If you would like to contribute, please send an email to dev@apisix.apache.org t
 
 ## How to become an APISIX committer?
 
-Anyone can be a contributor to an Apache project. Being a contributor simply means that you take an interest in the project and contribute in some way, ranging from asking sensible questions (which documents the project and provides feedback to developers) through to providing new features as patches.
+Anyone can be a contributor to an Apache project. Being a contributor simply means that you take an interest in the project and contribute in some way, ranging from asking sensible questions (which documents the project and provides feedback to developers) to provide new features as patches.
 
-If you become a valuable contributor to the project you may well be invited to become a committer. Committer is a term used at the ASF to signify someone who is committed to a particular project. It brings with it the privilege of write access to the project repository and resources.
+If you become a valuable contributor to the project you may well be invited to become a committer. Committer is a term used at the ASF to signify someone who is committed to a particular project. It brings with it the privilege of writing access to the project repository and resources.
 
 More details could be found [here](https://community.apache.org/contributors/).
 
 ## Promotion
 
-The Apache APISIX community follows the Apache Community’s process on accepting a new committer. After a contributor participates in APISIX's community actively, (P)PMC and Committers will make decisions to invite the contributor join Committers and (P)PMC.
+The Apache APISIX community follows the Apache Community’s process of accepting a new committer. After a contributor participates in APISIX's community actively, (P)PMC and Committers will make decisions to invite the contributor to join Committers and (P)PMC.
 
 Processes are:
 
-1. Start the discussion and vote in @private. Only current PMC member could nominate
+1. Start the discussion and vote in @private. Only current PMC members could nominate
 
 2. If the vote passes, send an offer to become a committer with @private CC’ed
 
 3. New committer signs ICLA and apply Apache ID and email address
 
-4. Update Team page.
+4. Update the Team page.
 
 ## Responsibilities
 
@@ -69,7 +69,7 @@ Processes are:
 
 7. Improve processes and tools
 
-8. Guide new contributors join community.
+8. Guide new contributors to join the community.
 
 ## How to become an APISIX PMC?
 

--- a/website/docs/general/contributor-guide.md
+++ b/website/docs/general/contributor-guide.md
@@ -9,7 +9,7 @@ keywords:
 description: This article is a set of guidelines for Apache APISIX contributors, including things that a contributor can do and how to do it well.
 ---
 
-Please fee free to report bugs, submit suggestions, or submit PRs according to this guide.
+Please feel free to report bugs, submit suggestions, or submit PRs according to this guide.
 
 ## Submit an issue
 
@@ -23,15 +23,15 @@ Please fee free to report bugs, submit suggestions, or submit PRs according to t
 
 5. Fill in necessary information according to the template.
 
-6. Choose a label after issue created.
+6. Choose a label after the issue is created.
 
-7. Please pay attention to your issue, you may need provide more information during discussion.
+7. Please pay attention to your issue, you may need to provide more information during discussion.
 
 ## Developer Flow
 
 ### Fork repo
 
-Fork the Apache APISIX repo to your own repo to work, then setting proper upstream.
+Fork the Apache APISIX repo to your repo to work, then set proper upstream.
 
 ```sh
 git remote add upstream https://github.com/apache/apisix.git
@@ -47,7 +47,7 @@ git remote add upstream https://github.com/apache/apisix.git
 
 #### **Good First Issues**:
 
-Good First Issue curates easy pickings from this project, and helps you make your first contribution to Apache APISIX®.
+Good First Issue curates easy pickings from this project and helps you make your first contribution to Apache APISIX®.
 
 - [Apache APISIX®](https://github.com/apache/apisix/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [Apache APISIX® Ingress Controller](https://github.com/apache/apisix-ingress-controller/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
@@ -68,7 +68,7 @@ $ git pull upstream master
 $ git checkout -b IssueNo
 ```
 
-Notice: We will merge PR using squash, commit logs will be different form upstream if you use one older branch.
+Notice: We will merge PR using squash, commit logs will be different from upstream if you use one older branch.
 
 ### Coding
 
@@ -86,11 +86,11 @@ $ git push origin issueNo
 
 1. Send a pull request to the master branch.
 
-2. The mentor will do codes review before discussing some details (including the design, the implementation and the performance) with you.
+2. The mentor will do a codes review before discussing some details (including the design, the implementation, and the performance) with you.
 
 3. Also make sure that the pull request title has a semantic prefix like `fix:` or `feat:` or any other [conventional commit types](https://github.com/commitizen/conventional-commit-types/blob/master/index.json).
 
-4. Then congratulate to you to be an official contributor of Apache APISIX.
+4. Then congratulate you to be an official contributor of Apache APISIX.
 
 ### Delete branch
 
@@ -104,7 +104,7 @@ $ git push origin --delete issueNo
 
 ### Notice
 
-Please note that in order to show your ID in the contributor list, please DO NOT forget to set the configurations below:
+Please note that to show your ID in the contributor list, please DO NOT forget to set the configurations below:
 
 ```sh
 $ git config --global user.name "username"


### PR DESCRIPTION
As discussed in #879, 
> Hi @juzhiyuan, @shuaijinchao, @BeeBombshell I found similar issues on the Contributor Guide page as well. I would like to work on that and fix the documentation. Should I file a new issue or submit a PR in this issue itself?

Changes:

Fixed typos and grammatical errors on the Contributing Guide page and the Committer Guide page.

Screenshots of the change:

<img width="958" alt="image" src="https://user-images.githubusercontent.com/55613637/155003407-cf8a7020-63a1-4594-af9f-b2cab3c66b11.png">
