### PR TITLE
docs: fix error in lenovo case blog

### DIFF
--- a/blog/en/blog/2023/06/02/lenovo-uses-apisix.md
+++ b/blog/en/blog/2023/06/02/lenovo-uses-apisix.md
@@ -17,6 +17,8 @@ canonical_url: ""
 cover_url: "https://static.apiseven.com/uploads/2023/06/05/PBdaOToi_Lenovo-cover-APISIX.png"
 ---
 
+<!--truncate-->
+
 ## Overview
 
 I'm Leon Yang, a Senior IT Architect at Lenovo, dedicated to promoting the reuse of software engineering components and building a sharing technology ecosystem. In the past two years, I have published more than 20 patents in enterprise software, big data, and artificial intelligence.


### PR DESCRIPTION
Fixes: #1606 and https://github.com/apache/apisix-website/pull/1603

Changes:

Add `<!--truncate-->` in Lenovo user case blog to fix the display in blog summary page.
