### PR TITLE
feat: bump dashboard to 2.13.0

### DIFF
--- a/website/config/docs.js
+++ b/website/config/docs.js
@@ -18,8 +18,8 @@ module.exports = [
     shape: 'square',
     color: '#10B981',
     githubRepo: 'apache/apisix-dashboard',
-    version: '2.11.0',
-    releaseDate: '2022-03-23',
+    version: '2.13.0',
+    releaseDate: '2022-06-01',
     firstDocPath: '/USER_GUIDE',
   },
   {

--- a/website/config/downloads.js
+++ b/website/config/downloads.js
@@ -26,8 +26,8 @@ module.exports = [
     githubBranch: 'master',
     downloadPath: 'apisix/dashboard/2.11.0/apache-apisix-dashboard-2.11.0-src',
     dockerhubPath: 'apisix-dashboard',
-    version: '2.11.0',
-    releaseDate: '2022-03-23',
+    version: '2.13.0',
+    releaseDate: '2022-06-01',
     firstDocPath: '/USER_GUIDE',
   },
   {

--- a/website/config/downloads.js
+++ b/website/config/downloads.js
@@ -24,7 +24,7 @@ module.exports = [
     color: '#10B981',
     githubRepo: 'apache/apisix-dashboard',
     githubBranch: 'master',
-    downloadPath: 'apisix/dashboard/2.11.0/apache-apisix-dashboard-2.11.0-src',
+    downloadPath: 'apisix/dashboard/2.13.0/apache-apisix-dashboard-2.13.0-src',
     dockerhubPath: 'apisix-dashboard',
     version: '2.13.0',
     releaseDate: '2022-06-01',


### PR DESCRIPTION
Changes:

Upgrade APISIX Dashboard's download to 2.13.0.
