### PR TITLE
docs: remove slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The website of <a href="https://github.com/apache/apisix/">Apache APISIX®</a>
 
 A cloud-native microservices API Gateway
 
-<a href="https://apisix.apache.org/slack"><img  width="150" src="./website/static/img/join-slack.png"></a>
+<a href="https://apisix.apache.org/docs/general/join/#join-the-slack-channel"><img  width="150" src="./website/static/img/join-slack.png"></a>
 
 </div>
 

--- a/website/docs/general/join.md
+++ b/website/docs/general/join.md
@@ -39,8 +39,4 @@ Once successfully unsubscribed, you will receive a Goodbye email from dev-help@a
 
 ## Join the Slack Channel
 
-You can join the Apache APISIX Slack channel in two ways:
-
-- Join Apache Software Foundation Slack workspace using [this invite](https://apisix.apache.org/slack) (_Please [open an issue](./submit-issue.md) if this link is expired_), and then join the **#apisix** channel (Channels -> Browse channels -> search for "apisix").
-
-- By [subscribing to the mailing list](#subscribe-to-the-mailing-list) and sending an email to the list ([dev@apisix.apache.org](mailto:dev@apisix.apache.org)) requesting help to join.
+By [subscribing to the mailing list](#subscribe-to-the-mailing-list) and sending an email to the list ([dev@apisix.apache.org](mailto:dev@apisix.apache.org)) requesting help to join.


### PR DESCRIPTION
Changes:

The Apache Foundation has changed its rules to allow only manual invitations to join, so remove the invite link.

<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

Screenshots of the change:

<!-- Add screenshots depicting the changes. -->
