### PR TITLE
fix: revert .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ scripts/yarn.lock
 /.eslintcache
 /.stylelintcache
 
-website/docs/*
 website/docs-apisix_versioned_docs/*
 website/docs-apisix_versioned_sidebars/*
 website/docs-apisix-dashboard_versioned_docs/*


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendupottekkat@gmail.com>

This PR fixes the issue in the `.gitignore` file which caused additional files created to be untracked. See https://github.com/apache/apisix-website/pull/1132/files#r890164466