### PR TITLE
docs: add info about community meeting

### DIFF
--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -18,3 +18,16 @@ To add your event to the calendar, please open an issue in the [specified format
 :::
 
 <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ea5451&ctz=UTC&showCalendars=0&showTabs=0&showPrint=0&title&showTitle=0&showNav=1&showDate=1&src=Y19zb25ubDg2OXZoNnRqZDlmcmo3dDZyY21hMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23D50000" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+## Apache APISIX Community Meeting
+
+APISIX users, contributors, and maintainers get together once a month in an online meeting to discuss new features, share user stories, highlight contributors, and have more APISIX-related discussions.
+
+Everyone is welcome to join this open meeting as a listener or a speaker. To get an invite to the meeting, fill out [this form](https://apisix.apache.org/community-meeting-signup).
+
+If you would like to propose a topic for discussion, [send a message on Slack](https://apisix.apache.org/docs/general/join/#join-the-slack-channel).
+
+To learn more:
+
+- [APISIX Community Meeting Minutes](https://docs.google.com/document/d/1BKizjE_vGxxYCSrBehyGsa4Q7eS8DLIdgumC6fRm4TQ/edit)
+- [Previous meeting recordings](https://youtube.com/playlist?list=PLAoKZlos1sznjgFQsm31QAWeJmv8_w7SP)


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Adds info about the community meeting to the events page.

Preview: https://deploy-preview-1514--apache-apisix.netlify.app/docs/general/events/#apache-apisix-community-meeting