### PR TITLE
docs: update Elastisearch&OpenFunction blog cover

### DIFF
--- a/blog/zh/blog/2022/09/15/apache-apisix-integrat-with-elasticsearch-for-logger.md
+++ b/blog/zh/blog/2022/09/15/apache-apisix-integrat-with-elasticsearch-for-logger.md
@@ -13,7 +13,7 @@ keywords:
 - 数据管理
 description: 本文将为你介绍 Apache APISIX 的 elasticsearch-logger 插件的相关信息，以及如何通过此插件获取 APISIX 的实时日志。
 tags: [Plugins,Ecosystem]
-images: https://static.apiseven.com/2022/09/15/6322cf190ef2d.png
+image: https://static.apiseven.com/2022/09/20/63296a9ba9a7d.png
 ---
 
 > 本文将为你介绍 Apache APISIX 的 elasticsearch-logger 插件的相关信息，以及如何通过此插件获取 APISIX 的实时日志。

--- a/blog/zh/blog/2022/09/20/apisix-integrate-cncf-openfunction.md
+++ b/blog/zh/blog/2022/09/20/apisix-integrate-cncf-openfunction.md
@@ -14,6 +14,7 @@ keywords:
 - Serverless
 description: 本文介绍了 Apache APISIX openfunction 插件的功能与使用步骤，为 APISIX 的无服务领域功能再添一员。
 tags: [Plugins,Ecosystem]
+image: https://static.apiseven.com/2022/09/20/63296a9c05e59.png
 ---
 
 > 本文作者李从旺，开源爱好者与云原生技术爱好者，目前于佐治亚理工学院深圳校区进修硕士学位。本篇文章是在参与 APISIX 开源之夏项目「集成 OpenFunction 至 Apache APISIX」的功能呈现，希望此功能可以让你在使用 APISIX 进行扩展时更加便捷。


### PR DESCRIPTION
Changes:

update Elastisearch&OpenFunction blog cover

Before:
<img width="922" alt="image" src="https://user-images.githubusercontent.com/39793568/191196328-c1ca4185-cc00-4b69-b127-42422809a7a7.png">


After:
<img width="928" alt="image" src="https://user-images.githubusercontent.com/39793568/191196294-3784b65b-6721-485f-a73d-093f6f45603f.png">

