### PR TITLE
chore: cache build in node_modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
           path: |
             ./website/.docusaurus
             ./website/build
+            ./website/node_modules
           key: ${{ runner.os }}-dep-${{ steps.node-version.outputs.ver }}-docusaurus-${{ hashFiles('website/config/apisix-versions.js') }}
 
       - name: Build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "yarn workspace website build",
     "docusaurus": "yarn workspace website docusaurus",
     "serve": "yarn docusaurus serve",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prepare-data": "yarn sync-doc && yarn generate-repos-info"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.17.0",


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

* cache build folders in node_modules to speed up build
* prepare-data cmd

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
