### PR TITLE
docs: add redirect rules for APISIX 3.2 docs to netlify

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -43,6 +43,8 @@ Redirect 302 "/contributor-workshop-signup" "https://docs.google.com/forms/d/1LU
 Redirect 302 "/guest-blog-post" "https://forms.gle/unQpSm7FyqkfaSSP8/"
 RedirectMatch 302 "^/docs/apisix/getting-started/$" "/docs/apisix/getting-started/README/"
 RedirectMatch 302 "^/zh/docs/apisix/getting-started/$" "/zh/docs/apisix/getting-started/README/"
+RedirectMatch 302 ^/docs/apisix/3\.2/(.*)$ https://apache-apisix.netlify.app/docs/apisix/3.2/$1
+Redirect 302 /docs/apisix/3.2 https://apache-apisix.netlify.app/docs/apisix/3.2
 
 Redirect 301 "/docs/apisix/install" "/docs/apisix/how-to-build/"
 Redirect 301 "/docs/apisix/architecture-design/plugin/" "/docs/apisix/architecture-design/plugin-config/"

--- a/.htaccess
+++ b/.htaccess
@@ -43,8 +43,8 @@ Redirect 302 "/contributor-workshop-signup" "https://docs.google.com/forms/d/1LU
 Redirect 302 "/guest-blog-post" "https://forms.gle/unQpSm7FyqkfaSSP8/"
 RedirectMatch 302 "^/docs/apisix/getting-started/$" "/docs/apisix/getting-started/README/"
 RedirectMatch 302 "^/zh/docs/apisix/getting-started/$" "/zh/docs/apisix/getting-started/README/"
-RedirectMatch 302 ^/docs/apisix/3\.2/(.*)$ https://apache-apisix.netlify.app/docs/apisix/3.2/$1
-Redirect 302 /docs/apisix/3.2 https://apache-apisix.netlify.app/docs/apisix/3.2
+RedirectMatch 302 "^/docs/apisix/3\.2/plugins/(.*)$" "https://apache-apisix.netlify.app/docs/apisix/3.2/plugins/$1"
+RedirectMatch 302 "^/zh/docs/apisix/3\.2/plugins/(.*)$" "https://apache-apisix.netlify.app/zh/docs/apisix/3.2/plugins/$1"
 
 Redirect 301 "/docs/apisix/install" "/docs/apisix/how-to-build/"
 Redirect 301 "/docs/apisix/architecture-design/plugin/" "/docs/apisix/architecture-design/plugin-config/"


### PR DESCRIPTION
The original 3.2 documentation has been archived at https://apache-apisix.netlify.app/, and the original links no longer work. A redirect has been added to make the documentation accessible again via the old URLs.