### PR TITLE
fix: APISIX LTS SHA512 links error

### DIFF
--- a/website/src/pages/downloads/ProjectCard.js
+++ b/website/src/pages/downloads/ProjectCard.js
@@ -174,7 +174,7 @@ const ProjectCard = (props) => {
               </DropdownItem>
               <DropdownItem
                 className="download-dropdown-item"
-                href={`https://downloads.apache.org/${LTSDownloadPath}.tgz.asc`}
+                href={`https://downloads.apache.org/${LTSDownloadPath}.tgz.sha512`}
                 target="_blank"
               >
                 SHA512


### PR DESCRIPTION
Fixes: #909

Changes:

correct the SHA512 link

Screenshots of the change:

none
