### PR TITLE
fix: the home video overflow on Mobile

### DIFF
--- a/website/src/components/Video.tsx
+++ b/website/src/components/Video.tsx
@@ -1,14 +1,14 @@
-import type { FC } from 'react';
-import React from 'react';
-import videojs from 'video.js';
-import type { VideoJsPlayerOptions, VideoJsPlayer } from 'video.js';
-import 'video.js/dist/video-js.min.css';
-import '../css/landing-sections/video.css';
+import type { FC } from "react";
+import React from "react";
+import videojs from "video.js";
+import type { VideoJsPlayerOptions, VideoJsPlayer } from "video.js";
+import "video.js/dist/video-js.min.css";
+import "../css/landing-sections/video.css";
 
 export interface VideoProps {
-    options: VideoJsPlayerOptions,
-    // eslint-disable-next-line react/require-default-props
-    onReady?: ((player: VideoJsPlayer) => void) | undefined
+  options: VideoJsPlayerOptions;
+  // eslint-disable-next-line react/require-default-props
+  onReady?: ((player: VideoJsPlayer) => void) | undefined;
 }
 
 export const Video: FC<VideoProps> = (props) => {
@@ -24,7 +24,7 @@ export const Video: FC<VideoProps> = (props) => {
       if (!videoElement) return;
 
       const player = videojs(videoElement, options, () => {
-        videojs.log('player is ready');
+        videojs.log("player is ready");
         onReady?.(player);
       });
       playerRef.current = player;
@@ -49,7 +49,10 @@ export const Video: FC<VideoProps> = (props) => {
   return (
     <div data-vjs-player>
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video ref={videoRef} className="video-js vjs-big-play-centered" />
+      <video
+        ref={videoRef}
+        className="video-js vjs-big-play-centered video-player"
+      />
     </div>
   );
 };

--- a/website/src/css/landing-sections/video.css
+++ b/website/src/css/landing-sections/video.css
@@ -5,3 +5,9 @@
 .video-js.vjs-paused .vjs-big-play-button {
   display: inline-block !important;
 }
+
+.video-player {
+  aspect-ratio: 16/9;
+  max-width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Fixes: #1473

Close https://github.com/apache/apisix-website/issues/1473

Changes:

I fixed the promo video overflow issue on small screens in my pull request. Could you please review and accept it? It will improve the user experience. Thank you.

Screenshots of the change:

![Desktop Screenshot 2023 03 31 - 10 33 42 66 (2)](https://user-images.githubusercontent.com/48076909/229041776-c0d3b50e-02ce-4342-9147-6b895d4bfea0.png)


