### PR TITLE
docs: Update 0614 three blog EN images

### DIFF
--- a/blog/en/blog/2022/06/14/automated-operation-base-apache-apisix.md
+++ b/blog/en/blog/2022/06/14/automated-operation-base-apache-apisix.md
@@ -35,7 +35,7 @@ During the selection of gateway, we have carried out the actual test. Compared w
 
 The overall architecture of the automation operation and maintenance platform is as follows:
 
-![Architecture Diagram](https://static.apiseven.com/2022/06/blog/1/173292289-2986c1b4-3704-4d34-a30a-df4ee6f09da7.png)
+![Architecture Diagram](https://static.apiseven.com/2022/blog/0614/auto-en1.png)
 
 - Storage layer: the core is CMDB. Its main function is to record and manage the attributes of the organization's business and its resources, as well as the relationships between them. Not only is it responsible for querying the initial status of all business changes, but also all business resource changes should be fed back and recorded in it to realize the control of business standards and specifications. The storage layer also contains some authority management data, business work order flow data, and monitoring alarm time sequence data;
 
@@ -73,7 +73,7 @@ The overall architecture of the automation operation and maintenance platform is
 
 For all Web frameworks, user login is a mandatory option, and I will introduce this scenario to you next.
 
-![User Logins](https://static.apiseven.com/2022/06/blog/1/173294822-ade65508-842e-450c-bcda-d8400e102f7a.png)
+![User Logins](https://static.apiseven.com/2022/blog/0614/auto-en2.png)
 
 First of all, we need to understand the relevant components we use in the scenario. The first is the access front end, which is outside the gateway. Secondly, we use the APISIX cloud native API gateway as the business boundary. Then the auth service, which is a self-defined microservice, is used to verify the front-end URL request and user login request, and issue tokens to authenticated users. LDAP stores the company's internal password information. CMDB stores some business-related information, including organizational structure, some organizational information about the permissions that can be accessed, and finally the pages that the front end needs to access.
 
@@ -87,11 +87,11 @@ Here, we use the [`consumer restriction`](https://apisix.apache.org/zh/docs/apis
 
 Through the above description, I believe you have a certain understanding of the normal request process. Next, I will introduce you to the scenarios of how to judge the insufficient permissions of these users. In the operation and maintenance platform, if there is an operation involving data change, a token must be carried. When the token is verified by the ACL interface that it has no access, it will directly return to a page that is forbidden to access for the front end to the process. The following is the specific process of user login and permission verification scenarios and the related components used more.
 
-![Schematic Diagram](https://static.apiseven.com/2022/06/blog/1/173295581-983d945f-76da-4cc1-b9f3-5531f60e9af3.png)
+![Schematic Diagram](https://static.apiseven.com/2022/blog/0614/auto-en3.png)
 
 ### New service microservice access
 
-![Microservice Access](https://static.apiseven.com/2022/06/blog/1/173296472-4048d0fc-247c-4855-a407-3d270d366a52.png)
+![Microservice Access](https://static.apiseven.com/2022/blog/0614/auto-en4.png)
 
 In our daily work, we often launch some microservices, so how can we connect this microservice to the automatic operation and maintenance platform?
 

--- a/blog/en/blog/2022/06/14/how-mse-supports-canary-release-with-apache-apisix.md
+++ b/blog/en/blog/2022/06/14/how-mse-supports-canary-release-with-apache-apisix.md
@@ -55,7 +55,7 @@ How to quickly implement canary release solution along the whole life cycle in t
 
 Physical environment isolation, in fact, is to build real traffic isolation by adding machines.
 
-![Physical environment isolation](https://static.apiseven.com/2022/06/blog/2/173307762-c8d3c115-c7c0-415d-94eb-f259cadab3bb.png)
+![Physical environment isolation](https://static.apiseven.com/2022/blog/0614/mse-en1.png)
 
 This scheme needs to build a set of network isolated and resource-independent environments for canary services, and deploy the canary version of the services in it. Because it is isolated from the formal environment, other services in the formal environment cannot access the services that need canary release. Therefore, these online services need to be deployed redundantly in the canary deployment so that the entire call link can forward traffic normally. In addition, some other dependent middleware components such as the registry also need to be redundantly deployed in the canary deployment to ensure the visibility between microservices and ensure that the obtained node IP address only belongs to the current network environment.
 
@@ -65,7 +65,7 @@ This scheme is generally used to build enterprise testing and pre development en
 
 The other scheme is to build a logical environment isolation. We only need to deploy the canary version of the service. When the traffic flows on the call link, the gateway, each middleware and each micro service passing through will identify the canary traffic and dynamically forward it to the canary version of the corresponding service. As shown below:
 
-![Logical environment isolation](https://static.apiseven.com/2022/06/blog/2/173314750-0a86a58f-b89f-4421-b841-015bb3cd5869.png)
+![Logical environment isolation](https://static.apiseven.com/2022/blog/0614/mse-en2.png)
 
 The above figure can well show the effect of this scheme. We use different colors to represent the canary traffic of different versions. It can be seen that both the microservice gateway and the microservice itself need to identify the traffic and make dynamic decisions according to the governance rules. When the service version changes, the forwarding of this call link will also change in real time. Compared with the canary deployment built by machines, this scheme can not only save a lot of machine costs and operation and maintenance manpower, but also help developers to control the online traffic in real time and quickly.
 
@@ -254,7 +254,7 @@ Then configure the route corresponding to the `base`:
 
 Configure the route corresponding to `gray`, as shown in the following figure:
 
-![Configure diagram](https://static.apiseven.com/2022/06/blog/2/173322176-ab677577-8595-4875-85cb-2dc799070871.png)
+![Configure diagram](https://static.apiseven.com/2022/blog/0614/mse-en3.png)
 
 ```json
 {

--- a/blog/en/blog/2022/06/14/xueqiu-with-apache-apisix.md
+++ b/blog/en/blog/2022/06/14/xueqiu-with-apache-apisix.md
@@ -30,7 +30,7 @@ Among them, the real-time quotes service is docked to a variety of upstream data
 
 Apache APISIX can greatly simplify the complexity of implementing a dual-active architecture. APISIX's own cloud-native features, rich community ecology and plug-ins also lay a good foundation for the future evolution of Xueqiu's cloud-native architecture. In this article, we will introduce how Xueqiu is using Apache APISIX to evolve its internal dual-active architecture.
 
-![Original architecture](https://static.apiseven.com/2022/06/blog/xueqiu-1.png)
+![Original architecture](https://static.apiseven.com/2022/blog/0614/xueqiu-en1.png)
 
 The diagram above depicts the simple architecture of Xueqiu single room period, user traffic comes in from the cloud portal (SLB), and is processed by the gateway for simple public nature logic and forwarded to the back-end service. The back-end service will be through the SDK, the authentication module integrated in the service to the Xueqiu user center to initiate user authentication, and then continue to follow the business processing.
 
@@ -58,13 +58,13 @@ So on top of these pain points, Xueqiu wanted to be as transparent as possible t
 
 Based on the pain points that became apparent in the business practice scenarios, the Xueqiu Infrastructure team began researching gateway products. Through internal requirements and the comparison of current market gateway products, the final choice of the subsequent architecture based on Apache APISIX adjustment and use.
 
-![Ecological](https://static.apiseven.com/2022/06/blog/xueqiu-2.png)
+![Ecological](https://static.apiseven.com/2022/blog/0614/xueqiu-en2.png)
 
 ## Apache APISIX Practice
 
 ### Adjusted architecture
 
-![New architecture](https://static.apiseven.com/2022/06/blog/xueqiu-4.png)
+![New architecture](https://static.apiseven.com/2022/blog/0614/xueqiu-en3.png)
 
 The above figure shows the current dual-active architecture of Xueqiu Quotes. The left side shows the corresponding architecture in the original server room without much change; the right side shows the multi-live architecture designed based on multiple regions after going to the cloud.
 
@@ -120,7 +120,7 @@ Currently, Xueqiu gRPC service calls are based on the Zookeeper registry for reg
 
 The specific implementation is mainly on a content node of APISIX, when the worker process starts to poll the ZK-Rest cluster like in the figure below, and then regularly pull the source data information and actual information of the whole service, update to the local cache in the worker process, and use it to update the service list.
 
-![Extend ZooKeeper](https://static.apiseven.com/2022/06/blog/xueqiu-8.png)
+![Extend ZooKeeper](https://static.apiseven.com/2022/blog/0614/xueqiu-en4.png)
 
 As you can see from the above diagram, the ZK-Rest cluster is equivalent to accessing the data of ZooKeeper through the form of Rest. Therefore, the whole process is actually less functional (mainly based on its own business scenario requirements), and only one instance of it needs to be added to achieve the high availability feature, eliminating some complex operations.
 


### PR DESCRIPTION
Changes:

Update three blog EN images in https://github.com/apache/apisix-website/issues/1153
- https://apisix.apache.org/blog/2022/06/14/xueqiu-with-apache-apisix/
- https://apisix.apache.org/blog/2022/06/14/how-mse-supports-canary-release-with-apache-apisix/
- https://apisix.apache.org/blog/2022/06/14/automated-operation-base-apache-apisix/

Before
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/39793568/181441036-1a4290d0-331a-4464-b783-073adc771100.png">
After
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/39793568/181442600-17ff5346-a236-4ae5-b492-cf9908e1de42.png">
