### PR TITLE
docs: Updated Community, Security, Subscribe-Guide pages

### DIFF
--- a/website/docs/general/community.md
+++ b/website/docs/general/community.md
@@ -10,13 +10,13 @@ description: This article provides useful information about Apache APISIX's Comm
 
 
 Apache APISIX is a project maintained by community members under the Apache Software Foundation.
-It is an open source project that abides by the [Apache Software Foundation's code of conduct](https://www.apache.org/foundation/policies/conduct.html). Apache APISIX is a dynamic, real-time, high-performance Cloud-Native API Gateway. It handles traditional north-south traffic, as well as east-west traffic between services.
+It is an open-source project that abides by the [Apache Software Foundation's code of conduct](https://www.apache.org/foundation/policies/conduct.html). Apache APISIX is a dynamic, real-time, high-performance Cloud-Native API Gateway. It handles traditional north-south traffic, as well as east-west traffic between services.
 
 ## How to Get Involved
 
-Apache APISIX is an open source infrastructure software project that provides API processing and analytics with products and solutions for microservices and real-time traffic processing; such as API gateway, k8s ingress controller, and Service Mesh.
+Apache APISIX is an open-source infrastructure software project that provides API processing and analytics with products and solutions for microservices and real-time traffic processing; such as API gateway, k8s ingress controller, and Service Mesh.
 
-Want to get involved with a project, join our slack community, collaborate & interact with other community members who will make sure you are not left out. We are open to any form of contribution; like code contributions, design, community management, advocacy, or you can just to listen in.
+Want to get involved with a project, join our Slack community, collaborate & interact with other community members who will make sure you are not left out. We are open to any form of contribution; like code contributions, design, community management, advocacy, or you can just listen in.
 
 ### Joining the Mailing List
 

--- a/website/docs/general/security-guide.md
+++ b/website/docs/general/security-guide.md
@@ -9,8 +9,8 @@ keywords:
 description: If you have apprehensions regarding APISIX’s security or you discover vulnerability or potential threat, don’t hesitate to get in touch with the Apache Security Team by dropping a mail at security@apache.org.
 ---
 
-The Apache Software Foundation takes a rigorous stance on eliminating security issues in its software projects. Apache APISIX is also very concerned Security issues related to its features and functionality.
+The Apache Software Foundation takes a rigorous stance on eliminating security issues in its software projects. Apache APISIX is also very concerned about security issues related to its features and functionality.
 
-If you have apprehensions regarding APISIX’s security or you discover vulnerability or potential threat, don’t hesitate to get in touch with the Apache Security Team by dropping a mail at security@apache.org. Please specify the project name as APISIX and its product name APISIX or APISIX-Dashboard in the email and provide a description of the relevant problem or potential threat. You are also urged to recommend the way to reproduce and replicate the issue. The Apache Security Team and the APISIX community will get back to you after assessing and analysing the findings.
+If you have apprehensions regarding APISIX’s security or you discover vulnerability or potential threat, don’t hesitate to get in touch with the Apache Security Team by dropping a mail at security@apache.org. Please specify the project name as APISIX and its product name APISIX or APISIX-Dashboard in the email and describe the relevant problem or potential threat. You are also urged to recommend a way to reproduce and replicate the issue. The Apache Security Team and the APISIX community will get back to you after assessing and analyzing the findings.
 
-Please pay attention to report the security issue on the security email before disclosing it on the public domain.
+Please pay attention to reporting the security issue on the security email before disclosing it to the public domain.

--- a/website/docs/general/subscribe-guide.md
+++ b/website/docs/general/subscribe-guide.md
@@ -10,9 +10,9 @@ keywords:
 description: Subscribe to the Apache APISIX mailing list to discuss issues, suggest new ideas and participate in other community discussions.
 ---
 
-You can subscribe to the Apache APISIX mailing list to discuss issues, suggest new ideas and participate in other community discussions.
+You can subscribe to the Apache APISIX mailing list to discuss issues, suggest new ideas, and participate in other community discussions.
 
-1. To subscribe to the mailing list, first send an email to dev-subscribe@apisix.apache.org.
+1. To subscribe to the mailing list, first, send an email to dev-subscribe@apisix.apache.org.
 
 2. Once you send the email, you will receive a confirmation e-mail from dev-help@apisix.apache.org.
 


### PR DESCRIPTION
With reference to #879 

Changes:

Fixed typos and grammatical errors on the Community, Security, and Subscribe-Guide page.

Screenshots of the change:

<img width="960" alt="image" src="https://user-images.githubusercontent.com/53828745/156936622-a10d36c3-0852-49be-bbe5-b53b3d2f0821.png">
