### PR TITLE
chore: disable deploy to netlify github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Deploy to Netlify
         uses: ./.github/actions/actions-netlify
-        if: ${{ !github.event.pull_request.merged }}
+        if: ${{ false }}
         with:
           publish-dir: "./website/build"
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

This step is temporarily disabled because this preview is not working for now.

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
