### PR TITLE
docs: format and update links

### DIFF
--- a/website/docs/general/contributor-guide.md
+++ b/website/docs/general/contributor-guide.md
@@ -35,7 +35,7 @@ If you would like to contribute, let us know by sending an email to dev@apisix.a
 
 You can also contribute by fixing one of the [open issues](https://github.com/apache/apisix/issues).
 
-1. Once you have chosen an issue to work on or [opened a new issue](#submitting-an-issue), please comment on the issue and ask a [Committer or PMC](/team) to assign it to you.
+1. Once you have chosen an issue to work on or [opened a new issue](/docs/general/submit-issue), please comment on the issue and ask a [Committer or PMC](/team) to assign it to you.
 
 2. Please check to see if the issue is already being worked on and indicate when you will be able to complete it.
 

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/blog-contributing-guide.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/blog-contributing-guide.md
@@ -50,7 +50,7 @@ description: 如何在 Apache APISIX 官网提交或更新博客？
     - 添加图片前请先将图片上传到[公共图片 CDN 服务](https://markdown-editor-chi.vercel.app/#/)然后在 Markdown 文件中添加图片链接。
     - 表格及图片蕴涵了大量信息，我们很乐意看到它们。从经验来看小于等于4列的表格在网页上显得更加美观。
 
-4. 根据你新建的博客[创建一个 PR](/docs/general/contributor-guide/##创建一个-pr)。
+4. 根据你新建的博客[创建一个 PR](/docs/general/contributor-guide/#创建一个-pr)。
 
 :::note
 

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/contributor-guide.md
@@ -35,7 +35,7 @@ description: Apache APISIX 贡献者指南。
 
 你可以选择修复一个正在进行的 [Issues](https://github.com/apache/apisix/issues)。
 
-1. 一旦你选择了一个 issue 进行工作或[创建新的 issue](#submitting-an-issue)，请在该 issue 下留言，并让一个 [Committer 或者 PMC](/team) 将它分配给你。
+1. 一旦你选择了一个 issue 进行工作或[创建新的 issue](/docs/general/submit-issue)，请在该 issue 下留言，并让一个 [Committer 或者 PMC](/team) 将它分配给你。
 
 2. 请检查 issue 的状态，并推断你是否能够完成该 issue。
 


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:
1. format link refer to markdown grammar
2. fix dead links

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
