### PR TITLE
fix: link check ci failed

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           yarn workspace scripts link-checker && git status
       - name: Archive Broken Links List
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: broken-links.json


### PR DESCRIPTION
Fixes: #[Add issue number here]

The link check ci failed, refer this: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Changes:

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
