### PR TITLE
fix: deploy ci failed

### DIFF
--- a/scripts/special-process-v2md.sh
+++ b/scripts/special-process-v2md.sh
@@ -8,9 +8,11 @@ BASEDIR=$(dirname $0)/..
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sed -i '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs/apisix-ingress-controller/references/v2.mdx
   sed -i '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.7.0/references/v2.mdx
+  sed -i '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.8.0/references/v2.mdx
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   sed -i '' '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs/apisix-ingress-controller/references/v2.mdx
   sed -i '' '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.7.0/references/v2.mdx
+  sed -i '' '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.8.0/references/v2.mdx
 else
   echo "Unsupported OS: $OSTYPE"
   exit 1


### PR DESCRIPTION
Fixes: the deploy ci failed

Changes:

Fixed the issue of failure to deploy CI due to `markdown-link-check-disable` not being correctly removed due to the new version released by [apisix-ingress-controller](https://github.com/apache/apisix-ingress-controller).

<img width="330" alt="image" src="https://github.com/apache/apisix-website/assets/72343596/d7b393c8-e739-4bae-874e-e793686b128d">

