### PR TITLE
fix: Fix canonical links

### DIFF
--- a/blog/en/blog/2024/02/13/apisix-owasp-coraza-core-ruleset.md
+++ b/blog/en/blog/2024/02/13/apisix-owasp-coraza-core-ruleset.md
@@ -17,6 +17,10 @@ tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/10/vVlFQu7C_img-HDlf4Xx9m1iqS0Ico3oBZ.png
 ---
 
+<head>
+    <link rel="canonical" href="https://blog.frankel.ch/apisix-owasp-coraza-core-ruleset/" />
+</head>
+
 >The Open Worldwide Application Security Project is an online community that produces freely available articles, methodologies, documentation, tools, and technologies in the fields of IoT, system software and web application security. The OWASP provides free and open resources. It is led by a non-profit called The OWASP Foundation. The OWASP Top 10 - 2021 is the published result of recent research based on comprehensive data compiled from over 40 partner organizations.
 >
 > --[OWASP website](https://owasp.org/)

--- a/blog/en/blog/2024/02/20/secure-api-practices-apisix-1.md
+++ b/blog/en/blog/2024/02/20/secure-api-practices-apisix-1.md
@@ -19,6 +19,10 @@ tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/15/kgIjhRXf_img-BuLDzx81CexYQAzkaF36h_large.webp
 ---
 
+<head>
+    <link rel="canonical" href="https://blog.frankel.ch/secure-api-practices-apisix/1/" />
+</head>
+
 >A couple of months ago, I stumbled upon this list of  Secure your API with these [16 practices to secure your API](https://www.linkedin.com/posts/brijpandeyji_secure-your-api-with-these-16-practices-activity-7094020647529369601-5kzQ/):
 >
 > 1. Authentication 🕵️️ - Verifies the identity of users accessing APIs.

--- a/blog/en/blog/2024/02/27/secure-api-practices-apisix-2.md
+++ b/blog/en/blog/2024/02/27/secure-api-practices-apisix-2.md
@@ -19,6 +19,9 @@ tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/15/kgIjhRXf_img-BuLDzx81CexYQAzkaF36h_large.webp
 ---
 
+<head>
+    <link rel="canonical" href="https://blog.frankel.ch/secure-api-practices-apisix/2/" />
+</head>
 
 >[Last week](https://blog.frankel.ch/secure-api-practices-apisix/1/), we listed 16 practices to help secure one's APIs and described how to implement them with Apache APISIX.
 >


### PR DESCRIPTION
I have forgotten canonical links in a couple of cross posts.

Reminder: without the canonical link, SEO (i.e., Google) flags the content of one of the site as duplicate and gives a huge SEO penalty.
