### PR TITLE
docs: update Slack Invitation link

### DIFF
--- a/website/docs/general/join.md
+++ b/website/docs/general/join.md
@@ -31,6 +31,6 @@ You can subscribe to the Apache APISIX mailing list to discuss issues, suggest n
 
 You can join the Apache APISIX Slack channel in two ways:
 
-- Join Apache Software Foundation Slack workspace using [this invite](https://join.slack.com/t/the-asf/shared_invite/zt-vlfbf7ch-HkbNHiU_uDlcH_RvaHv9gQ) (_Please [open an issue](./submit-issue.md) if this link is expired_), and then join the **#apisix** channel (Channels -> Browse channels -> search for "apisix").
+- Join Apache Software Foundation Slack workspace using [this invite](https://join.slack.com/t/the-asf/shared_invite/zt-1egxjz7lw-lWl142XNDopj4FlqNMUM5g) (_Please [open an issue](./submit-issue.md) if this link is expired_), and then join the **#apisix** channel (Channels -> Browse channels -> search for "apisix").
 
 - By [subscribing to the mailing list](#subscribe-to-the-mailing-list) and sending an email to the list ([dev@apisix.apache.org](mailto:dev@apisix.apache.org)) requesting help to join.

--- a/website/i18n/zh/docusaurus-plugin-content-docs/current/join.md
+++ b/website/i18n/zh/docusaurus-plugin-content-docs/current/join.md
@@ -30,7 +30,7 @@ Apache APISIX 是一个由 Apache 软件基金会下的社区成员维护的项�
 
 你可以通过以下两种方式加入 Apache APISIX 的 Slack 频道：
 
-- 通过此[邀请链接](https://join.slack.com/t/the-asf/shared_invite/zt-vlfbf7ch-HkbNHiU_uDlcH_RvaHv9gQ)加入 Apache 软件基金会 Slack 工作区，然后加入 **#apisix** 频道（频道 -> 浏览频道 -> 搜索 "apisix"）。
+- 通过此[邀请链接](https://join.slack.com/t/the-asf/shared_invite/zt-1egxjz7lw-lWl142XNDopj4FlqNMUM5g)加入 Apache 软件基金会 Slack 工作区，然后加入 **#apisix** 频道（频道 -> 浏览频道 -> 搜索 "apisix"）。
 
 :::tip
 


### PR DESCRIPTION
**Changes**

Update Expired Slack Link, this link will be expired in 30 days.

