### PR TITLE
fix: Explicitly set the rel=canonical of the OpenTelemetry blog post

### DIFF
--- a/website/blog/2022/02/28/apisix-integration-opentelemetry-plugin.md
+++ b/website/blog/2022/02/28/apisix-integration-opentelemetry-plugin.md
@@ -23,6 +23,10 @@ tags: [Technology,Ecosystem,Observability]
 
 <!--truncate-->
 
+<head>
+    <link rel="canonical" href="https://opentelemetry.io/blog/2022/apisix/" />
+</head>
+
 ## Background Information
 
 Apache APISIX is a dynamic, real-time, high-performance API gateway that provides rich traffic management features such as load balancing, dynamic upstream, canary release, circuit breaking, authentication, observability, and more. It not only has many useful plugins, but also supports plugin dynamic change and hot swap.


### PR DESCRIPTION
Duplicate content is frowned upon by Google. This blog post has been already published on the OpenTelemetry web site. To avoid being flagged as duplicate and incur a SEO penalty, we need to reference the "original".

Alternatively, we could ask the OpenTelemetry team to point to our post. But it will probably take more time and it's not worth it IMHO.