### PR TITLE
fix: skewed images for right-pane

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -593,8 +593,9 @@ a:hover {
 
 .imagePosition {
   position: absolute;
-  bottom: 20px;
+  bottom: 10px;
   left: 30px;
+  max-width: none;
 }
 
 .i-text-col {

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -593,7 +593,7 @@ a:hover {
 
 .imagePosition {
   position: absolute;
-  bottom: 10px;
+  bottom: 20px;
   left: 30px;
 }
 

--- a/website/src/pages/sections/features.jsx
+++ b/website/src/pages/sections/features.jsx
@@ -215,7 +215,8 @@ const Features = () => {
           className="right-pane"
           style={{
             width: "50%",
-            height: "100vh",
+            height: "70vh",
+            top: "60px",
             position: "relative",
             overflow: "hidden",
             display: "flex",

--- a/website/src/pages/sections/features.jsx
+++ b/website/src/pages/sections/features.jsx
@@ -215,8 +215,7 @@ const Features = () => {
           className="right-pane"
           style={{
             width: "50%",
-            height: "70vh",
-            top: "60px",
+            height: "100vh",
             position: "relative",
             overflow: "hidden",
             display: "flex",


### PR DESCRIPTION
Resized images in right-pane to no longer skew and is centered.
Fixes: #983 

### Changes:

File: features.jsx 
- Changed ```right-pane``` height from ```100vh``` to ```70vh``` to give the image an approx. 1:1 scaling. 
- Added ```top: 60px``` to  ```right-pane``` center the image closer to the middle due to resizing causing the image to position closer to the top of the page & to allow for the images to have extra room for the bottom portion of the images, due to the drop-shadow being cut off.

File: customTheme.css
- Added ```bottom: 20px``` to ```.imagePosition``` to remove the cutting of the drop-shadow at the bottom of the images.

These changes do not affect the layout on mobile.


Screenshots of the change:


### Before: 
![160608634-c2c0b639-4504-4040-baa6-19bd6ad30895](https://user-images.githubusercontent.com/2664520/160823533-bb043c61-1e19-4b3a-b200-28d543a17ca5.png)

![160608657-84452915-fb4d-4199-9643-31cab8c9e7b5](https://user-images.githubusercontent.com/2664520/160823544-f2da3f91-2073-490a-8180-09519657ca42.png)


### After:
<img width="1462" alt="Screenshot at Mar 30 11-17-39" src="https://user-images.githubusercontent.com/2664520/160823269-a93d15c3-49d5-4e24-8871-06c44f2fd6d7.png">

<img width="1330" alt="Screenshot at Mar 30 11-18-13" src="https://user-images.githubusercontent.com/2664520/160823285-818c3270-ff94-4378-9e5a-774363ce3a9d.png">

