### PR TITLE
fix: cloud-vs-open-source-vs-commercial-api-gateways

### DIFF
--- a/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
+++ b/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
@@ -23,6 +23,9 @@ tags: [Ecosystem]
 image: https://static.api7.ai/uploads/2025/02/17/gWz2QJYq_api-gateway-comparison.png
 ---
 
+This article explores the differences between cloud-managed, open-source, and commercial API gateways. It highlights key pros and cons, pricing risks, and strategic recommendations for businesses that anticipate API growth and hybrid cloud adoption.
+<!--truncate-->
+
 ## Introduction
 
 API gateways have become essential components in modern cloud architectures. They provide security, traffic management, observability, and service orchestration—critical for handling APIs at scale. However, with multiple API gateway solutions available, choosing the right one can be challenging.


### PR DESCRIPTION
add missing truncate
