### PR TITLE
chore(config/navbar): remove unexpected space

### DIFF
--- a/website/config/navbar.js
+++ b/website/config/navbar.js
@@ -72,7 +72,7 @@ module.exports = [
       },
       {
         to: '/plugins',
-        label: 'Plugin Hub',
+        label: 'PluginHub',
       },
       {
         to: '/docs/general/join',


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

Remove unexpected space from Plugin Hub's label.

This will fix below problem.

> I noticed @juxianzheng has translated it to Chinese, just like other lines. But as @Baoyuantop saw in preview, this part of change does not show up. Need to take a closer look @juzhiyuan @SkyeYoung .
>
> _Originally posted by @yzeng25 in https://github.com/apache/apisix-website/pull/1024#discussion_r852842089_

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
