### PR TITLE
docs: update info for joining apisix slack channel

### DIFF
--- a/website/docs/general/join.md
+++ b/website/docs/general/join.md
@@ -31,6 +31,6 @@ You can subscribe to the Apache APISIX mailing list to discuss issues, suggest n
 
 You can join the Apache APISIX Slack channel in two ways:
 
-- Using [this invite](https://join.slack.com/t/the-asf/shared_invite/zt-vlfbf7ch-HkbNHiU_uDlcH_RvaHv9gQ) (_Please [open an issue](./submit-issue.md) if this link is expired_).
+- Join Apache Software Foundation Slack workspace using [this invite](https://join.slack.com/t/the-asf/shared_invite/zt-vlfbf7ch-HkbNHiU_uDlcH_RvaHv9gQ) (_Please [open an issue](./submit-issue.md) if this link is expired_), and then join the **#apisix** channel (Channels -> Browse channels -> search for "apisix").
 
 - By [subscribing to the mailing list](#subscribe-to-the-mailing-list) and sending an email to the list ([dev@apisix.apache.org](mailto:dev@apisix.apache.org)) requesting help to join.


### PR DESCRIPTION
Why this change: 
- It is noticed that many people do not join the actual #apisix channel after joining the ASF Slack workspace. We should provide clearer guidance on how to join the Slack channel.

Changes:

- Add information in the slack joining guide so that people know how to join #apisix the channel after joining the ASF workspace on Slack.


