### PR TITLE
fix: replace useBaseUrl to href

### DIFF
--- a/website/src/components/ArrowAnim.tsx
+++ b/website/src/components/ArrowAnim.tsx
@@ -1,13 +1,12 @@
 import type { FC } from 'react';
 import React from 'react';
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import Translate from '@docusaurus/Translate';
 
 const ArrowAnim: FC = () => (
   <Link
-    to={useBaseUrl('blog')}
+    href="/blog"
     className="btn-docs"
   >
     <div className="goto">

--- a/website/src/components/sections/Endcta.tsx
+++ b/website/src/components/sections/Endcta.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import Translate from '@docusaurus/Translate';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import useWindowType from '@theme/hooks/useWindowSize';
@@ -28,7 +27,7 @@ const EndCTA: FC = () => {
         )}
       </p>
       <div className={style.links}>
-        <Link to={useBaseUrl('docs/apisix/getting-started')} className="btn btn-download">
+        <Link href="/docs/apisix/getting-started" className="btn btn-download">
           <Translate id="hero.component.download.btn">Getting Started</Translate>
         </Link>
         <ArrowAnim />

--- a/website/src/components/sections/HeroSection.tsx
+++ b/website/src/components/sections/HeroSection.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import React from 'react';
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import Translate from '@docusaurus/Translate';
 
 import BrowserOnly from '@docusaurus/BrowserOnly';
@@ -47,7 +46,7 @@ const HeroSection: FC = () => (
         </Translate>
       </h3>
       <div className="hero-ctas">
-        <Link to={useBaseUrl('docs/apisix/getting-started')} className="btn btn-download">
+        <Link href="/docs/apisix/getting-started" className="btn btn-download">
           <Translate id="hero.component.download.btn">Getting Started</Translate>
         </Link>
         <ArrowAnim />

--- a/website/src/css/landing-sections/endcta.module.scss
+++ b/website/src/css/landing-sections/endcta.module.scss
@@ -54,7 +54,7 @@ $apisix-color: #e8433e;
 
   @include respond-below(sm) {
     min-height: 50vh;
-    margin: 0 1rem;
+    margin: 4rem 1rem 0;
     align-items: flex-start;
     padding: 100px 2rem;
 


### PR DESCRIPTION
Fixes: #[Add issue number here]

1. useBaseUrl hooks to jump the target link 404
