### PR TITLE
fix: added proper redirection to ingress-controller docs

### DIFF
--- a/config/docs.js
+++ b/config/docs.js
@@ -19,7 +19,7 @@ module.exports = [
     githubRepo: 'apache/apisix-ingress-controller',
     version: '1.6.0',
     releaseDate: '2022-12-30',
-    firstDocPath: '/getting-started',
+    firstDocPath: '/overview',
   },
   {
     name: 'APISIX® Helm Charts',

--- a/config/docs.js
+++ b/config/docs.js
@@ -17,8 +17,8 @@ module.exports = [
     shape: 'hexagon',
     color: '#2563EB',
     githubRepo: 'apache/apisix-ingress-controller',
-    version: '1.6.0',
-    releaseDate: '2022-12-30',
+    version: '2.0.0',
+    releaseDate: '2025-12-17',
     firstDocPath: '/overview',
   },
   {

--- a/config/downloads.js
+++ b/config/downloads.js
@@ -25,8 +25,8 @@ module.exports = [
     githubBranch: 'master',
     downloadPath: 'apisix/ingress-controller/1.6.0/apache-apisix-ingress-controller-1.6.0-src',
     dockerhubPath: 'apisix-ingress-controller',
-    version: '1.6.0',
-    releaseDate: '2022-12-30',
+    version: '2.0.0',
+    releaseDate: '2025-12-17',
     firstDocPath: '/overview',
   },
   {

--- a/config/downloads.js
+++ b/config/downloads.js
@@ -27,7 +27,7 @@ module.exports = [
     dockerhubPath: 'apisix-ingress-controller',
     version: '1.6.0',
     releaseDate: '2022-12-30',
-    firstDocPath: '/getting-started',
+    firstDocPath: '/overview',
   },
   {
     name: 'APISIX® Java Plugin Runner',


### PR DESCRIPTION
Fixes: #1974 and #1972 

Changes I made:

/config/docs.js and /config/downloads.js gave the property "firstDocPath" a value = /getting-started which didn't existed for the ingress-controller docs so instead i changed its value to /overview which was also opening the docs when clicked via Navbar.

Now the issue of 404 Page Not Found while clicking on the card of ingress controller is resolved.
Thanks