### PR TITLE
removed the google calendar in event calendar which is not loading

### DIFF
--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -1,25 +1,15 @@
 ---
 id: events
-title: Events calendar
+title: Events
 keywords:
   - Events
   - Conferences
   - Workshops
   - Meetups
-description: This page provides information about upcoming Apache APISIX's community events where you can track meetups, conferences, and workshops.
+description: This page provides information about previous Apache APISIX's community events.
 ---
 
-You can [subscribe to this calendar](https://calendar.google.com/calendar/embed?src=c_sonnl869vh6tjd9frj7t6rcma0%40group.calendar.google.com&ctz=Asia%2FKolkata) to get notified about online community meetups and events around the world with APISIX maintainers.
-
-:::note
-
-To add your event to the calendar, please open an issue in the [specified format](https://github.com/apache/apisix-website/issues/new/choose).
-
-:::
-
-<!-- <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ea5451&ctz=UTC&showCalendars=0&showTabs=0&showPrint=0&title&showTitle=0&showNav=1&showDate=1&src=Y19zb25ubDg2OXZoNnRqZDlmcmo3dDZyY21hMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23D50000" width="800" height="600" frameborder="0" scrolling="no"></iframe> -->
-
-## Apache APISIX Community Meetup Malaysia and Singapore
+## Apache APISIX Community Meetup Malaysia and Singapore 2023
 
 Apache APISIX Community Meetups are a place where APISIX users, contributors, and maintainers come together to discuss everything APISIX.
 
@@ -33,7 +23,7 @@ As an attendee, you can expect talks and workshops related to but not limited to
 
 See below to learn more about the events.
 
-### Malaysia Meetup
+## Malaysia Meetup
 
 **Date**: 4th July 2023, 10 AM to 4 PM
 
@@ -41,24 +31,24 @@ See below to learn more about the events.
 
 To join the event for FREE, [submit this form](https://forms.gle/sUmjdBQAMPjDehYR8).
 
-#### Schedule
+### Schedule
 
 [Download the PDF version](https://bit.ly/apisix-meetup-malaysia).
 
-| Talk                                         | Speaker           | Time  |
-| -------------------------------------------- | ----------------- | ----- |
-| Welcome remarks                              | Navendu Pottekkat | 10:15 |
-| APISIX-the past, present, and the future     | Ming Wen          | 10:30 |
-| How banking companies use APISIX             | Yuansheng Wang    | 11:00 |
-| Dynamic, user credentials-based routing      | Bobur Umurzokov   | 11:30 |
-| Powering the world's data centers with AMD   | Koh Lian Chong    | 12:00 |
-| Elevating Apache APISIX to the cloud         | Chao Zhang        | 1:30  |
-| Introduction to Apache CloudStack            | Kiran Chavala     | 2:00  |
-| Managing data residency                      | Nicolas Fränkel   | 2:30  |
-| How is APISIX fast?                          | Navendu Pottekkat | 3:00  |
-| Using ChatGPT to write custom APISIX plugins | Bobur Umurzokov   | 3:30  |
+| Talk                                                  | Speaker                   | Time  |
+| ----------------------------------------------------- | ------------------------- | ----- |
+| Welcome remarks                                       | Navendu Pottekkat         | 10:15 |
+| APISIX-the past, present, and the future              | Ming Wen                  | 10:30 |
+| How banking companies use APISIX                      | Yuansheng Wang            | 11:00 |
+| Dynamic, user credentials-based routing               | Bobur Umurzokov           | 11:30 |
+| Powering the world's data centers with AMD            | Koh                       | 2:00  |
+| Elevating Apache APISIX to the cloud                  | Chao Zhang                | 2:30  |
+| Introduction to Apache CloudStack                     | Kiran Chavala             | 3:00  |
+| Managing data residency                               | Nicolas Fränkel           | 3:30  |
+| How is APISIX fast?                                   | Navendu Pottekkat         | 4:00  |
+| Using ChatGPT to write custom APISIX plugins          | Bobur Umurzokov           | 4:30  |
 
-### Singapore Meetup
+## Singapore Meetup
 
 **Date**: 8th July 2023, 10 AM to 1 PM
 
@@ -66,25 +56,22 @@ To join the event for FREE, [submit this form](https://forms.gle/sUmjdBQAMPjDehY
 
 To join the event for FREE, [submit this form](https://forms.gle/JSzVmfXon9HCTSee9).
 
-#### Schedule
+### Schedule
 
 | Talk                                                  | Speaker                   | Time  |
 | ----------------------------------------------------- | ------------------------- | ----- |
-| Welcome remarks                                       | Navendu Pottekkat         | 10:15 |
-| How companies using APISIX                            | Yuansheng Wang            | 10:30 |
-| Best practices for building reliable APIs             | Navendu Pottekkat         | 11:00 |
+| Introduction to Apache APISIX                         | Ming Wen                  | 10:00 |
+| Roadmap to APISIX 3.0                                 | Yuansheng Wang            | 10:30 |
+| How is APISIX fast?                                   | Navendu Pottekkat         | 11:00 |
 | Hands-on with Apache APISIX                           | Zhiyuan Ju                | 11:30 |
 | Contributing to an Apache Software Foundation project | Apache APISIX maintainers | 12:00 |
 
-## Monthly Community Meetings
+## Community Meetings
 
-APISIX users, contributors, and maintainers get together once a month in an online meeting to discuss new features, share user stories, highlight contributors, and have more APISIX-related discussions.
+APISIX users, contributors, and maintainers get together in an online meeting to discuss new features, share user stories, highlight contributors, and have more APISIX-related discussions. Everyone is welcome to join this open meeting as a listener or a speaker.
 
-Everyone is welcome to join this open meeting as a listener or a speaker. To get an invite to the meeting, fill out [this form](https://apisix.apache.org/community-meeting-signup).
-
-If you would like to propose a topic for discussion, [send a message on Slack](https://apisix.apache.org/docs/general/join/#join-the-slack-channel).
+If you would like to propose a topic for discussion, join in our Slack channel and [send a message](https://apisix.apache.org/docs/general/join/#join-the-slack-channel).
 
 To learn more:
 
-- [APISIX Community Meeting Minutes](https://docs.google.com/document/d/1BKizjE_vGxxYCSrBehyGsa4Q7eS8DLIdgumC6fRm4TQ/edit)
 - [Previous meeting recordings](https://youtube.com/playlist?list=PLAoKZlos1sznjgFQsm31QAWeJmv8_w7SP)

--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -17,7 +17,7 @@ To add your event to the calendar, please open an issue in the [specified format
 
 :::
 
-<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ea5451&ctz=UTC&showCalendars=0&showTabs=0&showPrint=0&title&showTitle=0&showNav=1&showDate=1&src=Y19zb25ubDg2OXZoNnRqZDlmcmo3dDZyY21hMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23D50000" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<!-- <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ea5451&ctz=UTC&showCalendars=0&showTabs=0&showPrint=0&title&showTitle=0&showNav=1&showDate=1&src=Y19zb25ubDg2OXZoNnRqZDlmcmo3dDZyY21hMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23D50000" width="800" height="600" frameborder="0" scrolling="no"></iframe> -->
 
 ## Apache APISIX Community Meetup Malaysia and Singapore
 

--- a/website/docs/general/events.md
+++ b/website/docs/general/events.md
@@ -8,7 +8,6 @@ keywords:
   - Meetups
 description: This page provides information about previous Apache APISIX's community events.
 ---
-
 ## Apache APISIX Community Meetup Malaysia and Singapore 2023
 
 Apache APISIX Community Meetups are a place where APISIX users, contributors, and maintainers come together to discuss everything APISIX.
@@ -35,18 +34,18 @@ To join the event for FREE, [submit this form](https://forms.gle/sUmjdBQAMPjDehY
 
 [Download the PDF version](https://bit.ly/apisix-meetup-malaysia).
 
-| Talk                                                  | Speaker                   | Time  |
-| ----------------------------------------------------- | ------------------------- | ----- |
-| Welcome remarks                                       | Navendu Pottekkat         | 10:15 |
-| APISIX-the past, present, and the future              | Ming Wen                  | 10:30 |
-| How banking companies use APISIX                      | Yuansheng Wang            | 11:00 |
-| Dynamic, user credentials-based routing               | Bobur Umurzokov           | 11:30 |
-| Powering the world's data centers with AMD            | Koh                       | 2:00  |
-| Elevating Apache APISIX to the cloud                  | Chao Zhang                | 2:30  |
-| Introduction to Apache CloudStack                     | Kiran Chavala             | 3:00  |
-| Managing data residency                               | Nicolas Fränkel           | 3:30  |
-| How is APISIX fast?                                   | Navendu Pottekkat         | 4:00  |
-| Using ChatGPT to write custom APISIX plugins          | Bobur Umurzokov           | 4:30  |
+| Talk                                         | Speaker           | Time  |
+| -------------------------------------------- | ----------------- | ----- |
+| Welcome remarks                              | Navendu Pottekkat | 10:15 |
+| APISIX-the past, present, and the future     | Ming Wen          | 10:30 |
+| How banking companies use APISIX             | Yuansheng Wang    | 11:00 |
+| Dynamic, user credentials-based routing      | Bobur Umurzokov   | 11:30 |
+| Powering the world's data centers with AMD   | Koh Lian Chong    | 12:00 |
+| Elevating Apache APISIX to the cloud         | Chao Zhang        | 1:30  |
+| Introduction to Apache CloudStack            | Kiran Chavala     | 2:00  |
+| Managing data residency                      | Nicolas Fränkel   | 2:30  |
+| How is APISIX fast?                          | Navendu Pottekkat | 3:00  |
+| Using ChatGPT to write custom APISIX plugins | Bobur Umurzokov   | 3:30  |
 
 ## Singapore Meetup
 
@@ -56,13 +55,13 @@ To join the event for FREE, [submit this form](https://forms.gle/sUmjdBQAMPjDehY
 
 To join the event for FREE, [submit this form](https://forms.gle/JSzVmfXon9HCTSee9).
 
-### Schedule
+#### Schedule
 
 | Talk                                                  | Speaker                   | Time  |
 | ----------------------------------------------------- | ------------------------- | ----- |
-| Introduction to Apache APISIX                         | Ming Wen                  | 10:00 |
-| Roadmap to APISIX 3.0                                 | Yuansheng Wang            | 10:30 |
-| How is APISIX fast?                                   | Navendu Pottekkat         | 11:00 |
+| Welcome remarks                                       | Navendu Pottekkat         | 10:15 |
+| How companies using APISIX                            | Yuansheng Wang            | 10:30 |
+| Best practices for building reliable APIs             | Navendu Pottekkat         | 11:00 |
 | Hands-on with Apache APISIX                           | Zhiyuan Ju                | 11:30 |
 | Contributing to an Apache Software Foundation project | Apache APISIX maintainers | 12:00 |
 


### PR DESCRIPTION
Fixes: #[removed the google calendar in event calendar which is not loading]

Changes:


![Monosnap Events calendar  Apache APISIX® -- Cloud-Native API Gateway 2025-01-20 09-56-33](https://github.com/user-attachments/assets/2a7f735d-413e-4f9d-b363-846750ecc5f7)
https://apisix.apache.org/docs/general/events/

 for now I have commented out  that link if you give me new link I will add it