### PR TITLE
feat: website route (downloads, help, plugins, showcase) translation

### DIFF
--- a/website/i18n/zh/code.json
+++ b/website/i18n/zh/code.json
@@ -60,15 +60,15 @@
     "description": "Verify the releases"
   },
   "download.website.link.PGP_KEY": {
-    "message": "获取PGP签名密钥",
+    "message": "获取 PGP 签名密钥",
     "description": "Get PGP signatures KEYS"
   },
   "download.website.verify.step1": {
-    "message": "你可以使用 PGP 或 SHA 签名验证 Apache APISIX 的文件完整性，使用 GPG 或 PGP 验证 PGP 签名的合法性， 建议从主目录获取密钥文件和ASC签名文件。",
+    "message": "你可以使用 PGP 或 SHA 签名验证 Apache APISIX 的文件完整性，使用 GPG 或 PGP 验证 PGP 签名的合法性， 建议从主目录获取密钥文件和 ASC 签名文件。",
     "description": "It is essential that you verify the integrity of the downloaded files using the PGP or SHA signatures. The PGP signatures can be verified using GPG or PGP. Please download the KEYS as well as the asc signature files for relevant distribution. It is recommended to get these files from the main distribution directory and not from the mirrors."
   },
   "download.website.verify.step2": {
-    "message": "如果需要验证二进制文件/源代码，您可以从主目录下载相关的 asc 文件，并遵循下面的指南。",
+    "message": "如果需要验证二进制文件/源代码，您可以从主目录下载相关的 ACS 文件，并遵循下面的指南。",
     "description": "To verify the binaries/sources you can download the relevant asc files for it from main distribution directory and follow the below guide."
   },
   "help.website.title": {

--- a/website/i18n/zh/code.json
+++ b/website/i18n/zh/code.json
@@ -3,29 +3,21 @@
     "message": "。",
     "description": "."
   },
