### PR TITLE
fix: remove Contributor Over Time section

### DIFF
--- a/website/src/pages/team.tsx
+++ b/website/src/pages/team.tsx
@@ -299,15 +299,7 @@ const Team: FC = () => {
           </Translate>
         </SectionSubtitle>
         <RepoCardsContainer>{repoComponents}</RepoCardsContainer>
-        <SectionTitle>
-          <Translate id="team.webpage.content.ContributorOverTime">Contributor Over Time</Translate>
-        </SectionTitle>
-        <SectionSubtitle>
-          <Translate id="team.webpage.content.ContributorOverTimeNote">
-            Note: This graph contains contributors from all repos under Apache APISIX
-          </Translate>
-        </SectionSubtitle>
-        <img src="https://contributor-graph-api.apiseven.com/contributors-svg?repo=apache/apisix&merge=true" alt="Contributor Over Time" />
+        
         <ContributeCard>
           <ContributeCardLeftSide>
             <ContributeCardTitle>


### PR DESCRIPTION
Removed the as asked Contributor Over Time section
![Monosnap Commented out missing contributor graph image in the team page by Jitmisra · Pull Request #1840 · apacheapisix-website 2025-01-18 16-32-10](https://github.com/user-attachments/assets/d54b8415-59a9-4fe5-b638-2bbe951f73c2)
