### PR TITLE
fix: remove doc event poster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,4 @@ scripts/temp/**
 /website/src/pages/edit.*
 /website/src/css/edit.*
 /blog/src/theme/Footer/
-/doc/src/theme/Footer/
 website/src/theme/Footer/event-poster-card.json

--- a/scripts/generate-event-poster-card.sh
+++ b/scripts/generate-event-poster-card.sh
@@ -6,5 +6,4 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")/..
 
 cp ${SCRIPTPATH}/config/event-poster-card.json ${SCRIPTPATH}/website/src/theme/Footer/
-cp ${SCRIPTPATH}/website/src/theme/Footer/* ${SCRIPTPATH}/doc/src/theme/Footer/
 cp ${SCRIPTPATH}/website/src/theme/Footer/* ${SCRIPTPATH}/blog/src/theme/Footer/


### PR DESCRIPTION
Fixes: #[Add issue number here]

There are some issues with event poster builds in the doc directory that needs to be fixed, so remove the event poster from the doc for now and fix the main branch build failure.


Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
