### PR TITLE
docs: import the latest event info to Events page

### DIFF
--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -25,9 +25,105 @@ that have a specific focus on Apache APISIX.
 * **Dates:** from 2022-06-29 to 2022-07-02
 * **Location:** Berlin, Germany
 
+#### [DevDays](https://devdays.lt/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 04-26-22 to 04-28-22
+* **Location** Lithuania
+
+#### [SciFiDevCon](https://www.scifidevcon.com/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 05-01-22 to 05-31-22
+* **Location** Online
+
+#### [GeeCon](https://2022.geecon.org/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 05-11-22 to 05-13-22
+* **Location** Poland
+
+#### [Cloud Native Rejekts](https://cloud-native.rejekts.io/)
+
+* **Topic** Plugin Orchestration for an API Gateway
+* **Speaker** Bobur Umurzokov
+* **Dates** from 05-14-22 to 05-15-22
+* **Location** Spain
+
+#### [JavaCro Spring](https://2022spring.javacro.hr/eng/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 05-16-22 to 05-17-22
+* **Location** Croatia
+
+#### [JavaCro Spring](https://2022spring.javacro.hr/eng/)
+
+* **Topic** Chopping the monolith
+* **Speaker** Nicolas Fränkel
+* **Dates** from 05-16-22 to 05-17-22
+* **Location** Croatia
+
+#### [jPrime](https://jprime.io/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 05-25-22 to 05-26-22
+* **Location** Bulgaria
+
+#### [Java Day Istanbul](http://www.javaday.istanbul/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 05-28-22 to 05-28-22
+* **Location** Turkey
+
+#### [JNation](https://2022.jnation.pt/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 06-07-22 to 06-07-22
+* **Location** Portugal
+
+#### [WeAreDevelopers World Congress](https://worldcongress.dev/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 06-14-22 to 06-14-22
+* **Location** Germany
+
+#### [CloudLand](https://www.cloudland.org/de/home/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 06-29-22 to 07-02-22
+* **Location** Germany
+
+#### [CloudLand](https://www.cloudland.org/de/home/)
+
+* **Topic** Chopping the monolith
+* **Speaker** Nicolas Fränkel
+* **Dates** from 06-29-22 to 07-02-22
+* **Location** Germany
+
+#### [Web Developer Conference](https://www.web-developer-conference.de/)
+
+* **Topic** Evolving your APIs
+* **Speaker** Nicolas Fränkel
+* **Dates** from 09-26-22 to 09-28-22
+* **Location** Germany
+
 ### Workshops
 
-Coming soon...
+#### [Craft Conf](https://craft-conf.com/)
+
+* **Topic** Hands-on APISIX
+* **Speaker** Nicolas Fränkel, Bobur Umurzokov
+* **Dates** from 05-31-22 to 06-03-22
+* **Location** Hungary
 
 ### Meetups
 

--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -22,91 +22,91 @@ that have a specific focus on Apache APISIX.
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 04-26-22 to 04-28-22
+* **Dates** from 26-Apr-2022 to 28-Apr-2022
 * **Location** Lithuania
 
 #### [SciFiDevCon](https://www.scifidevcon.com/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 05-01-22 to 05-31-22
+* **Dates** 1-May-2022 to 31-May-2022
 * **Location** Online
 
 #### [GeeCon](https://2022.geecon.org/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 05-11-22 to 05-13-22
