### PR TITLE
docs: Added cover image for blog

### DIFF
--- a/blog/en/blog/2022/06/27/getting-start-with-apisix-test-cases.md
+++ b/blog/en/blog/2022/06/27/getting-start-with-apisix-test-cases.md
@@ -16,6 +16,7 @@ keywords:
 - GitHub
 description: This article introduces the test case of APISIX and how to write the test case, and shows the actual operation effect from the local and GitHub.
 tags: [Community,Ecosystem]
+image: https://static.apiseven.com/2022/11/13/637053d67a0d4.png
 ---
 
 > This article introduces the test case of APISIX and how to write the test case, and shows the actual operation effect from the local and GitHub.

--- a/blog/en/blog/2022/07/22/how-is-google-cloud-tau-t2a-performing.md
+++ b/blog/en/blog/2022/07/22/how-is-google-cloud-tau-t2a-performing.md
@@ -13,6 +13,7 @@ keywords:
     - ARM64
 description: This article mainly uses the cloud native API gateway Apache APISIX to compare the performance of Google Cloud T2A and Google Cloud T2D.
 tags: [Ecosystem]
+image: https://static.apiseven.com/2022/11/11/636dc26637f24.png
 ---
 
 > This article mainly uses Apache APISIX to compare the performance of Google Cloud T2A and Google Cloud T2D.


### PR DESCRIPTION
With reference to https://github.com/apache/apisix-website/issues/1245

Changes:

Added cover image for the following blogs: 
- [x] How is Google Cloud Tau T2A performing?
- [x] Getting Started with APISIX Test Cases 
