### PR TITLE
feat : Markdown Link Check Action

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,10 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^(https?://)?(127.0.0.1|localhost|192.168.33.1|somehost\\.com)"
+        }
+    ],
+    "aliveStatusCodes": [
+        200
+    ]
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,10 +130,3 @@ jobs:
           publish_branch: asf-site
           force_orphan: true
 
-      - name: Run linkinator
-        uses: JustinBeckwith/linkinator-action@v1
-        with:
-          path: website/build
-          recursive: true
-          verbosity: error
-          skip: "^(?!http://localhost)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,3 +129,11 @@ jobs:
           publish_dir: website/build
           publish_branch: asf-site
           force_orphan: true
+
+      - name: Run linkinator
+        uses: JustinBeckwith/linkinator-action@v1
+        with:
+          path: website/build
+          recursive: true
+          verbosity: error
+          skip: "^(?!http://localhost)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,3 +137,4 @@ jobs:
           recursive: true
           verbosity: error
           skip: "^(?!http://localhost)"
+gi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,4 +137,3 @@ jobs:
           recursive: true
           verbosity: error
           skip: "^(?!http://localhost)"
-gi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,4 +129,3 @@ jobs:
           publish_dir: website/build
           publish_branch: asf-site
           force_orphan: true
-

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -36,14 +36,23 @@ jobs:
         run: |
           yarn sync-docs && git status
 
-      - name: Check Links
-        run: |
-          yarn workspace scripts link-checker && git status
-
-      - name: Archive Broken Links List
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Run link check
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          name: broken-links.json
-          path: scripts/brokenLinks.json
-          retention-days: 5
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/mlc_config.json'
+          folder-path: 'doc/docs/, doc/i18n/zh/'
+      
+      # - name: Check Links
+      #   run: |
+      #     yarn workspace scripts link-checker && git status
+
+      # - name: Archive Broken Links List
+      #   uses: actions/upload-artifact@v3
+      #   if: always()
+      #   with:
+      #     name: broken-links.json
+      #     path: scripts/brokenLinks.json
+      #     retention-days: 5
+

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -43,16 +43,4 @@ jobs:
           use-verbose-mode: 'yes'
           config-file: '.github/mlc_config.json'
           folder-path: 'doc/docs/, doc/i18n/zh/'
-      
-      # - name: Check Links
-      #   run: |
-      #     yarn workspace scripts link-checker && git status
-
-      # - name: Archive Broken Links List
-      #   uses: actions/upload-artifact@v3
-      #   if: always()
-      #   with:
-      #     name: broken-links.json
-      #     path: scripts/brokenLinks.json
-      #     retention-days: 5
-
+        continue-on-error: true


### PR DESCRIPTION
Fixes: [#9721](https://github.com/apache/apisix/issues/9721)

I've found an issue with the current approach to finding broken links, as many of the reported broken links are encountering CORS-related errors, not being truly broken. However, we can get accurate results by using the provided [Markdown Link Check](https://github.com/marketplace/actions/markdown-link-check).

Changes:
I have added the action to run `markdown-link-check` in the `link-check` workflow.

Current Issue: 
![image](https://github.com/apache/apisix-website/assets/61664827/cd9e149d-1db3-4503-8b8e-426ffe5b1f30)

These are not broken links

Fixed Issue:
![image](https://github.com/apache/apisix-website/assets/61664827/e4b253ed-df5a-4a78-8ef5-f339f4f592cb)

All the links in the file are verified to be correct. 

Additionally, I have addressed the issue where the current approach was mistakenly identifying localhost links as broken links. To fix this, I included a [configuration file](https://github.com/apache/apisix-website/blob/4b80a8486fbcd0df6513f445c68c2244d2e28a76/.github/mlc_config.json) to ignore those specific links during the checking process. Now, the link checker should function more accurately and not flag localhost links as broken.
![image](https://github.com/apache/apisix-website/assets/61664827/97792ead-7760-4900-8ffe-a2fa54a67ea8)
