### PR TITLE
feat: try 2 use code.json config, translations website

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+# root file changes
+repo:
+  - "*"
+
+#
+blog:
+  - website/blog/**/*
+  - website/articles/**/*
+  - website/i18n/zh/docusaurus-plugin-content-blog/**/*
+
+#
+docs-general:
+  - website/docs/general/**/*
+  - website/i18n/zh/docusaurus-plugin-content-docs/**/*
+
+#
+pages:
+  - website/config/*
+  - website/src/**/*
+  - website/static/**/*
+
+#
+scripts:
+  - scripts/**/*

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -5,16 +5,29 @@ name: Check broken links
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+  pull_request_target:
+    types:
+      - "opened"
+      - "edited"
+      - "synchronize"
+      - "reopened"
+    branches:
+      - "test-labeler"
   schedule:
     # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
     - cron: "0 5 * * *"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
   # This workflow contains a single job called "build"
   check:
     # The type of runner that the job will run on

--- a/website/i18n/zh/code.json
+++ b/website/i18n/zh/code.json
@@ -1,10 +1,10 @@
 {
   "hero.webpage.title.fragment1": {
-    "message": "简洁且敏捷的",
+    "message": "简洁高效的",
     "description": "Effortless and smooth"
   },
   "hero.webpage.title.fragment2": {
-    "message": "API 信息",
+    "message": "API 流量",
     "description": "API Traffic"
   },
   "hero.webpage.title.fragment3": {
@@ -12,7 +12,7 @@
     "description": "management"
   },
   "hero.webpage.subtitle.content": {
-    "message": "Apache APISIX 提供了丰富的流量管理功能，如负载平衡、Dynamic Upstream、蜡烛版本、代码断路器、身份校验、所见即所得等...",
+    "message": "Apache APISIX 提供了丰富的流量管理功能，如负载平衡、动态上游、金丝雀发布、断路器、身份校验、可观测性等",
     "description": "Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more..."
   },
   "hero.webpage.download.btn": {
@@ -28,7 +28,7 @@
     "description": "Document"
   },
   "docs.webpage.title.DocumentSubtitle": {
-    "message": "开源代表着一种向善的力量",
+    "message": "让产品与技术背后的细节更加可视化",
     "description": "We love open source."
   }
 }

--- a/website/i18n/zh/code.json
+++ b/website/i18n/zh/code.json
@@ -1,0 +1,34 @@
+{
+  "hero.webpage.title.fragment1": {
+    "message": "简洁且敏捷的",
+    "description": "Effortless and smooth"
+  },
+  "hero.webpage.title.fragment2": {
+    "message": "API 信息",
+    "description": "API Traffic"
+  },
+  "hero.webpage.title.fragment3": {
+    "message": "管理",
+    "description": "management"
+  },
+  "hero.webpage.subtitle.content": {
+    "message": "Apache APISIX 提供了丰富的流量管理功能，如负载平衡、Dynamic Upstream、蜡烛版本、代码断路器、身份校验、所见即所得等...",
+    "description": "Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more..."
+  },
+  "hero.webpage.download.btn": {
+    "message": "立即体验",
+    "description": "Download"
+  },
+  "arrowAnim.webpage.link.btn": {
+    "message": "阅读文档",
+    "description": "Go to docs..."
+  },
+  "docs.webpage.title.Document": {
+    "message": "文档",
+    "description": "Document"
+  },
+  "docs.webpage.title.DocumentSubtitle": {
+    "message": "开源代表着一种向善的力量",
+    "description": "We love open source."
+  }
+}

--- a/website/src/components/ArrowAnim.tsx
+++ b/website/src/components/ArrowAnim.tsx
@@ -5,6 +5,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import gsap from 'gsap';
 
 import '../css/customTheme.css';
