### PR TITLE
fix: extract elements in h1 tags

### DIFF
--- a/website/src/components/sections/HeroSection.tsx
+++ b/website/src/components/sections/HeroSection.tsx
@@ -26,17 +26,13 @@ const LazyLoadHeroCanvas = () => {
 const HeroSection: FC = () => (
   <div className="hero-sec-wrap" style={{ width: '100%' }}>
     <div className="hero-text">
-      <h1 className="hero-title">
-        <span><Translate id="hero.component.title.fragment1">Full Lifecycle API Management</Translate></span>
-        {' '}
-        <br />
-        <span style={{ color: '#E8433E', fontSize: 32 }}>
-          <Translate id="hero.component.title.fragment2">API Gateway, Ingress Controller, etc.</Translate>
-        </span>
-      </h1>
-      <h2 className="hero-subtitle">
-        <Translate id="hero.component.subtitle.content">Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, etc.</Translate>
+      <h1 className="hero-title"><Translate id="hero.component.title.fragment1">Full Lifecycle API Management</Translate></h1>
+      <h2 className="hero-subtitle" style={{ color: '#E8433E', fontSize: 32, fontWeight: 700 }}>
+        <Translate id="hero.component.title.fragment2">API Gateway, Ingress Controller, etc.</Translate>
       </h2>
+      <h3 className="hero-subtitle">
+        <Translate id="hero.component.subtitle.content">Apache APISIX provides rich traffic management features like Load Balancing, Dynamic Upstream, Canary Release, Circuit Breaking, Authentication, Observability, etc.</Translate>
+      </h3>
       <div className="hero-ctas">
         <Link
           to={useBaseUrl('downloads')}


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:
to handle this issue
<img width="980" alt="image" src="https://user-images.githubusercontent.com/48400568/178434501-eec9c038-8ebc-48c9-80b2-14dd3a77aff1.png">

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