+* **Dates** from 11-May-2022 to 13-May-2022
 * **Location** Poland
 
 #### [Cloud Native Rejekts](https://cloud-native.rejekts.io/)
 
 * **Topic** Plugin Orchestration for an API Gateway
 * **Speaker** [Bobur Umurzokov](https://github.com/Boburmirzo)
-* **Dates** from 05-14-22 to 05-15-22
+* **Dates** from 14-May-2022 to 15-May-2022
 * **Location** Spain
 
 #### [JavaCro Spring](https://2022spring.javacro.hr/eng/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 05-16-22 to 05-17-22
+* **Dates** from 16-May-2022 to 17-May-2022
 * **Location** Croatia
 
 #### [JavaCro Spring](https://2022spring.javacro.hr/eng/)
 
 * **Topic** Chopping the monolith
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 05-16-22 to 05-17-22
+* **Dates** from 16-May-2022 to 17-May-2022
 * **Location** Croatia
 
 #### [jPrime](https://jprime.io/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 05-25-22 to 05-26-22
+* **Dates** from 25-May-2022 to 26-May-2022
 * **Location** Bulgaria
 
 #### [Java Day Istanbul](http://www.javaday.istanbul/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 05-28-22 to 05-28-22
+* **Dates** from 28-May-2022 to 28-May-2022
 * **Location** Turkey
 
 #### [JNation](https://2022.jnation.pt/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 06-07-22 to 06-07-22
+* **Dates** from 07-June-2022 to 07-June-2022
 * **Location** Portugal
 
 #### [WeAreDevelopers World Congress](https://worldcongress.dev/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 06-14-22 to 06-14-22
+* **Dates** from 14-June-2022 to 14-June-2022
 * **Location** Germany
 
 #### [CloudLand](https://www.cloudland.org/de/home/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 06-29-22 to 07-02-22
+* **Dates** from 29-June-2022 to 02-July-2022
 * **Location** Germany
 
 #### [CloudLand](https://www.cloudland.org/de/home/)
 
 * **Topic** Chopping the monolith
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 06-29-22 to 07-02-22
+* **Dates** from 29-June-2022 to 02-July-2022
 * **Location** Germany
 
 #### [Web Developer Conference](https://www.web-developer-conference.de/)
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 09-26-22 to 09-28-22
+* **Dates** from 26-September-2022 to 28-September-2022
 * **Location** Germany
 
 ### Workshops
@@ -115,7 +115,7 @@ that have a specific focus on Apache APISIX.
 
 * **Topic** Hands-on APISIX
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel), [Bobur Umurzokov](https://github.com/Boburmirzo)
-* **Dates** from 05-31-22 to 06-03-22
+* **Dates** from 31-May-2022 to 03-June-2022
 * **Location** Hungary
 
 ### Meetups

--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -106,7 +106,7 @@ that have a specific focus on Apache APISIX.
 
 * **Topic** Evolving your APIs
 * **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates** from 26-September-2022 to 28-September-2022
+* **Dates** from 26-Sep-2022 to 28-Sep-2022
 * **Location** Germany
 
 ### Workshops

--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -18,101 +18,94 @@ that have a specific focus on Apache APISIX.
 
 ### Conferences
 
-#### [CloudLand](https://www.cloudland.org/de/home/)
-
-* **Topic:** Evolving your APIs
-* **Speaker:** [Nicolas Fränkel](https://github.com/nfrankel)
-* **Dates:** from 2022-06-29 to 2022-07-02
-* **Location:** Berlin, Germany
-
 #### [DevDays](https://devdays.lt/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 04-26-22 to 04-28-22
 * **Location** Lithuania
 
 #### [SciFiDevCon](https://www.scifidevcon.com/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 05-01-22 to 05-31-22
 * **Location** Online
 
 #### [GeeCon](https://2022.geecon.org/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 05-11-22 to 05-13-22
 * **Location** Poland
 
 #### [Cloud Native Rejekts](https://cloud-native.rejekts.io/)
 
 * **Topic** Plugin Orchestration for an API Gateway
-* **Speaker** Bobur Umurzokov
+* **Speaker** [Bobur Umurzokov](https://github.com/Boburmirzo)
 * **Dates** from 05-14-22 to 05-15-22
 * **Location** Spain
 
 #### [JavaCro Spring](https://2022spring.javacro.hr/eng/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 05-16-22 to 05-17-22
 * **Location** Croatia
 
 #### [JavaCro Spring](https://2022spring.javacro.hr/eng/)
 
 * **Topic** Chopping the monolith
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 05-16-22 to 05-17-22
 * **Location** Croatia
 
 #### [jPrime](https://jprime.io/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 05-25-22 to 05-26-22
 * **Location** Bulgaria
 
 #### [Java Day Istanbul](http://www.javaday.istanbul/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 05-28-22 to 05-28-22
 * **Location** Turkey
 
 #### [JNation](https://2022.jnation.pt/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 06-07-22 to 06-07-22
 * **Location** Portugal
 
 #### [WeAreDevelopers World Congress](https://worldcongress.dev/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 06-14-22 to 06-14-22
 * **Location** Germany
 
 #### [CloudLand](https://www.cloudland.org/de/home/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 06-29-22 to 07-02-22
 * **Location** Germany
 
 #### [CloudLand](https://www.cloudland.org/de/home/)
 
 * **Topic** Chopping the monolith
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 06-29-22 to 07-02-22
 * **Location** Germany
 
 #### [Web Developer Conference](https://www.web-developer-conference.de/)
 
 * **Topic** Evolving your APIs
-* **Speaker** Nicolas Fränkel
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel)
 * **Dates** from 09-26-22 to 09-28-22
 * **Location** Germany
 
@@ -121,7 +114,7 @@ that have a specific focus on Apache APISIX.
 #### [Craft Conf](https://craft-conf.com/)
 
 * **Topic** Hands-on APISIX
-* **Speaker** Nicolas Fränkel, Bobur Umurzokov
+* **Speaker** [Nicolas Fränkel](https://github.com/nfrankel), [Bobur Umurzokov](https://github.com/Boburmirzo)
 * **Dates** from 05-31-22 to 06-03-22
 * **Location** Hungary
 


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

Add upcoming events information imported from the internal Lark excel file.
Here, you can see only accepted , confirmed and APISIX related events list.

Screenshots of the change:

![image](https://user-images.githubusercontent.com/14247607/161433945-ef63327a-780f-44ae-9a20-47ef4f154083.png)