### PR TITLE
docs: update build apisix and build java plugin web link

### DIFF
--- a/blog/en/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins.md
+++ b/blog/en/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins.md
@@ -47,7 +47,7 @@ The order of execution of multiple programming languages plugins is defined in t
 
 ## Building Development Environment
 
-First, you need to build the Apache APISIX runtime or development environment, please refer to [Build Apache APISIX](https://github.com/apache/apisix/blob/master/docs/en/latest/how-to-build.md), and [Build apisix-java-plugin-runner](https://github.com/apache/apisix-java-plugin-runner/blob/main/docs/development.md).
+First, you need to build the Apache APISIX runtime or development environment, please refer to [Build Apache APISIX](https://github.com/apache/apisix/blob/master/docs/en/latest/building-apisix.md), and [Build apisix-java-plugin-runner](https://github.com/apache/apisix-java-plugin-runner/blob/main/docs/en/latest/deployment-guide.md).
 
 Note: Apache APISIX and apisix-java-plugin-runner need to be located on the same instance.
 

--- a/blog/en/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins.md
+++ b/blog/en/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins.md
@@ -47,7 +47,7 @@ The order of execution of multiple programming languages plugins is defined in t
 
 ## Building Development Environment
 
-First, you need to build the Apache APISIX runtime or development environment, please refer to [Build Apache APISIX](https://github.com/apache/apisix/blob/master/docs/en/latest/building-apisix.md), and [Build apisix-java-plugin-runner](https://github.com/apache/apisix-java-plugin-runner/blob/main/docs/en/latest/deployment-guide.md).
+First, you need to build the Apache APISIX runtime or development environment, please refer to [Build Apache APISIX](https://github.com/apache/apisix/blob/master/docs/en/latest/building-apisix.md), and [Build apisix-java-plugin-runner](https://github.com/apache/apisix-java-plugin-runner/blob/main/docs/en/latest/development.md).
 
 Note: Apache APISIX and apisix-java-plugin-runner need to be located on the same instance.
 


### PR DESCRIPTION
Changes:

update build apisix doc and build java plugin doc weblink.

Screenshots of the change:

![image](https://user-images.githubusercontent.com/9354193/184590530-ee0b6306-559d-49f6-8654-5edaa52713c9.png)
