### PR TITLE
chore: remove 'es' from languages in common.js (#1003)

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -41,7 +41,7 @@ const projects = [
   },
 ];
 
-const languages = ['en', 'zh', 'es'];
+const languages = ['en', 'zh'];
 
 module.exports = {
   projects,


### PR DESCRIPTION
fix #1003 

changes:
Removed 'es' from languages in line 44.
