### PR TITLE
fix: apisix LTS version in nav 

### DIFF
--- a/config/apisix-versions.js
+++ b/config/apisix-versions.js
@@ -8,7 +8,7 @@ const versions = ['2.12', '2.13', '2.14', '2.15', '3.0', '3.1', '3.2', '3.3'];
 /**
  * @type {Array<string>} LTS version list
  */
-const LTSVersions = ['2.15'];
+const LTSVersions = ['3.3'];
 
 /**
  * @type {{[origin: string]: string}} version display name mapping to origin name

--- a/config/apisix-versions.js
+++ b/config/apisix-versions.js
@@ -8,7 +8,7 @@ const versions = ['2.12', '2.13', '2.14', '2.15', '3.0', '3.1', '3.2', '3.3'];
 /**
  * @type {Array<string>} LTS version list
  */
-const LTSVersions = ['3.3'];
+const LTSVersions = ['3.2'];
 
 /**
  * @type {{[origin: string]: string}} version display name mapping to origin name


### PR DESCRIPTION
Fixes: #[Add issue number here]

> _Question from deng_
>
> 注意到 apache site 上 downloads 的 LTS 版本每次都会 bump 成 latest release version
> https://apisix.apache.org/downloads/
> 
> 与同站上文档 LTS 不符合：
> https://apisix.apache.org/docs/apisix/getting-started/README/

Changes:

should be merged after https://github.com/apache/apisix-website/pull/1581

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
