### PR TITLE
fix: improve visibility of Blog page in dark mode

### DIFF
--- a/blog/en/docusaurus.config.js
+++ b/blog/en/docusaurus.config.js
@@ -96,7 +96,7 @@ module.exports = {
     },
     colorMode: {
       defaultMode: 'light',
-      disableSwitch: true,
+      disableSwitch: false,
       respectPrefersColorScheme: false,
     },
     image: 'https://static.apiseven.com/202202/apache-apisix.png',

--- a/blog/src/css/customTheme.scss
+++ b/blog/src/css/customTheme.scss
@@ -35,6 +35,7 @@
 }
 
 html[data-theme="dark"] {
+  --ifm-color-primary: #db433e;
   --color-secondary-bg: #121212;
   --ifm-color-dark: #b0b0b0;
   --color-title: #f0f0f0;
@@ -233,7 +234,7 @@ a {
 }
 
 a:hover {
-  color: var(--color-primary);
+  color: var(--ifm-color-dark);
   text-decoration: none;
 }
 

--- a/blog/src/css/customTheme.scss
+++ b/blog/src/css/customTheme.scss
@@ -141,7 +141,7 @@ div.inner {
 }
 
 header h2 {
-  color: var(--color-primary);
+  color: var(--color-title);
 }
 
 @media only screen and (max-width: 414px) {

--- a/blog/src/theme/BlogLayout/style.module.scss
+++ b/blog/src/theme/BlogLayout/style.module.scss
@@ -27,7 +27,7 @@
   width: 100%;
   flex-wrap: wrap;
   padding: 0.25rem 1rem;
-  transition: all 0.3s ease-in-out;
+  transition: color 0.3s ease-in-out;
   font-family: apple-system, system-ui, sans-serif;
   border-bottom: 1px solid #e8e8ed;
 

--- a/blog/src/theme/BlogLayout/style.module.scss
+++ b/blog/src/theme/BlogLayout/style.module.scss
@@ -52,6 +52,7 @@
     font-weight: 400;
     font-size: 14px;
     transition: inherit;
+    color: var(--color-title);
 
     &:default {
       color: #1d1d1f;

--- a/blog/src/theme/BlogLayout/style.module.scss
+++ b/blog/src/theme/BlogLayout/style.module.scss
@@ -42,6 +42,7 @@
     z-index: -1;
     position: absolute;
     top: 0;
+    left: 0;
     backdrop-filter: blur(12px);
   }
 

--- a/blog/src/theme/BlogLayout/style.module.scss
+++ b/blog/src/theme/BlogLayout/style.module.scss
@@ -28,8 +28,12 @@
   flex-wrap: wrap;
   padding: 0.25rem 1rem;
   transition: all 0.3s ease-in-out;
-  border-bottom: 1px solid #e8e8ed;
   font-family: apple-system, system-ui, sans-serif;
+  border-bottom: 1px solid #e8e8ed;
+
+  html[data-theme="dark"] & {
+    border-bottom: 1px solid #252525;
+  }
 
   &::before {
     content: "";
@@ -59,6 +63,10 @@
 
     &::before {
       background-color: hsl(100deg 100% 100% / 85%);
+
+      html[data-theme="dark"] & {
+        background-color: hsl(0deg 0% 0% / 85%);
+      }
     }
 
     > a {

--- a/blog/src/theme/BlogLayout/style.module.scss
+++ b/blog/src/theme/BlogLayout/style.module.scss
@@ -56,6 +56,10 @@
     &:default {
       color: #1d1d1f;
     }
+
+    &:hover {
+      color: var(--ifm-color-primary);
+    }
   }
 
   &.expand {

--- a/blog/src/theme/BlogPosts/style.module.scss
+++ b/blog/src/theme/BlogPosts/style.module.scss
@@ -155,6 +155,10 @@
       & .authors {
         display: flex;
 
+        html[data-theme="dark"] & img {
+          filter: brightness(0.85);
+        }
+
         & .author {
           width: 32px;
           height: 32px;

--- a/blog/src/theme/BlogPosts/style.module.scss
+++ b/blog/src/theme/BlogPosts/style.module.scss
@@ -98,7 +98,7 @@
         transition: all 0.3s ease-in-out !important;
 
         html[data-theme="dark"] & {
-          filter: brightness(0.9);
+          filter: brightness(0.85);
         }
       }
     }

--- a/blog/src/theme/BlogPosts/style.module.scss
+++ b/blog/src/theme/BlogPosts/style.module.scss
@@ -98,7 +98,7 @@
         transition: all 0.3s ease-in-out !important;
 
         html[data-theme="dark"] & {
-          opacity: 0.9 !important;
+          filter: brightness(0.9);
         }
       }
     }

--- a/blog/src/theme/BlogPosts/style.module.scss
+++ b/blog/src/theme/BlogPosts/style.module.scss
@@ -125,7 +125,6 @@
         h2 {
           font-size: 1.375rem;
           line-height: 1.2em;
-          color: #222;
           margin-top: 0.8rem;
           margin-bottom: 0.5em;
           transition: all 0.3s ease-in-out;
@@ -136,7 +135,6 @@
         }
 
         p {
-          color: #1d1d1f;
           max-height: #{1.7 * 3}em;
           overflow-y: hidden;
           text-overflow: ellipsis;

--- a/blog/src/theme/BlogPosts/style.module.scss
+++ b/blog/src/theme/BlogPosts/style.module.scss
@@ -96,6 +96,10 @@
         width: $width !important;
         transform-origin: center center;
         transition: all 0.3s ease-in-out !important;
+
+        html[data-theme="dark"] & {
+          opacity: 0.9 !important;
+        }
       }
     }
 
@@ -128,10 +132,6 @@
           margin-top: 0.8rem;
           margin-bottom: 0.5em;
           transition: all 0.3s ease-in-out;
-
-          &:hover {
-            opacity: 0.6;
-          }
         }
 
         p {
@@ -146,6 +146,10 @@
       & .footer {
         display: flex;
         align-items: center;
+
+        & > time {
+          opacity: 0.9;
+        }
       }
 
       & .authors {
@@ -195,7 +199,7 @@
       }
 
       h2 {
-        opacity: 0.6;
+        opacity: 0.8;
       }
 
       & .tags:hover + a > h2 {

--- a/blog/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/blog/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -37,7 +37,12 @@ const LocaleDropdownNavbarItem: FC<LocaleDropdownNavbarItemProps> = (props) => {
   if (windowType !== 'mobile') {
     if (pathname.startsWith('/zh/blog')) {
       return (
-        <Link autoAddBaseUrl={false} to="pathname:///blog" target="_parent">
+        <Link
+          className={styles.localizedBlogLink}
+          autoAddBaseUrl={false}
+          to="pathname:///blog"
+          target="_parent"
+        >
           English Blog
         </Link>
       );
@@ -45,7 +50,12 @@ const LocaleDropdownNavbarItem: FC<LocaleDropdownNavbarItemProps> = (props) => {
 
     if (pathname.startsWith('/blog')) {
       return (
-        <Link autoAddBaseUrl={false} to="pathname:///zh/blog" target="_parent">
+        <Link
+          className={styles.localizedBlogLink}
+          autoAddBaseUrl={false}
+          to="pathname:///zh/blog"
+          target="_parent"
+        >
           中文博客
         </Link>
       );

--- a/blog/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
+++ b/blog/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
@@ -9,3 +9,7 @@
   vertical-align: text-bottom;
   margin-right: 5px;
 }
+
+.localizedBlogLink {
+  padding: 4px 12px;
+}

--- a/blog/zh/docusaurus.config.js
+++ b/blog/zh/docusaurus.config.js
@@ -98,7 +98,7 @@ module.exports = {
     },
     colorMode: {
       defaultMode: 'light',
-      disableSwitch: true,
+      disableSwitch: false,
       respectPrefersColorScheme: false,
     },
     image: 'https://static.apiseven.com/202202/apache-apisix.png',

--- a/doc/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/doc/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -36,11 +36,31 @@ const LocaleDropdownNavbarItem: FC<LocaleDropdownNavbarItemProps> = (props) => {
   const { pathname } = useLocation();
 
   if (pathname.startsWith('/zh/blog')) {
-    return <Link isNavLink autoAddBaseUrl={false} to="pathname:///blog" target="_self">English Blog</Link>;
+    return (
+      <Link
+        className={styles.localizedBlogLink}
+        isNavLink
+        autoAddBaseUrl={false}
+        to="pathname:///blog"
+        target="_self"
+      >
+        English Blog
+      </Link>
+    );
   }
 
   if (pathname.startsWith('/blog')) {
-    return <Link isNavLink autoAddBaseUrl={false} to="pathname:///zh/blog" target="_self">中文博客</Link>;
+    return (
+      <Link
+        className={styles.localizedBlogLink}
+        isNavLink
+        autoAddBaseUrl={false}
+        to="pathname:///zh/blog"
+        target="_self"
+      >
+        中文博客
+      </Link>
+    );
   }
 
   function getLocaleLabel(locale) {

--- a/doc/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
+++ b/doc/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
@@ -9,3 +9,7 @@
   vertical-align: text-bottom;
   margin-right: 5px;
 }
+
+.localizedBlogLink {
+  padding: 4px 12px;
+}

--- a/website/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
+++ b/website/src/theme/NavbarItem/LocaleDropdownNavbarItem/index.tsx
@@ -36,11 +36,31 @@ const LocaleDropdownNavbarItem: FC<LocaleDropdownNavbarItemProps> = (props) => {
   const { pathname } = useLocation();
 
   if (pathname.startsWith('/zh/blog')) {
-    return <Link isNavLink autoAddBaseUrl={false} to="pathname:///blog" target="_self">English Blog</Link>;
+    return (
+      <Link
+        className={styles.localizedBlogLink}
+        isNavLink
+        autoAddBaseUrl={false}
+        to="pathname:///blog"
+        target="_self"
+      >
+        English Blog
+      </Link>
+    );
   }
 
   if (pathname.startsWith('/blog')) {
-    return <Link isNavLink autoAddBaseUrl={false} to="pathname:///zh/blog" target="_self">中文博客</Link>;
+    return (
+      <Link
+        className={styles.localizedBlogLink}
+        isNavLink
+        autoAddBaseUrl={false}
+        to="pathname:///zh/blog"
+        target="_self"
+      >
+        中文博客
+      </Link>
+    );
   }
 
   function getLocaleLabel(locale) {

--- a/website/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
+++ b/website/src/theme/NavbarItem/LocaleDropdownNavbarItem/styles.module.css
@@ -9,3 +9,7 @@
   vertical-align: text-bottom;
   margin-right: 5px;
 }
+
+.localizedBlogLink {
+  padding: 4px 12px;
+}


### PR DESCRIPTION
Fixes: #1308

Changes:

- make `BlogPostItem`'s title and description more visible
- enable dark mode switch in **Blog** page
- add padding for the links of `中文博客` and `English Blog` in Navbar

Screenshots of the change:

- BlogPostItem
  
  before:

  ![post-before](https://user-images.githubusercontent.com/86521894/195559207-28e4a6ab-0561-4b6d-a14a-da62ac784bd9.png)

  after:

  ![post-after](https://user-images.githubusercontent.com/86521894/195559403-ab6a54c6-d45a-44a2-8dea-cb86d3b00db7.png)

- dark mode switch & padding for links of `中文博客` and `English Blog`

  before:
  
  ![link-before](https://user-images.githubusercontent.com/86521894/195559527-431e5102-d52e-41d4-92a7-20318d4e90a0.png)

  after:

  ![link-after](https://user-images.githubusercontent.com/86521894/195559815-815838c4-90a0-47d9-b71a-53e6be081106.png)
