### PR TITLE
fix: correct `/v1/discovery/kubernetes/dump` new feature description in the 3.10.0 release notes

### DIFF
--- a/blog/en/blog/2024/08/14/release-apache-apisix-3.10.0.md
+++ b/blog/en/blog/2024/08/14/release-apache-apisix-3.10.0.md
@@ -121,15 +121,15 @@ curl "http://127.0.0.1:9180/apisix/admin/ssls" -X PUT -d '
 
 For more information, see [PR #11277](https://github.com/apache/apisix/pull/11277).
 
-### Add K8s discovery memory dump endpoint to Control API
+### List K8s cluster endpoints in Control API discovery memory dump
 
-The Control API now offers a new endpoint `/v1/discovery/kubernetes/dump` to see the nodes discovered by K8s discovery. For example:
+The Control API `/v1/discovery/kubernetes/dump` endpoint now lists K8s cluster endpoints. For example:
 
 ```shell
 curl http://127.0.0.1:9090/v1/discovery/kubernetes/dump | jq
 ```
 
-You will see the discovered node information:
+You will see the cluster endpoints:
 
 ```json
 {

--- a/blog/zh/blog/2024/08/14/release-apache-apisix-3.10.0.md
+++ b/blog/zh/blog/2024/08/14/release-apache-apisix-3.10.0.md
@@ -121,15 +121,15 @@ curl "http://127.0.0.1:9180/apisix/admin/ssls" -X PUT -d '
 
 有关更多信息，请参阅 [PR #11277](https://github.com/apache/apisix/pull/11277)。
 
-### Control API 支持查看 K8s 服务发现的节点
+### 在 Control API 支持查看 K8s 服务发现集群节点
 
-Control API 现在提供了一个新端点 `/v1/discovery/kubernetes/dump`，用于查看 K8s 发现发现的节点。例如：
+控制 API `/v1/discovery/kubernetes/dump` 支持查看 K8s 服务发现集群节点。例如：
 
 ```shell
 curl http://127.0.0.1:9090/v1/discovery/kubernetes/dump | jq
 ```
 
-您将看到发现的节点信息：
+您将看到发现的集群节点信息：
 
 ```json
 {


### PR DESCRIPTION
https://github.com/apache/apisix/pull/11111 didn't add the endpoint; it exposed more information (cluster endpoints). The PR title was misleading.