### PR TITLE
docs: fix Grafana dashboard and Product table images in Poor Man's API blog

### DIFF
--- a/blog/en/blog/2022/11/23/poor-man-api.md
+++ b/blog/en/blog/2022/11/23/poor-man-api.md
@@ -36,7 +36,7 @@ Instead of writing our REST API, we use the PostgREST component:
 
 Let's apply it to a simple use case. Here's a `product` table that I want to expose via a CRUD API:
 
-![Product table]https://blog.frankel.ch/assets/generated/poor-man-api/table.svg
+![Product table](https://blog.frankel.ch/assets/generated/poor-man-api/table.svg)
 
 Note that you can find the whole source code on [GitHub](https://github.com/ajavageek/poor-man-api) to follow along.
 
@@ -345,7 +345,7 @@ curl http://apisix:9080/apisix/admin/global_rules/2 -H 'X-API-KEY: 123xyz' -X PU
 
 Send a couple of queries and open the Grafana dashboard. It should look similar to this:
 
-![Grafana dashboard]https://blog.frankel.ch/assets/resources/poor-man-api/grafana.jpg
+![Grafana dashboard](https://blog.frankel.ch/assets/resources/poor-man-api/grafana.jpg)
 
 ## Conclusion
 


### PR DESCRIPTION
Changes:

Two images are not listed correctly in markdown syntax, as a result, they would not show up in the correct way.

I also notice an image `![Proto model project structure](https://blog.frankel.ch/assets/resources/grpc-client-side/model-project-structure.jpg)` is using the correct syntax yet not showing up in https://apisix.apache.org/blog/2023/03/16/grpc-client-side/.

But I want to fix syntax error first and see how it goes. If this does not work, the next option is to upload all of them to https://drive.api7.ai/ as suggested in https://github.com/apache/apisix-website/pull/1518#pullrequestreview-1322161979, and replace the image links.

Screenshots of the current status:

Link: https://apisix.apache.org/blog/2022/11/23/poor-man-api/

![image](https://github.com/apache/apisix-website/assets/36651058/924599a7-9be2-4581-a7aa-b29b5dae3243)


<img width="989" alt="截屏2023-06-07 21 58 37" src="https://github.com/apache/apisix-website/assets/36651058/e68b732e-98b1-452f-bffb-e562262d1f54">
