### PR TITLE
fix: set lang code according to baseUrl

### DIFF
--- a/website/config/ssrTemplate.js
+++ b/website/config/ssrTemplate.js
@@ -14,10 +14,10 @@ module.exports = {
         <%~ metaAttribute %>
       <% }); %>
       <% it.stylesheets.forEach((stylesheet) => { %>
-        <link rel="stylesheet" href="https://apisix-website-static.apiseven.com/<%= stylesheet %>" />
+        <link rel="stylesheet" href="https://apisix-website-static.apiseven.com<%= it.baseUrl %><%= stylesheet %>" />
       <% }); %>
       <% it.scripts.forEach((script) => { %>
-        <link rel="preload" href="https://apisix-website-static.apiseven.com/<%= script %>" as="script">
+        <link rel="preload" href="https://apisix-website-static.apiseven.com<%= it.baseUrl %><%= script %>" as="script">
       <% }); %>
       <!-- Matomo from the ASF -->
       <script>
@@ -45,7 +45,7 @@ module.exports = {
         <%~ it.appHtml %>
       </div>
       <% it.scripts.forEach((script) => { %>
-        <script src="https://apisix-website-static.apiseven.com/<%= script %>"></script>
+        <script src="https://apisix-website-static.apiseven.com<%= it.baseUrl %><%= script %>"></script>
       <% }); %>
       <%~ it.postBodyTags %>
     </body>


### PR DESCRIPTION
**Changes:**

When switches to other languages, the template engine `eta` needs to setup baseUrl