### PR TITLE
fix: disable dashboard next version doc config

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -99,6 +99,7 @@ module.exports = {
         path: 'docs/apisix-dashboard',
         showLastUpdateAuthor: true,
         showLastUpdateTime: true,
+        includeCurrentVersion: false,
         routeBasePath: '/docs/dashboard',
         sidebarPath: require.resolve('./docs/apisix-dashboard/sidebars.json'),
         editUrl(props) {

--- a/scripts/sync-docs.js
+++ b/scripts/sync-docs.js
@@ -137,6 +137,7 @@ const tasks = new Listr([
           },
           {
             title: `Extract ${project.name} next version documents`,
+            skip: () => project.name === 'apisix-dashboard',
             task: () => extractDocsNextVersionTasks(project, project.branch),
           },
         ]),


### PR DESCRIPTION
Fixes: #[Add issue number here]

Changes:

In order for the documentation site to render properly.

Temp solution from https://github.com/apache/apisix-website/pull/1912#pullrequestreview-2845530798.

Screenshots of the change:

<img width="2508" alt="image" src="https://github.com/user-attachments/assets/dacfe6e1-0ef2-46d1-bc9d-1942790d762f" />