### PR TITLE
site: Update twitter new x icon

### DIFF
--- a/doc/src/theme/Footer/index.tsx
+++ b/doc/src/theme/Footer/index.tsx
@@ -11,7 +11,7 @@ import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { Icon } from '@iconify/react';
 import githubIcon from '@iconify/icons-akar-icons/github-fill';
-import twitterIcon from '@iconify/icons-ri/twitter-x-fill';
+import twitterXFill from '@iconify/icons-ri/twitter-x-fill';
 import slackIcon from '@iconify/icons-akar-icons/slack-fill';
 import youtubeIcon from '@iconify/icons-akar-icons/youtube-fill';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
@@ -63,7 +63,7 @@ const footer = {
           to: '/docs/general/join',
         },
         {
-          icon: twitterIcon,
+          icon: twitterXFill,
           label: 'Twitter',
           to: 'https://twitter.com/ApacheAPISIX',
         },


### PR DESCRIPTION
Fixes: #1677 #1678 

Changes:

Just looked up the Iconify site on how to code this.

Since Docusaurus is based on React, you'd change the modification to `import twitterXFill from '@iconify/icons-ri/twitter-x-fill';` and it should work properly. Then change the variable name in line 67 to `twitterXFill` as well.

Check out https://icon-sets.iconify.design/ri/twitter-x-fill/ for detail info.
