### PR TITLE
fix: add a new line between brief and introduction

### DIFF
--- a/blog/en/blog/2024/05/31/monthly-report.md
+++ b/blog/en/blog/2024/05/31/monthly-report.md
@@ -8,6 +8,7 @@ image: https://static.apiseven.com/uploads/2024/05/31/cYKGTnFs_may-cover-en.png
 
 > We have recently made some additions and improvements to specific features within Apache APISIX. These include supporting the hcv namespace in HashiCorp Vault and allowing setting headers in introspection requests. For detailed information, please read the monthly report.
 <!--truncate-->
+
 ## Introduction
 
 From its inception, the Apache APISIX project has embraced the ethos of open-source community collaboration, propelling it into the ranks of the most active global open-source API gateway projects. The proverbial wisdom of 'teamwork makes the dream work' rings true in our way and is made possible by the collective effort of our community.

--- a/blog/zh/blog/2024/05/31/monthly-report.md
+++ b/blog/zh/blog/2024/05/31/monthly-report.md
@@ -7,6 +7,7 @@ image: https://static.apiseven.com/uploads/2024/05/31/Z09ywV24_may-cover-cn.png
 ---
 > 最近，我们新增并改进了 Apache APISIX 的部分功能，包含在 HashiCorp Vault 中支持 hcv namespace 和 在 OIDC 插件中允许在自省请求中设置标头。有关更多功能新亮点，请阅读本期月报。
 <!--truncate-->
+
 ## 导语
 
 Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便崭露头角，如今已经成为全球最活跃的开源 API 网关项目之一。正如谚语所言，“众人拾柴火焰高”，这一辉煌成就，得益于整个社区伙伴的协同努力。


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

Add a new line between brief and intro to make intro a title within the actual content.

The current introduction titles have wrong format.

This PR will fix the format issues in May monthly report in English and Chinese.

<img width="1725" alt="截屏2024-06-19 19 50 03" src="https://github.com/apache/apisix-website/assets/36651058/2c586069-6538-443d-a789-a55702a7b3d9">
