### PR TITLE
fix: the build error **Invalid docs option "versions": unknown versions (2.15) found**

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -90,11 +90,6 @@ module.exports = {
             projectName: 'apisix',
           });
         },
-        versions: {
-          2.15: {
-            banner: 'none',
-          },
-        },
       },
     ],
     [


### PR DESCRIPTION
Fixes: #[Add issue number here]

1. Because we archive apisix documentation up to 3.8.0, so we can remove the 2.15 config, it's causes the main branch build error

refer #1832 

Changes:

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
