### PR TITLE
docs: fix dead link in doc style guide

### DIFF
--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/documentation-guide.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/documentation-guide.md
@@ -11,7 +11,7 @@ description: Apache APISIX 中文文档的贡献指南，适用于 APISIX 中文
 
 本文档是 Apache APISIX 中文文档的贡献指南，适用于为 APISIX 贡献中文文档的开发者，贡献者应遵循此文档以确保文档一致性。
 
-要了解关于贡献的更多信息，请参考[代码贡献流程](../docs/general/contributor-guide.md)。
+要了解关于贡献的更多信息，请参考[代码贡献流程](/docs/general/contributor-guide)。
 
 ## 语气、内容和受众
 


### PR DESCRIPTION
Fixes: #1121 

Changes: 

Change file path `../docs/general/contributor-guide.md` to `/docs/general/contributor-guide`

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


<!-- Add screenshots depicting the changes. -->
