### PR TITLE
fix: link in announcing-integration-of-apisix-and-ai-ml-api

### DIFF
--- a/blog/en/blog/2025/07/29/announcing-integration-of-apisix-and-ai-ml-api.md
+++ b/blog/en/blog/2025/07/29/announcing-integration-of-apisix-and-ai-ml-api.md
@@ -32,7 +32,7 @@ AI/ML API provides a unified OpenAI-compatible API with access to **300+ LLMs** 
 ### Prerequisites
 
 1. [Install APISIX](https://apisix.apache.org/docs/apisix/installation-guide/).
-2. Generate your API key on [AI/ML API dashboard](https://platform.openai.com/api-keys).
+2. Generate your API key on [AI/ML API dashboard](https://aimlapi.com/app/keys/).
   ![Generate AI/ML API Key](https://static.api7.ai/uploads/2025/07/30/dGXA7d0r_ai-ml-api-key.webp)
 
 ### Configure the Route


### PR DESCRIPTION
Fix the error link, which should be aimlapi: 
<img width="1120" height="458" alt="image" src="https://github.com/user-attachments/assets/c958ff60-d8a0-460f-8bbd-182d477d876e" />

