### PR TITLE
feat: full width version dropdown items

### DIFF
--- a/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -97,6 +97,9 @@ const DocsVersionDropdownNavbarItem = ({
     return (
       <DefaultNavbarItem
         {...props}
+        style={{
+          width: '100%',
+        }}
         mobile={mobile}
         label={dropdownLabel}
         to={dropdownTo}

--- a/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -111,6 +111,9 @@ const DocsVersionDropdownNavbarItem = ({
   return (
     <DropdownNavbarItem
       {...props}
+      style={{
+        width: '100%',
+      }}
       mobile={mobile}
       label={dropdownLabel}
       to={dropdownTo}

--- a/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -19,6 +19,7 @@ import type { GlobalDataVersion } from '@docusaurus/plugin-content-docs-types';
 import clsx from 'clsx';
 import { LTSVersions } from '../../../../config/apisix-versions';
 import style from './style.module.scss';
+import './style.scss';
 
 const getVersionMainDoc = (version: GlobalDataVersion) => version.docs.find((doc) => doc.id === version.mainDocId)!;
 

--- a/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
+++ b/doc/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.tsx
@@ -97,9 +97,6 @@ const DocsVersionDropdownNavbarItem = ({
     return (
       <DefaultNavbarItem
         {...props}
-        style={{
-          width: '100%',
-        }}
         mobile={mobile}
         label={dropdownLabel}
         to={dropdownTo}
@@ -111,9 +108,6 @@ const DocsVersionDropdownNavbarItem = ({
   return (
     <DropdownNavbarItem
       {...props}
-      style={{
-        width: '100%',
-      }}
       mobile={mobile}
       label={dropdownLabel}
       to={dropdownTo}

--- a/doc/src/theme/NavbarItem/style.scss
+++ b/doc/src/theme/NavbarItem/style.scss
@@ -1,0 +1,5 @@
+div.navbar-sidebar, div.docs-doc-page {
+  .dropdown__menu .dropdown__link {
+    width: 100%;
+  }
+}

--- a/doc/src/theme/NavbarItem/style.scss
+++ b/doc/src/theme/NavbarItem/style.scss
@@ -1,3 +1,4 @@
+// for sidebar doc version dropdown
 div.navbar-sidebar, div.docs-doc-page {
   .dropdown__menu .dropdown__link {
     width: 100%;


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

* Change the document dropdown option to full width to facilitate switching document versions
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<table>
<tr>
<th>OLD</th>
<th>NEW</th>
</tr>

<tr>
<td><img src="https://user-images.githubusercontent.com/48400568/211730886-053d8ea5-f533-4535-bd6a-3cff19a3d0f4.png" width="200"></td>
<td><img src="https://user-images.githubusercontent.com/48400568/211730810-51dc2efe-f51e-4174-a3b7-98d863776b5f.png" width="200"></td>
</tr>
</table>
