### PR TITLE
blog: correct datadog plugin update and breaking change in 3.14.0 release

### DIFF
--- a/blog/en/blog/2025/10/10/release-apache-apisix-3.14.0.md
+++ b/blog/en/blog/2025/10/10/release-apache-apisix-3.14.0.md
@@ -29,16 +29,6 @@ There are also a few important changes included in this release. Should you find
 
 ## Breaking Changes
 
-### Admin API no longer populates default values
-
-The Admin API will no longer automatically populate default values when writing configurations. Previously, when users submitted configurations through the Admin API, APISIX would automatically fill in default values for optional fields before storing them. This behavior has been removed to prevent user confusion and improve compatibility with tools like the APISIX Ingress Controller.
-
-This change affects how configurations are written but not how they are read - when retrieving configurations via GET requests, the default values will still be present in the response as they are populated during the read operation.
-
-Users should ensure their configuration supply all necessary values in the Admin API payload, as default values will no longer be automatically added during write operations.
-
-For more information, see [PR #12603](https://github.com/apache/apisix/pull/12603).
-
 ### `jwt-auth` plugin requires `secret` for non-RS/ES algorithms
 
 The `jwt-auth` plugin will no longer automatically generate a secret value when none is provided for algorithms other than RS256 and ES256. Previously, when users configured the `jwt-auth` plugin without providing a secret for algorithms like HS256 or HS512, APISIX would automatically generate one.
@@ -175,6 +165,7 @@ For more information, see [PR #12405](https://github.com/apache/apisix/pull/1240
 
 ## Other Updates
 
+* Admin API no longer populates default values (PR [#12603](https://github.com/apache/apisix/pull/12603))
 * Add healthcheck manager to decouple upstream (PR [#12426](https://github.com/apache/apisix/pull/12426))
 * Decouple Prometheus exporter calculation and output (PR [#12383](https://github.com/apache/apisix/pull/12383))
 * Redact encrypted fields from error logs to prevent sensitive data leakage (PR [#12629](https://github.com/apache/apisix/pull/12629))

--- a/blog/en/blog/2025/10/10/release-apache-apisix-3.14.0.md
+++ b/blog/en/blog/2025/10/10/release-apache-apisix-3.14.0.md
@@ -161,7 +161,6 @@ For more information, see [PR #12465](https://github.com/apache/apisix/pull/1246
 
 The `datadog` plugin now provides enhanced metrics and tags to support a wider range of observability needs. This update introduces several new tags:
 
-* `response_status`: The HTTP response status code (e.g., "200", "404", "503").
 * `response_status_class`: The class of the HTTP response status code (e.g., "2xx", "4xx", "5xx").
 * `path`: The HTTP path pattern, available only if the `include_path` attribute is set to `true`.
 * `method`: The HTTP method, available only if the `include_method` attribute is set to `true`.

--- a/blog/zh/blog/2025/10/10/release-apache-apisix-3.14.0.md
+++ b/blog/zh/blog/2025/10/10/release-apache-apisix-3.14.0.md
@@ -161,7 +161,6 @@ AI/ML API 提供统一的 OpenAI 兼容 API，可访问 300 多个 LLM，例如 
 
 `datadog` 插件现在提供增强的指标和标签，以支持更广泛的可观察性需求。此更新引入了几个新标签：
 
-* `response_status`：HTTP 响应状态代码（例如，“200”、“404”、“503”）。
 * `response_status_class`：HTTP 响应状态代码的类别（例如，“2xx”、“4xx”、“5xx”）。
 * `path`：HTTP 路径模式，仅当 `include_path` 属性设置为 `true` 时可用。
 * `method`：HTTP 方法，仅当 `include_method` 属性设置为 `true` 时可用。

--- a/blog/zh/blog/2025/10/10/release-apache-apisix-3.14.0.md
+++ b/blog/zh/blog/2025/10/10/release-apache-apisix-3.14.0.md
@@ -29,16 +29,6 @@ tags: [Community]
 
 ## 重大变更
 
-### Admin API 不再填充默认值
-
-Admin API 在写入配置时将不再自动填充默认值。以前，当用户通过 Admin API 提交配置时，APISIX 会在存储可选字段之前自动填充默认值。此行为已被移除，以避免用户混淆，并提高与 APISIX Ingress Controller 等工具的兼容性。
-
-此变更会影响配置的写入方式，但不会影响配置的读取方式——通过 GET 请求检索配置时，默认值仍会显示在响应中，因为它们是在读取操作期间填充的。
-
-用户应确保其配置在 Admin API 负载中提供所有必要值，因为在写入操作期间将不再自动添加默认值。
-
-更多信息，请参阅 [PR #12603](https://github.com/apache/apisix/pull/12603)。
-
 ### `jwt-auth` 插件需要为非 RS/ES 算法提供 `secret`
 
 如果未为 RS256 和 ES256 以外的算法提供密钥，`jwt-auth` 插件将不再自动生成密钥值。以前，如果用户配置 `jwt-auth` 插件时未为 HS256 或 HS512 等算法提供密钥，APISIX 会自动生成一个密钥。
@@ -175,6 +165,7 @@ AI/ML API 提供统一的 OpenAI 兼容 API，可访问 300 多个 LLM，例如 
 
 ## 其他更新
 
+* Admin API 不再填充默认值 (PR [#12603](https://github.com/apache/apisix/pull/12603))
 * 添加健康检查管理器以解耦上游 (PR [#12426](https://github.com/apache/apisix/pull/12426))
 * 解耦 Prometheus 导出器的计算和输出 (PR [#12383](https://github.com/apache/apisix/pull/12383))
 * 删除错误日志中的加密字段，以防止敏感数据泄露 (PR [#12629](https://github.com/apache/apisix/pull/12629))


### PR DESCRIPTION
1. datadog: `response_status` was not an addition in this PR.
2. "Admin API stops populating default values" is not a breaking change