### PR TITLE
fix: hide color mode switch in mobile

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect } from "react";
 import useThemeContext from '@theme/hooks/useThemeContext';
 import Layout from "@theme/Layout";
+import useWindowType from "@theme/hooks/useWindowSize";
 
 import HeroSection from "./sections/heroSection";
 import Architecture from "./sections/architecture";
@@ -27,11 +28,25 @@ const useWindowSize = () => {
 
 const ThemeResetComponent = () => {
   const {isDarkTheme, setLightTheme, setDarkTheme} = useThemeContext();
+  const windowType = useWindowType();
+
+  useEffect(()=>{
+    if (windowType === 'mobile') {
+      //  remove mode switch at navbar-sidebar
+      const sidebarModeSwitch = document.querySelector("div.navbar-sidebar__brand > div");
+      if (sidebarModeSwitch) {
+        sidebarModeSwitch.style.display = 'none';
+      }
+    } else {
+      // remove mode switch at navbar
+      const navbarRightItems = document.querySelector("div.navbar__items.navbar__items--right > div.react-toggle");
+      if (navbarRightItems) {
+        navbarRightItems.style.display = 'none';
+      }
+    }
+  }, [windowType])
 
   useEffect(() => {
-    const children = document.querySelector(".navbar__items--right").childElementCount;
-    document.querySelector(".navbar__items--right").childNodes[children-2].style.display = "none";
-
     if(isDarkTheme) {
       setLightTheme(true);
     }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -39,9 +39,9 @@ const ThemeResetComponent = () => {
       }
     } else {
       // remove mode switch at navbar
-      const navbarRightItems = document.querySelector("div.navbar__items.navbar__items--right > div.react-toggle");
-      if (navbarRightItems) {
-        navbarRightItems.style.display = 'none';
+      const navbarModeSwitch = document.querySelector("div.navbar__items.navbar__items--right > div.react-toggle");
+      if (navbarModeSwitch) {
+        navbarModeSwitch.style.display = 'none';
       }
     }
   }, [windowType])


### PR DESCRIPTION
Fixes: #872

Changes:

- Split the code of hiding color mode switch to another `useEffect`
- Use `useWindowType` to check if it is mobile
- Hide color mode switch in mobile 

Screenshots of the change:

none
