### PR TITLE
feat: support matomo from the ASF

### DIFF
--- a/website/config/ssrTemplate.js
+++ b/website/config/ssrTemplate.js
@@ -19,6 +19,25 @@ module.exports = {
       <% it.scripts.forEach((script) => { %>
         <link rel="preload" href="<%= it.baseUrl %><%= script %>" as="script">
       <% }); %>
+      <!-- Matomo from the ASF -->
+      <script>
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before
+      "trackPageView" */
+        /* We explicitly disable cookie tracking to avoid privacy issues */
+        _paq.push(['disableCookies']);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+          var u="https://analytics.apache.org/";
+          _paq.push(['setTrackerUrl', u+'matomo.php']);
+          _paq.push(['setSiteId', '17']);
+          var d=document, g=d.createElement('script'),
+      s=d.getElementsByTagName('script')[0];
+          g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+      </script>
+      <!-- End Matomo Code -->
     </head>
     <body <%~ it.bodyAttributes %>>
       <%~ it.preBodyTags %>


### PR DESCRIPTION
**Changes:**

The ASF asks to use Matomo instead of GA after July 2022, so we need to record data as early as possible by integrating this service. Visit https://analytics.apache.org/ for more information.

For PMC members, please search and read email "New data privacy policy - may impact your websites".