### PR TITLE
feat: add structured data for SEO

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -44,6 +44,33 @@ const ThemeResetComponent = () => {
   return (null);
 };
 
+// structured data for improved SEO
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "softwareApplication",
+  name: "Apache APISIX",
+  alternateName: "APISIX",
+  description: "Open source and cloud native API gateway, based on the Nginx library and etcd.",
+  abstract: "High-performance, cloud-native, open source API Gateway from the Apache Software Foundation.",
+  url: "https://apisix.apache.org",
+  thumbnailUrl:
+    "https://raw.githubusercontent.com/apache/apisix/master/logos/apisix-white-bg.jpg",
+  sameAs: [
+    "https://twitter.com/ApacheAPISIX",
+    "https://github.com/apache/apisix",
+    "https://www.youtube.com/@apacheapisix",
+    "https://www.linkedin.com/company/apache-apisix/",
+  ],
+  isPartOf: "Apache Software Foundation",
+  maintainer: "Apache Software Foundation",
+  contributor: [
+    "API7.ai",
+    "Tencent",
+    "Zhihu",
+    "Alibaba Cloud",
+  ],
+};
+
 const Index: FC = () => (
   <Layout>
     <ThemeResetComponent />
@@ -64,6 +91,11 @@ const Index: FC = () => (
         name="og:description"
         content="Apache APISIX is a dynamic, real-time, high-performance Cloud-Native API gateway, based on the Nginx library and etcd."
       />
+
+      <script type="application/ld+json">
+        { JSON.stringify(structuredData) }
+      </script>
+
     </Head>
     <HeroSection />
     <Architecture />

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -63,12 +63,6 @@ const structuredData = {
   ],
   isPartOf: "Apache Software Foundation",
   maintainer: "Apache Software Foundation",
-  contributor: [
-    "API7.ai",
-    "Tencent",
-    "Zhihu",
-    "Alibaba Cloud",
-  ],
 };
 
 const Index: FC = () => (


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Related to #980

Adds structured data for the homepage. This is an initial setup and in the future we can automatically generate this data on every page in the site.

![Screenshot 2023-02-03 at 11 16 30 AM](https://user-images.githubusercontent.com/49474499/216522485-d4b04c69-65d9-487a-b873-bf583fa482f6.png)