### PR TITLE
added action for link checking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,3 +129,11 @@ jobs:
           publish_dir: website/build
           publish_branch: asf-site
           force_orphan: true
+
+      - name: Run linkinator
+        uses: JustinBeckwith/linkinator-action@v1
+        with:
+          path: website/build
+          recursive: true
+          verbosity: error
+          skip: "^(?!http://localhost)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,3 +137,4 @@ jobs:
           recursive: true
           verbosity: error
           skip: "^(?!http://localhost)"
+gi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,4 +137,3 @@ jobs:
           recursive: true
           verbosity: error
           skip: "^(?!http://localhost)"
-gi


### PR DESCRIPTION
Fixes: [#9721](https://github.com/apache/apisix/issues/9721)
Changes:

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I've found an issue with the current approach to finding broken links, as many of the reported broken links are encountering CORS-related errors, not being truly broken. However, we can get accurate results by using the provided [Linkinator GitHub Action](https://github.com/marketplace/actions/linkinator).

I have added the action to run `linkinator` after the website gets deployed.

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
