### PR TITLE
chore: update Slack invitation link

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -34,7 +34,7 @@ Options -Indexes
 
 </IfModule>
 
-Redirect 302 "/slack" "https://join.slack.com/t/the-asf/shared_invite/zt-1egxjz7lw-lWl142XNDopj4FlqNMUM5g"
+Redirect 302 "/slack" "https://join.slack.com/t/the-asf/shared_invite/zt-1g9ghsrol-v4hkkV8uKbGrDqRuPEq7fg"
 
 Redirect 301 "/docs/apisix/install" "/docs/apisix/how-to-build/"
 Redirect 301 "/docs/apisix/architecture-design/plugin/" "/docs/apisix/architecture-design/plugin-config/"


### PR DESCRIPTION
Changes:

Update Slack invitation link every 30 days.