### PR TITLE
fix:  the static resource loading exception encountered

### DIFF
--- a/config/ssrTemplate.js
+++ b/config/ssrTemplate.js
@@ -19,10 +19,10 @@ module.exports = {
       <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-Demi.otf"  as="font" type="font/otf" crossorigin>
       <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-ExtraBold.otf" as="font" type="font/otf" crossorigin>
       <% it.scripts.forEach((script) => { %>
-        <link rel="preload" href="<%= process.env.preview ? '' : 'https://apisix-website-static.apiseven.com' %><%= it.baseUrl %><%= script %>" as="script">
+        <link rel="preload" href="<%= process.env.preview ? '' : 'https://apisix.apache.org' %><%= it.baseUrl %><%= script %>" as="script">
       <% }); %>
       <% it.stylesheets.forEach((stylesheet) => { %>
-        <link rel="stylesheet" href="<%= process.env.preview ? '' : 'https://apisix-website-static.apiseven.com' %><%= it.baseUrl %><%= stylesheet %>" />
+        <link rel="stylesheet" href="<%= process.env.preview ? '' : 'https://apisix.apache.org' %><%= it.baseUrl %><%= stylesheet %>" />
       <% }); %>
       <!-- Matomo from the ASF -->
       <script>
@@ -50,7 +50,7 @@ module.exports = {
         <%~ it.appHtml %>
       </div>
       <% it.scripts.forEach((script) => { %>
-        <script src="<%= process.env.preview ? '' : 'https://apisix-website-static.apiseven.com' %><%= it.baseUrl %><%= script %>"></script>
+        <script src="<%= process.env.preview ? '' : 'https://apisix.apache.org' %><%= it.baseUrl %><%= script %>"></script>
       <% }); %>
       <%~ it.postBodyTags %>
     </body>


### PR DESCRIPTION
When using a global proxy, the page cannot be accessed normally:

![img_v3_02e7_aab53a46-04de-44b7-b61a-e264159ff01g](https://github.com/user-attachments/assets/7798901e-0bbf-4428-9a70-6ff110f5887a)

Changes:

1. remove unavailable CDN domains.
2. use the original domain name: apisix.apache.org

