### PR TITLE
docs: fix mixed language in splunk blog

### DIFF
--- a/website/blog/2022/02/10/apisix-splunk-integration.md
+++ b/website/blog/2022/02/10/apisix-splunk-integration.md
@@ -38,7 +38,7 @@ This article explains how to configure and use the [Splunk HEC](https://docs.spl
 
 ## About splunk-hec-logging lugin
 
-The [splunk-hec-logging](https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/splunk-hec-logging.md) is used to forward Apache APISIX request logs to Splunk for analysis and storage. When enabled, Apache APISIX will take the request context information during the Log phase, serialize it into [Splunk Event Data 格式](https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata) and submit it to the batch queue. The data in the queue is committed to Splunk HEC when the maximum processing capacity of the batch queue per batch is triggered, or when the maximum time to refresh the buffer is reached.
+The [splunk-hec-logging](https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/splunk-hec-logging.md) is used to forward Apache APISIX request logs to Splunk for analysis and storage. When enabled, Apache APISIX will take the request context information during the Log phase, serialize it into [Splunk Event Data Format](https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata) and submit it to the batch queue. The data in the queue is committed to Splunk HEC when the maximum processing capacity of the batch queue per batch is triggered, or when the maximum time to refresh the buffer is reached.
 
 ## How to use the splunk-hec-logging plugin
 


### PR DESCRIPTION
Changes:

fix mixed language in splunk blog. Change `Splunk Event Data 格式` to `Splunk Event Data Format`