-  "hero.webpage.title.fragment1": {
-    "message": "简单高效的",
-    "description": "Effortless and smooth"
+  "showcase.website.title": {
+    "message": "产品展示",
+    "description": "Showcase"
   },
-  "hero.webpage.title.fragment2": {
-    "message": "API 流量",
-    "description": "API Traffic"
+  "showcase.website.tips.used": {
+    "message": "他们都在使用 Apache APISIX 进行生产和研究",
+    "description": "This project is used by all these folks"
   },
-  "hero.webpage.title.fragment3": {
-    "message": "管理组件",
-    "description": "management"
+  "showcase.website.tips.wantUse": {
+    "message": "你也在使用它吗？告诉我们是如何使用，我们将会积极的收集和采纳你的意见。",
+    "description": "Are you using this project?&nbsp;"
   },
-  "hero.webpage.subtitle.content": {
-    "message": "Apache APISIX 是一个动态、实时、高性能的云原生 API 网关，提供了负载均衡、动态上游、灰度发布、服务熔断、身份认证、可观测性等丰富的流量管理功能。",
-    "description": "Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more..."
-  },
-  "hero.webpage.download.btn": {
-    "message": "立即体验",
-    "description": "Download"
-  },
-  "arrowAnim.webpage.link.btn": {
-    "message": "阅读文档",
-    "description": "Go to docs..."
+  "showcase.website.link.addYourCompany": {
+    "message": "加入使用者名单",
+    "description": "Add your company"
   },
   "docs.webpage.title.Document": {
     "message": "产品文档",
@@ -34,6 +26,86 @@
   "docs.webpage.title.DocumentSubtitle": {
     "message": "让产品与技术背后的细节更加可视化",
     "description": "We love open source."
+  },
+  "download.website.title": {
+    "message": "开启智能网关之旅",
+    "description": "Downloads"
+  },
+  "download.website.subtitle": {
+    "message": "We love open source.",
+    "description": "We love open source."
+  },
+  "download.website.history.title": {
+    "message": "历史版本",
+    "description": "History Versions"
+  },
+  "download.website.history.all": {
+    "message": "如果你想要预览 Apache APISIX 已发布的所有版本，请查看 ",
+    "description": "Find all APISIX releases in the&nbsp;"
+  },
+  "download.website.link.archive": {
+    "message": "Archive repository",
+    "description": "Archive repository"
+  },
+  "download.website.link.incubator": {
+    "message": "Incubating Archive repository",
+    "description": "Incubating Archive repository"
+  },
+  "download.website.history.incubator": {
+    "message": " 存储着 Apache APISIX 旧版孵化器项目的备份归档，你也可以随时查阅它们。",
+    "description": "&nbsp;hosts older releases when APISIX was an incubator project."
+  },
+  "download.website.verify.title": {
+    "message": "验证 Apache APISIX 版本号",
+    "description": "Verify the releases"
+  },
+  "download.website.link.PGP_KEY": {
+    "message": "获取PGP签名密钥",
+    "description": "Get PGP signatures KEYS"
+  },
+  "download.website.verify.step1": {
+    "message": "你可以使用 PGP 或 SHA 签名验证 Apache APISIX 的文件完整性，使用 GPG 或 PGP 验证 PGP 签名的合法性， 建议从主目录获取密钥文件和ASC签名文件。",
+    "description": "It is essential that you verify the integrity of the downloaded files using the PGP or SHA signatures. The PGP signatures can be verified using GPG or PGP. Please download the KEYS as well as the asc signature files for relevant distribution. It is recommended to get these files from the main distribution directory and not from the mirrors."
+  },
+  "download.website.verify.step2": {
+    "message": "如果需要验证二进制文件/源代码，您可以从主目录下载相关的 asc 文件，并遵循下面的指南。",
+    "description": "To verify the binaries/sources you can download the relevant asc files for it from main distribution directory and follow the below guide."
+  },
+  "help.website.title": {
+    "message": "需要帮助吗？",
+    "description": "NEED HELP?"
+  },
+  "help.website.subtitle": {
+    "message": "维护 Apache APISIX 的专业团队人员随时可以为你答疑解惑",
+    "description": "This project is maintained by a dedicated group of people."
+  },
+  "help.website.docs.title": {
+    "message": "官方文档",
+    "description": "Browse Docs"
+  },
+  "help.website.docs.tips": {
+    "message": "访问官方技术文档以了解更多",
+    "description": "Learn more using the documentation on this site."
+  },
+  "help.website.link.docs": {
+    "message": "阅读文档",
+    "description": "Read Documents"
+  },
+  "help.website.community.title": {
+    "message": "加入社区",
+    "description": "Join Community"
+  },
+  "help.website.community.tips": {
+    "message": "告诉我们你遇到了什么问题？",
+    "description": "Ask questions about the documentation and project"
+  },
+  "plugins.website.title": {
+    "message": "Apache APISIX®️ 插件中心",
+    "description": "Apache APISIX®️ Plugin Hub"
+  },
+  "plugins.website.subtitle": {
+    "message": "功能强大，即插即用",
+    "description": "Powerful Plugins and Easy Integrations"
   },
   "team.webpage.title.Team": {
     "message": "团队介绍",
@@ -70,6 +142,10 @@
   "team.webpage.content.StartContributeBtn": {
     "message": "开始参与社区贡献",
     "description": "Start Contribute"
+  },
+  "arrowAnim.component.link.btn": {
+    "message": "阅读文档",
+    "description": "Go to docs..."
   },
   "architecture.component.title.name": {
     "message": "适用于超大规模、复杂的业务系统",
@@ -250,5 +326,25 @@
   "homeEventsSection.component.link.Subscribe": {
     "message": "立即订阅",
     "description": "Subscribe"
+  },
+  "hero.component.title.fragment1": {
+    "message": "简单高效的",
+    "description": "Effortless and smooth"
+  },
+  "hero.component.title.fragment2": {
+    "message": "API 流量",
+    "description": "API Traffic"
+  },
+  "hero.component.title.fragment3": {
+    "message": "管理组件",
+    "description": "management"
+  },
+  "hero.component.subtitle.content": {
+    "message": "Apache APISIX 是一个动态、实时、高性能的云原生 API 网关，提供了负载均衡、动态上游、灰度发布、服务熔断、身份认证、可观测性等丰富的流量管理功能。",
+    "description": "Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more..."
+  },
+  "hero.component.download.btn": {
+    "message": "立即体验",
+    "description": "Download"
   }
 }

--- a/website/i18n/zh/code.json
+++ b/website/i18n/zh/code.json
@@ -4,15 +4,15 @@
     "description": "."
   },
   "showcase.website.title": {
-    "message": "产品展示",
+    "message": "用户列表",
     "description": "Showcase"
   },
   "showcase.website.tips.used": {
-    "message": "他们都在使用 Apache APISIX 进行生产和研究",
+    "message": "Apache APISIX 被众多产品与用户所信赖",
     "description": "This project is used by all these folks"
   },
   "showcase.website.tips.wantUse": {
-    "message": "你也在使用它吗？告诉我们是如何使用，我们将会积极的收集和采纳你的意见。",
+    "message": "你也在使用它吗？请让我们知道！",
     "description": "Are you using this project?&nbsp;"
   },
   "showcase.website.link.addYourCompany": {
@@ -28,11 +28,11 @@
     "description": "We love open source."
   },
   "download.website.title": {
-    "message": "开启智能网关之旅",
+    "message": "立即下载",
     "description": "Downloads"
   },
   "download.website.subtitle": {
-    "message": "We love open source.",
+    "message": "We love Open Source.",
     "description": "We love open source."
   },
   "download.website.history.title": {
@@ -72,11 +72,11 @@
     "description": "To verify the binaries/sources you can download the relevant asc files for it from main distribution directory and follow the below guide."
   },
   "help.website.title": {
-    "message": "需要帮助吗？",
+    "message": "获取帮助",
     "description": "NEED HELP?"
   },
   "help.website.subtitle": {
-    "message": "维护 Apache APISIX 的专业团队人员随时可以为你答疑解惑",
+    "message": "Apache APISIX 维护者们将积极为你答疑解惑",
     "description": "This project is maintained by a dedicated group of people."
   },
   "help.website.docs.title": {

--- a/website/src/components/ArrowAnim.tsx
+++ b/website/src/components/ArrowAnim.tsx
@@ -54,7 +54,7 @@ const ArrowAnim: FC = () => {
       onMouseLeave={mouseOut}
       className="btn-docs"
     >
-      <Translate id="arrowAnim.webpage.link.btn">Go to docs...</Translate>
+      <Translate id="arrowAnim.component.link.btn">Go to docs...</Translate>
       <svg width="15" strokeWidth="3" height="25" viewBox="0 0 43 32" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path ref={endpathRef1} d="M27.5 1L42.5 16L27.5 31" stroke="black" strokeLinecap="round" strokeLinejoin="round" />
         <path ref={endpathRef2} className="arrow-btn" d="M42.5 16H0.5" stroke="black" strokeLinecap="round" strokeLinejoin="round" />

--- a/website/src/components/ProjectCard.tsx
+++ b/website/src/components/ProjectCard.tsx
@@ -1,8 +1,11 @@
 import type { Dispatch, FC, SetStateAction } from 'react';
 import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
+
 import useOutsideClick from '../hooks/useOutsideClick';
+
 import '../css/customTheme.css';
+
 import IconInfo from '../assets/icons/info.svg';
 import IconStar from '../assets/icons/star.svg';
 import IconDocumentText from '../assets/icons/document-text.svg';
@@ -13,7 +16,9 @@ import IconHexagon from '../assets/icons/hexagon.svg';
 import IconStarSolid from '../assets/icons/star-solid.svg';
 import IconOctagon from '../assets/icons/octagon.svg';
 import IconShield from '../assets/icons/shield.svg';
+
 import repoInfoList from '../../config/repos-info.json';
+
 import type { ContributeCardProps } from './ContributeCard';
 
 const Card = styled.div`
@@ -66,7 +71,7 @@ const Description = styled.div`
   }
 `;
 
-const ShapeBeforeTitle = styled.span<{color: string}>`
+const ShapeBeforeTitle = styled.span<{ color: string }>`
   margin-right: 12px;
   & svg {
     height: 1.75rem;
@@ -135,7 +140,7 @@ const ButtonRow = styled.div`
   display: flex;
 `;
 
-const Button = styled.button<{background: string}>`
+const Button = styled.button<{ background: string }>`
   padding: 12px 18px;
   font-size: 18px;
   font-weight: 600;
@@ -161,7 +166,7 @@ const Button = styled.button<{background: string}>`
   }
 `;
 
-const StyledDropdown = styled.div<{open: boolean}>`
+const StyledDropdown = styled.div<{ open: boolean }>`
   top: 45px;
   right: 0;
   position: absolute;
@@ -336,7 +341,7 @@ const ProjectCard: FC<ProjectCardProps> = (props) => {
           >
             <IconStar />
             {' '}
-            {repoInfo?.info.star}
+            {repoInfo?.info?.star ?? ' - '}
           </LeftSideLink>
           <LeftSideLink
             className="downloads-leftsidelink"
@@ -346,7 +351,7 @@ const ProjectCard: FC<ProjectCardProps> = (props) => {
           >
             <IconInfo />
             {' '}
-            {repoInfo?.info.issue}
+            {repoInfo?.info?.issue ?? ' - '}
           </LeftSideLink>
           <LeftSideLink
             className="downloads-leftsidelink"

--- a/website/src/components/sections/Architecture.tsx
+++ b/website/src/components/sections/Architecture.tsx
@@ -97,7 +97,7 @@ const Architecture: FC<ArchitectureProps> = (props) => {
         <div className="arch-card-caption">
           <p style={{ width: screenWidth >= 768 ? '50%' : '90%' }}>
             <Translate id="architecture.component.card.caption">
-              Apache APISIX is based on Nginx and etcd.
+              Apache APISIX is based on NGINX and etcd.
               Compared with traditional API gateways,
               APISIX has dynamic routing and hot-loading plugins
             </Translate>

--- a/website/src/components/sections/Comparison.tsx
+++ b/website/src/components/sections/Comparison.tsx
@@ -73,7 +73,7 @@ const Comparison: FC = () => (
             <td><Cross /></td>
           </tr>
           <tr>
-            <th scope="row">Support any Nginx variable as routing condition</th>
+            <th scope="row">Support any NGINX variable as routing condition</th>
             <td><Tick /></td>
             <td><Cross /></td>
           </tr>

--- a/website/src/components/sections/Endcta.tsx
+++ b/website/src/components/sections/Endcta.tsx
@@ -29,7 +29,7 @@ const EndCTA: FC = () => (
           to={useBaseUrl('downloads')}
           className="btn btn-download"
         >
-          <Translate id="hero.webpage.download.btn">Downloads</Translate>
+          <Translate id="hero.component.download.btn">Downloads</Translate>
         </Link>
         <ArrowAnim />
       </div>

--- a/website/src/components/sections/HeroSection.tsx
+++ b/website/src/components/sections/HeroSection.tsx
@@ -42,23 +42,23 @@ const HeroSection: FC = () => {
     <div className="hero-sec-wrap" style={{ width: '100%' }}>
       <div className="hero-text">
         <h2 ref={titleRef} className="hero-title hide-title">
-          <span><Translate id="hero.webpage.title.fragment1">Effortless and smooth</Translate></span>
+          <span><Translate id="hero.component.title.fragment1">Effortless and smooth</Translate></span>
           {' '}
           <span style={{ color: '#E8433E' }}>
-            <Translate id="hero.webpage.title.fragment2">API Traffic</Translate>
+            <Translate id="hero.component.title.fragment2">API Traffic</Translate>
           </span>
           {' '}
-          <Translate id="hero.webpage.title.fragment3">management.</Translate>
+          <Translate id="hero.component.title.fragment3">management.</Translate>
         </h2>
         <h3 ref={subtitleRef} className="hero-subtitle hide-subtitle">
-          <Translate id="hero.webpage.subtitle.content">Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more...</Translate>
+          <Translate id="hero.component.subtitle.content">Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, and more...</Translate>
         </h3>
         <div ref={ctaRef} className="hero-ctas hide-ctas">
           <Link
             to={useBaseUrl('downloads')}
             className="btn btn-download"
           >
-            <Translate id="hero.webpage.download.btn">Downloads</Translate>
+            <Translate id="hero.component.download.btn">Downloads</Translate>
           </Link>
           <ArrowAnim />
         </div>

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import styled from 'styled-components';
 import Layout from '@theme/Layout';
 import CodeBlock from '@theme/CodeBlock';
+
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+import Translate from '@docusaurus/Translate';
 import type { DownloadInfo } from '../components/ProjectCard';
 import ProjectCard from '../components/ProjectCard';
 
@@ -55,39 +58,43 @@ const DownloadCards: FC = () => {
 const Downloads: FC = () => (
   <Layout>
     <DownloadsPage>
-      <PageTitle>Downloads</PageTitle>
-      <PageSubtitle>We love open source.</PageSubtitle>
+      <PageTitle><Translate id="download.website.title">Downloads</Translate></PageTitle>
+      <PageSubtitle><Translate id="download.website.subtitle">We love open source.</Translate></PageSubtitle>
       <DownloadCards />
       <Description>
-        <h2>History Versions</h2>
+        <h2><Translate id="download.website.history.title">History Versions</Translate></h2>
         <div className="markdown">
-          Find all APISIX releases in the&nbsp;
+          <Translate id="download.website.history.all">Find all APISIX releases in the&nbsp;</Translate>
           <a href="https://archive.apache.org/dist/apisix/" target="_blank" rel="noreferrer">
-            Archive repository
+            <Translate id="download.website.link.archive">Archive repository</Translate>
           </a>
-          .
+          <Translate id="common.punctuation.anEnd">.</Translate>
           <br />
           <a
             href="https://archive.apache.org/dist/incubator/apisix/"
             target="_blank"
             rel="noreferrer"
           >
-            Incubating Archive repository
+            <Translate id="download.website.link.incubator">Incubating Archive repository</Translate>
           </a>
+          <Translate id="download.website.history.incubator">
             &nbsp;hosts older releases when APISIX was an incubator project.
+          </Translate>
         </div>
-        <h2>Verify the releases</h2>
+        <h2><Translate id="download.website.verify.title">Verify the releases</Translate></h2>
         <div className="markdown">
           <a href="https://downloads.apache.org/apisix/KEYS" target="_blank" rel="noreferrer">
-            Get PGP signatures KEYS
+            <Translate id="download.website.link.PGP_KEY">Get PGP signatures KEYS</Translate>
           </a>
           <br />
-          It is essential that you verify the integrity of the downloaded
-          files using the PGP or SHA signatures. The PGP signatures can be
-          verified using GPG or PGP. Please download the KEYS as well as the
-          asc signature files for relevant distribution. It is recommended to
-          get these files from the main distribution directory and not from
-          the mirrors.
+          <Translate id="download.website.verify.step1">
+            It is essential that you verify the integrity of the downloaded
+            files using the PGP or SHA signatures. The PGP signatures can be
+            verified using GPG or PGP. Please download the KEYS as well as the
+            asc signature files for relevant distribution. It is recommended to
+            get these files from the main distribution directory and not from
+            the mirrors.
+          </Translate>
           <br />
           <StyledCodeBlock>
             {`gpg -i KEYS
@@ -99,9 +106,11 @@ pgpk -a KEYS
 pgp -ka KEYS`}
           </StyledCodeBlock>
           <br />
-          To verify the binaries/sources you can download the relevant asc
-          files for it from main distribution directory and follow the below
-          guide.
+          <Translate id="download.website.verify.step2">
+            To verify the binaries/sources you can download the relevant asc
+            files for it from main distribution directory and follow the below
+            guide.
+          </Translate>
           <StyledCodeBlock>
             {`gpg --verify apache-apisix-********.asc apache-apisix-********
 

--- a/website/src/pages/help.tsx
+++ b/website/src/pages/help.tsx
@@ -2,6 +2,9 @@ import type { FC } from 'react';
 import React from 'react';
 import styled from 'styled-components';
 import Layout from '@theme/Layout';
+
+import Translate from '@docusaurus/Translate';
+
 import ChevronRight from '../assets/icons/chevron-right.svg';
 
 import '../css/customTheme.css';
@@ -26,9 +29,9 @@ const Page = styled.div`
 const Help: FC = () => (
   <Layout>
     <Page className="help-page">
-      <PageTitle>NEED HELP?</PageTitle>
+      <PageTitle><Translate id="help.website.title">NEED HELP?</Translate></PageTitle>
       <PageSubtitle>
-        This project is maintained by a dedicated group of people.
+        <Translate id="help.website.subtitle">This project is maintained by a dedicated group of people.</Translate>
       </PageSubtitle>
       <div className="row cards">
         <div className="card">
@@ -39,17 +42,17 @@ const Help: FC = () => (
                 id="documents-icon"
                 alt="documents icon"
               />
-              Browse Docs
+              <Translate id="help.website.docs.title">Browse Docs</Translate>
             </h2>
           </div>
-          <p>Learn more using the documentation on this site.</p>
+          <p><Translate id="help.website.docs.tips">Learn more using the documentation on this site.</Translate></p>
           <div className="buttons">
             <a
               href="https://apisix.apache.org/docs/"
               target="_blank"
               rel="noreferrer"
             >
-              Read Documents
+              <Translate id="help.website.link.docs">Read Documents</Translate>
               <ChevronRight />
             </a>
           </div>
@@ -58,10 +61,10 @@ const Help: FC = () => (
           <div className="header">
             <h2>
               <img src="/img/community.png" alt="community icon" />
-              Join Community
+              <Translate id="help.website.community.title">Join Community</Translate>
             </h2>
           </div>
-          <p>Ask questions about the documentation and project</p>
+          <p><Translate id="help.website.community.tips">Ask questions about the documentation and project</Translate></p>
           <div className="buttons">
             <a href="https://github.com/apache/apisix/issues" target="_blank" rel="noreferrer">
               GitHub

--- a/website/src/pages/plugins.tsx
+++ b/website/src/pages/plugins.tsx
@@ -17,7 +17,10 @@
 import type { FC } from 'react';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
+
 import Layout from '@theme/Layout';
+import Translate from '@docusaurus/Translate';
+
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 const PageTitle = styled.h1`
@@ -244,8 +247,12 @@ const Plugins: FC = () => {
   return (
     <Layout>
       <Page>
-        <PageTitle>Apache APISIX®️ Plugin Hub</PageTitle>
-        <PageSubtitle>Powerful Plugins and Easy Integrations</PageSubtitle>
+        <PageTitle>
+          <Translate id="plugins.website.title">Apache APISIX®️ Plugin Hub</Translate>
+        </PageTitle>
+        <PageSubtitle>
+          <Translate id="plugins.website.subtitle">Powerful Plugins and Easy Integrations</Translate>
+        </PageSubtitle>
         <SidebarContainer>{sidebar}</SidebarContainer>
         {plugins}
       </Page>

--- a/website/src/pages/showcase/index.tsx
+++ b/website/src/pages/showcase/index.tsx
@@ -1,6 +1,8 @@
 import type { FC } from 'react';
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Translate from '@docusaurus/Translate';
+
 import Layout from '@theme/Layout';
 import './styles.scss';
 
@@ -19,18 +21,18 @@ const Container: FC = (props) => {
 const Header: FC = () => (
   <div className="header">
     <div className="title">
-      Showcase
+      <Translate id="showcase.website.title">Showcase</Translate>
     </div>
     <div className="tips">
-      This project is used by all these folks
+      <Translate id="showcase.website.tips.used">This project is used by all these folks</Translate>
       <br />
-      Are you using this project?&nbsp;
+      <Translate id="showcase.website.tips.wantUse">Are you using this project?&nbsp;</Translate>
       <a
         href="https://github.com/apache/apisix/blob/master/powered-by.md"
         target="_blank"
         rel="noopener noreferrer"
       >
-        <u>Add your company</u>
+        <u><Translate id="showcase.website.link.addYourCompany">Add your company</Translate></u>
       </a>
     </div>
   </div>

--- a/website/src/pages/team.tsx
+++ b/website/src/pages/team.tsx
@@ -318,10 +318,10 @@ const Team: FC = () => {
             </ContributeCardTitle>
             <ContributeCardSubtitle>
               <Translate id="team.webpage.content.BecomeACommitterInto">
-                The Apache APISIX community follows the Apache Community&apos;s process
-                on accepting a new committer. After a contributor participates
-                APISIX&apos;s community actively, PMC and Committers will make decisions
-                to invite the contributor join Committers and PMC.
+                The Apache APISIX community follows the Apache Community process on
+                accepting a new committer.
+                After contributors actively participate in the APISIX community,
+                PMC and Committers will decide to invite contributors to join Committers and PMC.
               </Translate>
             </ContributeCardSubtitle>
             <ContributeCardButton href="/docs/general/contributor-guide">


### PR DESCRIPTION
🥳 this is last hard-coded in customized react template, appreciate everyone

Changes:

added translation :
```
   zh/showcase
   zh/help
   zh/downloads
   zh/plugins
```

change json key, make sure the translation json order is the same as the file directory order
```
{
    hero.webpage  ->   hero.component
    arrowAnim.webpage  ->  arrowAnim.component
}
```