### PR TITLE
fix: toggle theme switch appearing on the website pages

### DIFF
--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -415,10 +415,6 @@ a:hover {
 }
 
 @media only screen and (min-width: 768px) {
-  .react-toggle {
-    display: none;
-  }
-
   .arch-card-caption > p {
     width: 50%;
   }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,9 +1,7 @@
 import type { FC } from 'react';
-import React, { useEffect } from 'react';
-import useThemeContext from '@theme/hooks/useThemeContext';
+import React from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
-import useWindowType from '@theme/hooks/useWindowSize';
 
 import HeroSection from '../components/sections/HeroSection';
 import Architecture from '../components/sections/Architecture';
@@ -13,38 +11,8 @@ import Comparison from '../components/sections/Comparison';
 import OpensourcePromo from '../components/sections/OpensourcePromo';
 import EndCTA from '../components/sections/Endcta';
 
-const ThemeResetComponent = () => {
-  const { isDarkTheme, setLightTheme } = useThemeContext();
-  const windowType = useWindowType();
-
-  useEffect(() => {
-    if (windowType === 'mobile') {
-      //  remove mode switch at navbar-sidebar
-      const sidebarModeSwitch = document.querySelector('div.navbar-sidebar__brand > div') as HTMLDivElement;
-      if (sidebarModeSwitch) {
-        sidebarModeSwitch.style.display = 'none';
-      }
-    } else {
-      // remove mode switch at navbar
-      const navbarModeSwitch = document.querySelector('div.navbar__items.navbar__items--right > div.react-toggle') as HTMLDivElement;
-      if (navbarModeSwitch) {
-        navbarModeSwitch.style.display = 'none';
-      }
-    }
-  }, [windowType]);
-
-  useEffect(() => {
-    if (isDarkTheme) {
-      setLightTheme();
-    }
-  }, [isDarkTheme]);
-
-  return (null);
-};
-
 const Index: FC = () => (
   <Layout>
-    <ThemeResetComponent />
     <Head>
       <meta
         name="twitter:title"


### PR DESCRIPTION
Fixes: #1977 

Changes:
1. Removed the desktop rule that hid `.react-toggle` in `website/src/css/customTheme.scss`, so the theme switch is now visible in the navbar on all pages.

2. Removed `ThemeResetComponent` from `website/src/pages/index.tsx`, which previously forced light mode and manually hid the toggle via DOM queries. The component was forcing light theme whenever the home page was being opened.

Result:
The color mode switch now appears and works consistently across the whole website, matching the behavior of the Blog and Case Studies  page.

Screenshots of the change:

<img width="1915" height="653" alt="image" src="https://github.com/user-attachments/assets/2a96d5f3-8ad7-4658-997b-596b851d739e" />
<img width="1915" height="653" alt="Screenshot From 2025-12-17 13-53-41" src="https://github.com/user-attachments/assets/541a4e1f-2d31-4303-9209-b58ebb6757c2" />
