### PR TITLE
fix: docs search icon overlapping (#1719)

### DIFF
--- a/doc/src/css/customTheme.scss
+++ b/doc/src/css/customTheme.scss
@@ -413,10 +413,6 @@ a:hover {
 }
 
 @media only screen and (min-width: 768px) {
-  .react-toggle {
-    display: none;
-  }
-
   .arch-card-caption > p {
     width: 50%;
   }

--- a/doc/src/theme/DocPage/index.tsx
+++ b/doc/src/theme/DocPage/index.tsx
@@ -109,18 +109,8 @@ const DocPageContent = ({
   );
 
   useEffect(() => {
-    const childrenCount = document.querySelector('.navbar__items--right').childElementCount;
-    const el = document.querySelector('.navbar__items--right').childNodes[
-      childrenCount - 2
-    ] as HTMLDivElement;
-    el.style.display = window.innerWidth > 745 ? 'block' : 'none';
-
     const navbarLink = document.querySelectorAll('.navbar__link')[0] as HTMLAnchorElement;
     navbarLink.innerText = navbarLinkMap[currentPage];
-
-    return () => {
-      el.style.display = 'none';
-    };
   }, []);
 
   const toggleSidebar = useCallback(() => {


### PR DESCRIPTION
Fixes: #1719


### Before Changes:
![i-1719](https://github.com/apache/apisix-website/assets/91601717/55665f48-859a-42f8-8f37-af6f891c2f73)

### After Changes:
![changes](https://github.com/apache/apisix-website/assets/91601717/ea996513-36ad-499d-81bf-52f709f53524)