+import Translate from '@docusaurus/Translate';
 
 const ArrowAnim: FC = () => {
   const endpathRef1 = useRef(null);
@@ -53,7 +54,7 @@ const ArrowAnim: FC = () => {
       onMouseLeave={mouseOut}
       className="btn-docs"
     >
-      Go to docs...
+      <Translate id="arrowAnim.webpage.link.btn">Go to docs...</Translate>
       <svg width="15" strokeWidth="3" height="25" viewBox="0 0 43 32" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path ref={endpathRef1} d="M27.5 1L42.5 16L27.5 31" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
         <path ref={endpathRef2} className="arrow-btn" d="M42.5 16H0.5" stroke="black" strokeLinecap="round" strokeLinejoin="round" />

--- a/website/src/components/sections/HeroSection.tsx
+++ b/website/src/components/sections/HeroSection.tsx
@@ -3,12 +3,13 @@ import React, { useRef, useEffect } from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import gsap from 'gsap';
+import Translate from '@docusaurus/Translate';
 
 import '../../css/customTheme.css';
 import HeroCanvas from '../HeroCanvas';
 import ArrowAnim from '../ArrowAnim';
 
-const HeroSection:FC = () => {
+const HeroSection: FC = () => {
   const titleRef = useRef<HTMLHeadingElement>();
   const subtitleRef = useRef<HTMLHeadingElement>();
   const ctaRef = useRef<HTMLHeadingElement>();
@@ -41,19 +42,23 @@ const HeroSection:FC = () => {
     <div className="hero-sec-wrap" style={{ width: '100%' }}>
       <div className="hero-text">
         <h2 ref={titleRef} className="hero-title hide-title">
-          <span>Effortless and smooth</span>
+          <span><Translate id="hero.webpage.title.fragment1">Effortless and smooth</Translate></span>
           {' '}
-          <span style={{ color: '#E8433E' }}>API Traffic</span>
+          <span style={{ color: '#E8433E' }}>
+            <Translate id="hero.webpage.title.fragment2">API Traffic</Translate>
+          </span>
           {' '}
-          management.
+          <Translate id="hero.webpage.title.fragment3">management.</Translate>
         </h2>
-        <h3 ref={subtitleRef} className="hero-subtitle hide-subtitle">Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more...</h3>
+        <h3 ref={subtitleRef} className="hero-subtitle hide-subtitle">
+          <Translate id="hero.webpage.subtitle.content">Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more...</Translate>
+        </h3>
         <div ref={ctaRef} className="hero-ctas hide-ctas">
           <Link
             to={useBaseUrl('downloads')}
             className="btn btn-download"
           >
-            Downloads
+            <Translate id="hero.webpage.download.btn">Downloads</Translate>
           </Link>
           <ArrowAnim />
         </div>

--- a/website/src/pages/docs.tsx
+++ b/website/src/pages/docs.tsx
@@ -5,6 +5,8 @@ import '../css/customTheme.css';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
+import Translate from '@docusaurus/Translate';
+
 import IconTriangle from '../assets/icons/triangle.svg';
 import IconSquare from '../assets/icons/square.svg';
 import IconHexagon from '../assets/icons/hexagon.svg';
@@ -124,17 +126,17 @@ const shapeComponentMap = {
 };
 
 interface DocInfo {
-    name: string;
-    nameInParamCase: string;
-    description: string;
-    shape: string;
-    color: string;
-    version: string;
-    releaseDate: string;
-    firstDocPath: string;
+  name: string;
+  nameInParamCase: string;
+  description: string;
+  shape: string;
+  color: string;
+  version: string;
+  releaseDate: string;
+  firstDocPath: string;
 }
 
-interface ProjectCardProps extends DocInfo {}
+interface ProjectCardProps extends DocInfo { }
 
 const ProjectCard: FC<ProjectCardProps> = (props) => {
   const {
@@ -158,7 +160,7 @@ const ProjectCard: FC<ProjectCardProps> = (props) => {
       <VersionInfo className="docs-versioninfo">
         Latest version&nbsp;
         <span>{version}</span>
-&nbsp;released at&nbsp;
+        &nbsp;released at&nbsp;
         <span>{releaseDate}</span>
       </VersionInfo>
     </Card>
@@ -177,8 +179,12 @@ const Docs: FC = () => {
   return (
     <Layout>
       <Page>
-        <PageTitle>Documents</PageTitle>
-        <PageSubtitle>We love open source.</PageSubtitle>
+        <PageTitle>
+          <Translate id="docs.webpage.title.Document">Document</Translate>
+        </PageTitle>
+        <PageSubtitle>
+          <Translate id="docs.webpage.title.DocumentSubtitle">We love open source.</Translate>
+        </PageSubtitle>
         <CardsContainer>{projects}</CardsContainer>
       </Page>
     </Layout>


### PR DESCRIPTION
i want try to try add i18n code.json in website, like docusaurus docs: https://docusaurus.io/docs/i18n/tutorial
Do you have any better ideas, can call to me email

Screenshots of the change:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/23497322/168885103-74e62726-b553-46a7-a835-c1ed04f91055.png">

<img width="979" alt="image" src="https://user-images.githubusercontent.com/23497322/168885608-25b70dd7-1cf2-4712-8279-1c4be185a3ef.png">
