### PR TITLE
Update building-apisix-in-ubuntu-for-arm.md

### DIFF
--- a/blog/en/blog/2022/01/11/building-apisix-in-ubuntu-for-arm.md
+++ b/blog/en/blog/2022/01/11/building-apisix-in-ubuntu-for-arm.md
@@ -150,7 +150,7 @@ make install
 
 Before starting Apache APISIX you need to install etcd, more details can refer to the [official documentation](https://apisix.apache.org/docs/apisix/2.10/install-dependencies/#ubuntu-1604--1804).
 
-:::info
+:::note
 Because the installation tutorial was not written for arm, although etcd, was successfully installed, etcd could not be run successfully due to the default use of x86 binaries. The specific part of stepping on the pit will not be repeated here, but will directly put the correct steps for your reference.
 :::
 

--- a/blog/zh/blog/2022/01/11/building-apisix-in-ubuntu-for-arm.md
+++ b/blog/zh/blog/2022/01/11/building-apisix-in-ubuntu-for-arm.md
@@ -150,7 +150,7 @@ make install
 
 启动 Apache APISIX 之前需要先安装 etcd，具体安装步骤可参考[官方文档](https://apisix.apache.org/docs/apisix/2.10/install-dependencies/#ubuntu-1604--1804)
 
-:::info 提示
+:::note
 由于该安装教程并不是针对 arm 写的，虽然成功安装了 etcd，但未能成功将 etcd 运行起来，原因是由于默认使用 x86 的二进制文件导致。具体踩坑部分这里就不再赘述，直接放上正确步骤供大家参考。
 :::
 


### PR DESCRIPTION
```:::info``` doesn't work, the text was hidden
<img width="1138" alt="Screenshot 2023-10-25 at 4 31 58 PM" src="https://github.com/apache/apisix-website/assets/5351390/e6d632d5-c46b-48ba-a11a-523b232b6696">

current blog link: https://apisix.apache.org/blog/2022/01/11/building-apisix-in-ubuntu-for-arm/#run-the-etcd-in-docker 

Fixes: use `:::note` instead

Changes:

use `:::note` instead

Screenshots of the change:

