### PR TITLE
fix: removed duplicated `ip-restriction` plugin

### DIFF
--- a/website/static/data/plugins.json
+++ b/website/static/data/plugins.json
@@ -142,10 +142,6 @@
         "description": "The plugin allows you to restrict access to a Service or a Route by either whitelisting or blacklisting IP addresses"
       },
       {
-        "name": "ip-restriction",
-        "description": "The plugin allows you to restrict access to a Service or a Route by either whitelisting or blacklisting IP addresses"
-      },
-      {
         "name": "ua-restriction",
         "description": "The plugin allows you to restrict access to a Route or Service based on the User-Agent header with an allowlist and a denylist"
       },


### PR DESCRIPTION
Currently there are two: 
![dup](https://user-images.githubusercontent.com/39619599/231749707-295db87d-e367-49ae-be94-a1699ae91245.png)
