### PR TITLE
docs: add canonical links for cross-posted documents

### DIFF
--- a/website/blog/2021/11/17/dapr-with-apisix.md
+++ b/website/blog/2021/11/17/dapr-with-apisix.md
@@ -17,6 +17,10 @@ tags: [Technology]
 
 <!--truncate-->
 
+<head>
+    <link rel="canonical" href="https://blog.dapr.io/posts/2022/01/13/enable-dapr-with-apache-apisix-ingress-controller/" />
+</head>
+
 Essentially, the Apache APISIX controller will configure the same standard DAPR annotations to inject DAPRD sidecar. Exposing this sidecar allows external applications to communicate with applications in the cluster that have Dapr enabled.
 
 The following diagram shows the architectural flow of the actual project:

--- a/website/blog/2021/12/10/integrate-keycloak-auth-in-apisix.md
+++ b/website/blog/2021/12/10/integrate-keycloak-auth-in-apisix.md
@@ -22,6 +22,10 @@ tags: [Technology,Authentication]
 
 <!--truncate-->
 
+<head>
+    <link rel="canonical" href="https://www.keycloak.org/2021/12/apisix" />
+</head>
+
 ![Keycloak-APISIX Integration](https://static.apiseven.com/202108/1639129658486-393e8a3a-ccf2-496d-9b46-4db741bd6e55.png)
 
 [Keycloak](https://www.keycloak.org/) is an open source identity and access management solution for modern applications and services. Keycloak supports Single-Sign On, which enables services to interface with Keycloak through protocols such as OpenID Connect, OAuth 2.0, etc. Keycloak also supports integrations with different authentication services, such as Github, Google and Facebook.

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/17/dapr-with-apisix.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2021/11/17/dapr-with-apisix.md
@@ -17,6 +17,10 @@ tags: [Technology]
 
 <!--truncate-->
 
+<head>
+    <link rel="canonical" href="https://blog.dapr.io/posts/2022/01/13/enable-dapr-with-apache-apisix-ingress-controller/" />
+</head>
+
 本质上，Apache APISIX 控制器将配置相同标准 Dapr annotations 以注入 daprd sidecar。通过公开这个 sidecar，将允许外部应用程序与集群中启用 Dapr 的应用程序进行通信。
 
 下图为实际项目中的架构流程：

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2021/12/10/integrate-keycloak-auth-in-apisix.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2021/12/10/integrate-keycloak-auth-in-apisix.md
@@ -22,6 +22,10 @@ tags: [Technology,Authentication]
 
 <!--truncate-->
 
+<head>
+    <link rel="canonical" href="https://www.keycloak.org/2021/12/apisix" />
+</head>
+
 ![Keycloak-APISIX 集成](https://static.apiseven.com/202108/1639129658486-393e8a3a-ccf2-496d-9b46-4db741bd6e55.png)
 
 ## 什么是 Keycloak

--- a/website/i18n/zh/docusaurus-plugin-content-blog/2022/02/28/apisix-integration-opentelemetry-plugin.md
+++ b/website/i18n/zh/docusaurus-plugin-content-blog/2022/02/28/apisix-integration-opentelemetry-plugin.md
@@ -23,6 +23,10 @@ tags: [Technology,Ecosystem,Observability]
 
 <!--truncate-->
 
+<head>
+    <link rel="canonical" href="https://opentelemetry.io/blog/2022/apisix/" />
+</head>
+
 ## 背景信息
 
 Apache APISIX 是一个动态、实时、高性能的 API 网关，提供负载均衡、动态上游、灰度发布、服务熔断、身份认证、可观测性等丰富的流量管理功能。作为 API 网关，Apache APISIX 不仅拥有众多实用的插件，而且支持插件动态变更和热插拔。


### PR DESCRIPTION
Fixes: #999

Changes:
1. Add canonical link for Keycloak blog, zh-cn and en-us.
2. Add canonical link for Dapr blog, zh-cn and en-us.
3. Add canonical link for OpenTelemetry blog, zh-cn only, since en-us were already done in https://github.com/apache/apisix-website/pull/995/