### PR TITLE
fix: link behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "serve:blog:zh": "yarn workspace blog docusaurus serve zh",
     "serve:blog:en": "yarn workspace blog docusaurus serve en",
     "build:website:preview:serve": "yarn build:website:preview && yarn serve:website",
-    "build:doc:preview:serve": "yarn build:doc:previw && yarn serve:doc",
+    "build:doc:preview:serve": "yarn build:doc:preview && yarn serve:doc",
     "build:blog:zh:preview:serve": "yarn build:blog:zh:preview && yarn serve:blog:zh",
     "build:blog:en:preview:serve": "yarn build:blog:en:preview && yarn serve:blog:en",
     "prepare": "husky install",


### PR DESCRIPTION
Fixes: #1392

Changes:

Now, the behavior of the links in the `doc` part is:

1. `target: _self`
	1. belonging to the current category of the document
	2. of the current page (starts with `#`)
2. `target: _blank`
	1. not part of the current category (e.g., `apisix-docker` links and external links added under `apisix` documents)

For actual results, try the page mentioned in #1392.

Screenshots of the change:

none
<!-- Add screenshots depicting the changes. -->
