### PR TITLE
docs: Added cover images for blogs

### DIFF
--- a/blog/en/blog/2022/08/08/apache-apisix-performance-test-in-azure.md
+++ b/blog/en/blog/2022/08/08/apache-apisix-performance-test-in-azure.md
@@ -17,6 +17,7 @@ keywords:
 - Arm
 description: This article uses API Gateway Apache APISIX to compare the performance of Azure Ddsv5 and Azure Dpdsv5 in network IO-intensive scenarios.
 tags: [Ecosystem]
+image: https://static.apiseven.com/2022/10/28/635b53794f32a.png
 ---
 
 > This article uses API Gateway Apache APISIX to compare the performance of Azure Ddsv5 and Azure Dpdsv5 in network IO-intensive scenarios.

--- a/blog/en/blog/2022/08/12/arm-performance-google-aws-azure-with-apisix.md
+++ b/blog/en/blog/2022/08/12/arm-performance-google-aws-azure-with-apisix.md
@@ -23,6 +23,7 @@ keywords:
 - Apache APISIX
 description: This article compares the performance of Google, AWS, Azure, and Oracle ARM-based servers in network IO-intensive scenarios through the API gateway Apache APISIX.
 tags: [Ecosystem]
+image: https://static.apiseven.com/2022/10/18/634e6963ea45f.png
 ---
 
 > This article uses  Apache APISIX to compare the performance of AWS, Google, Azure, and Oracle ARM-based servers in network IO-intensive scenarios.

--- a/blog/en/blog/2022/10/05/rust-apisix.md
+++ b/blog/en/blog/2022/10/05/rust-apisix.md
@@ -12,6 +12,7 @@ keywords:
 - WebAssembly
 description: This article describes how to redevelop the response-rewrite plugin using Rust and WebAssembly.
 tags: [Case Studies]
+image: https://static.apiseven.com/2022/10/28/635b5378cdd1f.png
 ---
 
 > This article describes how to redevelop the response-rewrite plugin using Rust and WebAssembly.


### PR DESCRIPTION
With reference to https://github.com/apache/apisix-website/issues/1245

Changes:

Added cover images for the following blogs:

- [x] GCP, AWS, Azure, and OCI ARM-Based Server Performance Comparison
- [x] Rewriting the Apache APISIX response-rewrite plugin in Rust
- [x] How is the Azure ARM architecture server perform?