### PR TITLE
fix: update commits to 39 to align with pictures and ZH-CN blog

### DIFF
--- a/blog/en/blog/2025/05/30/2025-may-monthly-report.md
+++ b/blog/en/blog/2025/05/30/2025-may-monthly-report.md
@@ -13,7 +13,7 @@ image: https://static.api7.ai/uploads/2025/05/30/cQZIKC0l_2025-may-monthly-repor
 
 From its inception, the Apache APISIX project has embraced the ethos of open-source community collaboration, propelling it into the ranks of the most active global open-source API gateway projects. The proverbial wisdom of 'teamwork makes the dream work' rings true in our way and is made possible by the collective effort of our community.
 
-From May 1st to May 30, 8 contributors made 38 commits to Apache APISIX. We sincerely appreciate your contributions to Apache APISIX.
+From May 1st to May 30, 8 contributors made 39 commits to Apache APISIX. We sincerely appreciate your contributions to Apache APISIX.
 
 ## Contributor Statistics
 


### PR DESCRIPTION
The current text '38' is not matching up with the pictures in EN and ZH-CN blog, or the texts in ZH-CN blog.

Update to '39' to match up

Fixes: #[Add issue number here]

Changes:

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->

<img width="865" alt="截屏2025-06-03 20 16 31" src="https://github.com/user-attachments/assets/a6411b6d-a749-45cc-aa32-740ea744ec34" />

<img width="871" alt="截屏2025-06-03 20 18 15" src="https://github.com/user-attachments/assets/db045e3b-b0c1-4e0b-a341-4c00dc9fd258" />

