### PR TITLE
docs: add technical writers in the author list

### DIFF
--- a/website/blog/2021/08/25/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
+++ b/website/blog/2021/08/25/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
@@ -1,9 +1,15 @@
 ---
 title: Centralized authentication using the OpenID Connect plug-in for Apache APISIX
 slug: 2021/08/25/using-the-apache-apisix-openid-connect-plugin-for-centralized-authentication
-author: Xinxin Zhu
-authorURL: "https://github.com/starsz"
-authorImageURL: "https://avatars.githubusercontent.com/u/25628854?v=4"
+authors:
+  - name: "Xinxin Zhu"
+    title: "Author"
+    url: "https://github.com/starsz"
+    image_url: "https://avatars.githubusercontent.com/u/25628854?v=4"
+  - name: "Yilin Zeng"
+    title: "Technical Writer"
+    url: "https://github.com/yzeng25"
+    image_url: "https://avatars.githubusercontent.com/u/36651058?v=4"
 keywords:
   - API Gateway
   - APISIX

--- a/website/blog/2021/11/04/skywalking.md
+++ b/website/blog/2021/11/04/skywalking.md
@@ -1,8 +1,14 @@
 ---
 title: "The observability of Apache APISIX"
-author: "Haochao Zhuang"
-authorURL: "https://github.com/dmsolr"
-authorImageURL: "https://avatars.githubusercontent.com/u/29735230?v=4"
+authors:
+  - name: "Haochao Zhuang"
+    title: "Author"
+    url: "https://github.com/dmsolr"
+    image_url: "https://avatars.githubusercontent.com/u/29735230?v=4"
+  - name: "Yilin Zeng"
+    title: "Technical Writer"
+    url: "https://github.com/yzeng25"
+    image_url: "https://avatars.githubusercontent.com/u/36651058?v=4"
 keywords: 
 - Apache APISIX
 - observability

--- a/website/blog/2022/04/22/apisix-with-tidb-practice.md
+++ b/website/blog/2022/04/22/apisix-with-tidb-practice.md
@@ -1,8 +1,14 @@
 ---
 title: "Best Practices for TiDB-based Apache APISIX High Availability Configuration"
-author: "Chao Zhang"
-authorURL: "https://github.com/tokers"
-authorImageURL: "https://avatars.githubusercontent.com/u/10428333?v=4"
+authors:
+  - name: "Chao Zhang"
+    title: "Author"
+    url: "https://github.com/tokers"
+    image_url: "https://avatars.githubusercontent.com/u/10428333?v=4"
+  - name: "Estelle Rao"
+    title: "Technical Writer"
+    url: "https://github.com/EstelleRao"
+    image_url: "https://github.com/EstelleRao.png"
 keywords: 
 - API Gateway
 - APISIX

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2021/08/25/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2021/08/25/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
@@ -1,9 +1,15 @@
 ---
 title: "使用 Apache APISIX 的 OpenID Connect 插件进行集中身份认证"
 slug: 2021/08/25/using-the-apache-apisix-openid-connect-plugin-for-centralized-authentication
-author: "朱欣欣"
-authorURL: "https://github.com/starsz"
-authorImageURL: "https://avatars.githubusercontent.com/u/25628854?v=4"
+authors:
+  - name: "朱欣欣"
+    title: "Author"
+    url: "https://github.com/starsz"
+    image_url: "https://avatars.githubusercontent.com/u/25628854?v=4"
+  - name: "曾奕霖"
+    title: "Technical Writer"
+    url: "https://github.com/yzeng25"
+    image_url: "https://avatars.githubusercontent.com/u/36651058?v=4"
 keywords:
 - API 网关
 - APISIX

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/04/skywalking.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/04/skywalking.md
@@ -1,8 +1,14 @@
 ---
 title: "浅谈 Apache APISIX 的可观测性"
-author: "庄浩潮"
-authorURL: "https://github.com/dmsolr"
-authorImageURL: "https://avatars.githubusercontent.com/u/29735230?v=4"
+authors:
+  - name: "庄浩潮"
+    title: "Author"
+    url: "https://github.com/dmsolr"
+    image_url: "https://avatars.githubusercontent.com/u/29735230?v=4"
+  - name: "曾奕霖"
+    title: "Technical Writer"
+    url: "https://github.com/yzeng25"
+    image_url: "https://avatars.githubusercontent.com/u/36651058?v=4"
 keywords: 
 - Apache APISIX
 - 可观测性

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2022/04/22/apisix-with-tidb-practice.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2022/04/22/apisix-with-tidb-practice.md
@@ -1,8 +1,14 @@
 ---
 title: "基于 TiDB 的 Apache APISIX 高可用配置中心的最佳实践"
-author: "张超"
-authorURL: "https://github.com/tokers"
-authorImageURL: "https://avatars.githubusercontent.com/u/10428333?v=4"
+authors:
+  - name: "张超"
+    title: "Author"
+    url: "https://github.com/tokers"
+    image_url: "https://avatars.githubusercontent.com/u/10428333?v=4"
+  - name: "饶雅惠"
+    title: "Technical Writer"
+    url: "https://github.com/EstelleRao"
+    image_url: "https://github.com/EstelleRao.png"
 keywords: 
 - API 网关
 - APISIX


### PR DESCRIPTION
Changes:

Duo author template was initiated in Nov, 2021. I found some articles that needs to apply this template.

Add technical writers in the author list for the follow 3 blogs in en-us and zh-cn:

1. Centralized authentication using the OpenID Connect plug-in for Apache APISIX
2. The observability of Apache APISIX
3. Best Practices for TiDB-based Apache APISIX High Availability Configuration