### PR TITLE
docs: fix typos in recent blogs

### DIFF
--- a/website/blog/2022/02/10/splunk-apisix-integration.md
+++ b/website/blog/2022/02/10/splunk-apisix-integration.md
@@ -35,11 +35,11 @@ This article explains how to configure and use the [Splunk HEC](https://docs.spl
 
 [Splunk](https://www.splunk.com/) is a full-text search engine for machine data that can be used to collect, index, search, and analyze data from a variety of applications. According to DB Engines' search engine ranking, Splunk is currently in second place and is a widely used full-text search software. Splunk, like ElasticSearch, is a quasi-real-time data stream that provides uninterrupted search results.
 
-[Splunk HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector)is an HTTP event collector provided by Splunk that provides the ability to send data and application events to Splunk using the HTTP(S) protocol.
+[Splunk HTTP Event Collector(HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector)is an HTTP event collector provided by Splunk that provides the ability to send data and application events to Splunk using the HTTP(S) protocol.
 
 ## About splunk-hec-logging plugin
 
-The [splunk-hec-logging](https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/splunk-hec-logging.md) is used to forward Apache APISIX request logs to Splunk for analysis and storage. When enabled, Apache APISIX will take the request context information during the Log phase, serialize it into [Splunk Event Data Format](https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata) and submit it to the batch queue. The data in the queue is committed to Splunk HEC when the maximum processing capacity of the batch queue per batch is triggered, or when the maximum time to refresh the buffer is reached.
+When the maximum processing capacity of a queue is reached or when the maximum time to refresh the buffer is reached, data in the queue will be committed to Splunk HEC.
 
 ## How to use the splunk-hec-logging plugin
 

--- a/website/blog/2022/02/10/splunk-apisix-integration.md
+++ b/website/blog/2022/02/10/splunk-apisix-integration.md
@@ -37,7 +37,7 @@ This article explains how to configure and use the [Splunk HEC](https://docs.spl
 
 [Splunk HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector)is an HTTP event collector provided by Splunk that provides the ability to send data and application events to Splunk using the HTTP(S) protocol.
 
-## About splunk-hec-logging lugin
+## About splunk-hec-logging plugin
 
 The [splunk-hec-logging](https://github.com/apache/apisix/blob/master/docs/en/latest/plugins/splunk-hec-logging.md) is used to forward Apache APISIX request logs to Splunk for analysis and storage. When enabled, Apache APISIX will take the request context information during the Log phase, serialize it into [Splunk Event Data Format](https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata) and submit it to the batch queue. The data in the queue is committed to Splunk HEC when the maximum processing capacity of the batch queue per batch is triggered, or when the maximum time to refresh the buffer is reached.
 

--- a/website/blog/2022/03/02/apisix-integration-graphql-plugin.md
+++ b/website/blog/2022/03/02/apisix-integration-graphql-plugin.md
@@ -191,7 +191,7 @@ Apache APISIX can forward to different Upstreams according to different `graphql
   }'
 ```
 
-3. Create the second Upstream :
+3. Create the second Upstream:
 
 ```Shell
   curl http://192.168.1.200:9080/apisix/admin/upstreams/2 \
@@ -224,7 +224,7 @@ Apache APISIX can forward to different Upstreams according to different `graphql
 
 5. Test with the two `graphql_name` services created earlier, you can find that Apache APISIX can automatically select the forwarded Upstream based on the different `graphql_names` in the request.
 
-- If the request is this example:：
+- If the request is this example:
 
 ```Shell
   curl -i -H 'content-type: application/graphql' \

--- a/website/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
+++ b/website/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
@@ -98,8 +98,8 @@ This article is based on the following environments.
 
 - OS: Centos 7.9.
 - Apache APISIX 2.12.1, please refer to: [How-to-Bulid Apache APISIX](https://apisix.apache.org/docs/apisix/how-to-build).
-- CoreDNS 1.9.0，please refer to：[CoreDNS Installation Guide](https://coredns.io/manual/toc/#installation).
-- Node.js, please refer to:[Node.js Installation](https://github.com/nodejs/help/wiki/Installation).
+- CoreDNS 1.9.0，please refer to: [CoreDNS Installation Guide](https://coredns.io/manual/toc/#installation).
+- Node.js, please refer to: [Node.js Installation](https://github.com/nodejs/help/wiki/Installation).
 
 ### Procedure
 
@@ -124,9 +124,9 @@ CoreDNS listens on port `53` by default, and will read the `Corefile` configurat
 
 `Corefile` mainly implements functions by configuring plugins, so we need to configure three plugins:
 
-- `hosts`： You can use this parameter to bind the service name and IP address. fallthrough means that when the current plugin cannot return normal data, the request can be forwarded to the next plugin for processing (if it exists).
-- `forward`： Indicates to proxy the request to the specified address, usually the authoritative DNS server address.
-- `log`： Don't configure any parameters to print log information to the console interface for debugging.
+- `hosts`:  You can use this parameter to bind the service name and IP address. fallthrough means that when the current plugin cannot return normal data, the request can be forwarded to the next plugin for processing (if it exists).
+- `forward`:  Indicates to proxy the request to the specified address, usually the authoritative DNS server address.
+- `log`:  Don't configure any parameters to print log information to the console interface for debugging.
 
 ```Shell
   .:1053 {                           # Listen on port 1053

--- a/website/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
+++ b/website/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
@@ -99,7 +99,7 @@ This article is based on the following environments.
 - OS: Centos 7.9.
 - Apache APISIX 2.12.1, please refer to: [How-to-Bulid Apache APISIX](https://apisix.apache.org/docs/apisix/how-to-build).
 - CoreDNS 1.9.0，please refer to：[CoreDNS Installation Guide](https://coredns.io/manual/toc/#installation).
-- Node.js, please refer to:：[Node.js Installation](https://github.com/nodejs/help/wiki/Installation).
+- Node.js, please refer to:[Node.js Installation](https://github.com/nodejs/help/wiki/Installation).
 
 ### Procedure
 
@@ -140,7 +140,7 @@ CoreDNS listens on port `53` by default, and will read the `Corefile` configurat
   }
 ```
 
-3. Configuring Apache APISIX。
+3. Configuring Apache APISIX.
 
 Add the relevant configuration in the `conf/config.yaml` file and reload Apache APISIX.
 
@@ -154,7 +154,7 @@ Add the relevant configuration in the `conf/config.yaml` file and reload Apache 
                                       # here is the 1053 port of the local machine.
 ```
 
-4. 4. Configure routing information in Apache APISIX.
+4. Configure routing information in Apache APISIX.
 
 Next, we configure the relevant routing information by requesting the `Admin API`.
 

--- a/website/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
+++ b/website/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
@@ -124,9 +124,9 @@ CoreDNS listens on port `53` by default, and will read the `Corefile` configurat
 
 `Corefile` mainly implements functions by configuring plugins, so we need to configure three plugins:
 
-- `hosts`:  You can use this parameter to bind the service name and IP address. fallthrough means that when the current plugin cannot return normal data, the request can be forwarded to the next plugin for processing (if it exists).
-- `forward`:  Indicates to proxy the request to the specified address, usually the authoritative DNS server address.
-- `log`:  Don't configure any parameters to print log information to the console interface for debugging.
+- `hosts`: You can use this parameter to bind the service name and IP address. Fallthrough means that when the current plugin cannot return normal data, the request can be forwarded to the next plugin for processing (if it exists).
+- `forward`: Indicates to proxy the request to the specified address, usually the authoritative DNS server address.
+- `log`: Don't configure any parameters to print log information to the console interface for debugging.
 
 ```Shell
   .:1053 {                           # Listen on port 1053

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2022/02/10/splunk-apisix-integration.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2022/02/10/splunk-apisix-integration.md
@@ -35,7 +35,7 @@ Apache APISIX 作为一个高性能的 API 网关不仅在性能上有着良好�
 
 [Splunk](https://www.splunk.com/) 是一个机器数据的全文搜索引擎，可应用于采集、索引、搜索和分析各种应用数据，根据 [DB Engines 的检索引擎排名](https://db-engines.com/en/ranking/search+engine)，目前 Splunk 位列第二，是一款应用广泛的全文检索软件。Splunk 和 ElasticSearch 一样，是准实时可以提供不间断搜索结果的数据流。
 
-[Splunk HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) 是 Splunk 提供的 HTTP 事件收集器，主要提供以 HTTP(S) 协议将数据和应用程序事件发送到 Splunk 的能力。
+[Splunk HTTP Event Collector(HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) 是 Splunk 提供的 HTTP 事件收集器，主要提供以 HTTP(S) 协议将数据和应用程序事件发送到 Splunk 的能力。
 
 ## 关于 Splunk HEC Logging 插件
 


### PR DESCRIPTION
Changes:

Found some typos in recent blog posts when syncing to Medium account. This pull request will fix these typos.
