### PR TITLE
blog: add apisix ingress controller 2.0 release blog

### DIFF
--- a/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -30,7 +30,7 @@ This release achieves a significant milestone in Gateway API coverage with the a
 
 ### Introduce Gateway API Extensions
 
-APISIX Ingress Controller 2.0 introduces a set of official Gateway API extensions under the `apisix.apache.org/v1alpha1` group. Developed and maintained within the APISIX Ingress Controller community, these extensions provide production-grade capabilities that securely and reliably extend the standard specification.
+Building upon adherence to the Gateway API design principles, APISIX Ingress Controller 2.0 introduces a set of API extensions under `apisix.apache.org/v1alpha1` based on the Gateway API. These extensions provide additional capabilities not currently directly covered by the standard Gateway API, while maintaining the core semantics and usage patterns of the standard resources. They are designed to meet more complex and diverse real-world usage scenarios.
 
 - **GatewayProxy**: It defines the connection between the APISIX Ingress Controller and the APISIX, including auth, endpoints, and global plugins. It is referenced via `parametersRef` in Gateway, GatewayClass, or IngressClass resources.
 
@@ -48,7 +48,7 @@ These extensions offer a standardized, vendor-supported path to leverage advance
 
 APISIX Ingress Controller 2.0 offers a lightweight, etcd-free deployment option through its Standalone [API-Driven Mode](https://apisix.apache.org/docs/apisix/deployment-modes/#api-driven).
 
-This deployment paradigm stores routing configurations entirely in memory rather than in a configuration file, eliminating reliance on external databases. Updates are performed through a dedicated Standalone Admin API, which replaces the full configuration in a single operation and takes effect immediately via hot reloading, without requiring a restart.
+This deployment paradigm stores routing configurations entirely in memory rather than in a configuration file. Updates are performed through a dedicated Standalone Admin API, which replaces the full configuration in a single operation and takes effect immediately via hot reloading, without requiring a restart.
 
 This mode is designed specifically for the APISIX Ingress Controller and is primarily intended for integration with [ADC (API Declarative CLI)](https://github.com/api7/adc).
 
@@ -64,7 +64,7 @@ In the traditional deployment approach, APISIX uses etcd as its configuration ce
 <img alt="APISIX Ingress Controller Admin API Mode" style="width: 60%" src="https://static.api7.ai/uploads/2025/12/19/lX98Vcaj_apisix-ingress-controller-2-admin-api-mode.webp"></img>
 </div>
 
-#### Standalone Mode (Experimental)
+#### Standalone Mode
 
 APISIX can also run independently without relying on etcd, which is especially well‑suited for Kubernetes and single‑node deployments. It stores configurations in memory and manages them through the dedicated `/apisix/admin/configs` endpoint.
 

--- a/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -30,7 +30,7 @@ This release achieves a significant milestone in Gateway API coverage with the a
 
 ### Introduce Gateway API Extensions
 
-APISIX Ingress Controller 2.0 introduces a set of official Gateway API extensions under the `apisix.apache.org/v1alpha1` group. Developed and maintained within the Gateway API implementer community, these extensions provide production-grade capabilities that securely and reliably extend the standard specification.
+APISIX Ingress Controller 2.0 introduces a set of official Gateway API extensions under the `apisix.apache.org/v1alpha1` group. Developed and maintained within the APISIX Ingress Controller community, these extensions provide production-grade capabilities that securely and reliably extend the standard specification.
 
 - **GatewayProxy**: It defines the connection between the APISIX Ingress Controller and the APISIX, including auth, endpoints, and global plugins. It is referenced via `parametersRef` in Gateway, GatewayClass, or IngressClass resources.
 
@@ -52,8 +52,6 @@ This deployment paradigm stores routing configurations entirely in memory rather
 
 This mode is designed specifically for the APISIX Ingress Controller and is primarily intended for integration with [ADC (API Declarative CLI)](https://github.com/api7/adc).
 
-> ⚠️ This mode is intended for use with APISIX Ingress Controller and ADC. Direct usage without fully understanding its internal behavior is not recommended.
-
 ### Support Multi-Data-Plane Deployment Mode
 
 This release introduces flexible deployment options supporting multiple data plane modes, enabling a single ingress controller to manage several independent APISIX instances. This approach is ideal for environments requiring strict isolation—such as multi-tenancy, staging vs. production, or region-based routing—while maintaining centralized control.
@@ -68,10 +66,7 @@ In the traditional deployment approach, APISIX uses etcd as its configuration ce
 
 #### Standalone Mode (Experimental)
 
-APISIX can also run independently without relying on etcd, which is especially well‑suited for Kubernetes and single‑node deployments. It operates in two sub‑modes:
-
-- **File-driven**: Configuration is managed through `conf/apisix.yaml` files
-- **API-driven**: Configuration is stored in memory and fully managed through the dedicated `/apisix/admin/configs` endpoint
+APISIX can also run independently without relying on etcd, which is especially well‑suited for Kubernetes and single‑node deployments. It stores configurations in memory and manages them through the dedicated `/apisix/admin/configs` endpoint.
 
 This mode is particularly suitable for Kubernetes environments and single-node deployments, where the API-driven memory management approach combines the convenience of traditional Admin API with the simplicity of Standalone mode.
 

--- a/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX Ingress Controller 2.0: Production-Ready Platform for Modern Traffic Management"
+title: "Release Apache APISIX Ingress Controller 2.0"
 authors:
   - name: Yilia Lin
     title: Technical Writer
@@ -12,7 +12,7 @@ keywords:
   - Gateway API
   - Apache APISIX
 description: Apache APISIX Ingress Controller 2.0 delivers comprehensive Gateway API support, flexible multi-data-plane deployment, and etcd-free operation for robust, scalable Kubernetes traffic management.
-tags: [Ecosystem]
+tags: [Community]
 image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
 ---
 

--- a/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -1,0 +1,90 @@
+---
+title: "Apache APISIX Ingress Controller 2.0: Production-Ready Platform for Modern Traffic Management"
+authors:
+  - name: Yilia Lin
+    title: Technical Writer
+    url: https://github.com/Yilialinn
+    image_url: https://github.com/Yilialinn.png
+keywords:
+  - Ingress Controller
+  - APISIX Ingress Controller
+  - Kubernetes Ingress
+  - Gateway API
+  - Apache APISIX
+description: Apache APISIX Ingress Controller 2.0 delivers comprehensive Gateway API support, flexible multi-data-plane deployment, and etcd-free operation for robust, scalable Kubernetes traffic management.
+tags: [Ecosystem]
+image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
+---
+
+> Apache APISIX Ingress Controller 2.0 is officially released. It delivers comprehensive Gateway API support, flexible multi-data-plane deployment, and etcd-free operation for robust, scalable Kubernetes traffic management.
+
+<!--truncate-->
+
+Built on the high-performance API gateway Apache APISIX, [APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller) has undergone multiple iterations and validations, now capable of handling large-scale traffic management demands. The Apache APISIX community is pleased to announce the official release of [APISIX Ingress Controller 2.0](https://apisix.apache.org/docs/ingress-controller/overview/). This release delivers substantial enhancements across three foundational pillars—comprehensive compatibility, adaptable architecture, and enterprise-grade stability—empowering users to migrate their technology stacks smoothly and reliably.
+
+## Highlights of Apache APISIX Ingress Controller 2.0
+
+### Support Gateway API
+
+This release achieves a significant milestone in Gateway API coverage with the addition of TCPRoute, UDPRoute, GRPCRoute, and TLSRoute. These extensions provide native, protocol-aware routing for a wide range of traffic types—from traditional HTTP and TCP/UDP to modern gRPC and TLS passthrough/termination. This unified support allows organizations to manage diverse ingress requirements within a consistent, future-ready configuration model, simplifying multi-protocol deployment and easing the transition to full Gateway API adoption.
+
+### Introduce Gateway API Extensions
+
+APISIX Ingress Controller 2.0 introduces a set of official Gateway API extensions under the `apisix.apache.org/v1alpha1` group. Developed and maintained within the Gateway API implementer community, these extensions provide production-grade capabilities that securely and reliably extend the standard specification.
+
+- **GatewayProxy**: It defines the connection between the APISIX Ingress Controller and the APISIX, including auth, endpoints, and global plugins. It is referenced via `parametersRef` in Gateway, GatewayClass, or IngressClass resources.
+
+- **BackendTrafficPolicy**: It is for fine-grained traffic management of backend services, including load balancing, timeouts, retries, and host header handling in the APISIX Ingress Controller.
+
+- **Consumer**: It defines API consumers and their credentials, enabling authentication and plugin configuration for controlling access to API endpoints.
+
+- **PluginConfig**: It defines reusable plugin configurations that can be referenced by other resources like HTTPRoute, enabling separation of routing logic and plugin settings for better reusability and manageability.
+
+- **HTTPRoutePolicy**: It configures advanced traffic management and routing policies for HTTPRoute or Ingress resources, enhancing functionality without modifying the original resources.
+
+These extensions offer a standardized, vendor-supported path to leverage advanced APISIX features directly within the Gateway API ecosystem.
+
+### Support APISIX Standalone API-Driven Mode
+
+APISIX Ingress Controller 2.0 offers a lightweight, etcd-free deployment option through its Standalone [API-Driven Mode](https://apisix.apache.org/docs/apisix/deployment-modes/#api-driven).
+
+This deployment paradigm stores routing configurations entirely in memory rather than in a configuration file, eliminating reliance on external databases. Updates are performed through a dedicated Standalone Admin API, which replaces the full configuration in a single operation and takes effect immediately via hot reloading, without requiring a restart.
+
+This mode is designed specifically for the APISIX Ingress Controller and is primarily intended for integration with [ADC (API Declarative CLI)](https://github.com/api7/adc).
+
+> ⚠️ This mode is intended for use with APISIX Ingress Controller and ADC. Direct usage without fully understanding its internal behavior is not recommended.
+
+### Support Multi-Data-Plane Deployment Mode
+
+This release introduces flexible deployment options supporting multiple data plane modes, enabling a single ingress controller to manage several independent APISIX instances. This approach is ideal for environments requiring strict isolation—such as multi-tenancy, staging vs. production, or region-based routing—while maintaining centralized control.
+
+#### Admin API Mode
+
+In the traditional deployment approach, APISIX uses etcd as its configuration center, allowing administrators to dynamically manage routes, upstreams, and other resources through RESTful APIs. It supports distributed cluster deployments with real-time configuration synchronization.
+
+<div align="center">
+<img alt="APISIX Ingress Controller Admin API Mode" style="width: 60%" src="https://static.api7.ai/uploads/2025/12/19/lX98Vcaj_apisix-ingress-controller-2-admin-api-mode.webp"></img>
+</div>
+
+#### Standalone Mode (Experimental)
+
+APISIX can also run independently without relying on etcd, which is especially well‑suited for Kubernetes and single‑node deployments. It operates in two sub‑modes:
+
+- **File-driven**: Configuration is managed through `conf/apisix.yaml` files
+- **API-driven**: Configuration is stored in memory and fully managed through the dedicated `/apisix/admin/configs` endpoint
+
+This mode is particularly suitable for Kubernetes environments and single-node deployments, where the API-driven memory management approach combines the convenience of traditional Admin API with the simplicity of Standalone mode.
+
+<div align="center">
+<img alt="APISIX Ingress Controller Standalone Mode" style="width: 60%" src="https://static.api7.ai/uploads/2025/12/19/8IxjQgCP_apisix-ingress-controller-2-standalone-mode.webp"></img>
+</div>
+
+This multi-mode strategy empowers organizations to tailor their ingress architecture to diverse requirements without sacrificing manageability or control.
+
+## Conclusion
+
+Apache APISIX Ingress Controller 2.0 represents a significant evolution in Kubernetes ingress management, delivering a robust platform built for the complexity of modern, multi-protocol applications. By uniting comprehensive Gateway API support, extensible configuration through official API extensions, a lightweight standalone deployment mode, and versatile multi-data-plane management, this release provides a cohesive and powerful foundation for dynamic cloud environments.
+
+Whether you are standardizing ingress across diverse workloads, seeking greater architectural flexibility, or requiring enterprise-grade stability at scale, APISIX Ingress Controller 2.0 offers a forward-looking solution that simplifies operations without compromising capability. It stands as a testament to the community-driven innovation within the Apache APISIX ecosystem, designed to meet today's demands while adapting to tomorrow's challenges.
+
+> For a complete list of features and changes, please refer to the [Release Changelog](https://github.com/apache/apisix-ingress-controller/blob/2.0.0/CHANGELOG.md#200).

--- a/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -20,7 +20,7 @@ image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
 
 <!--truncate-->
 
-Built on the high-performance API gateway Apache APISIX, [APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller) has undergone multiple iterations and validations, now capable of handling large-scale traffic management demands. The Apache APISIX community is pleased to announce the official release of [APISIX Ingress Controller 2.0](https://apisix.apache.org/docs/ingress-controller/overview/). This release delivers substantial enhancements across three foundational pillars—comprehensive compatibility, adaptable architecture, and enterprise-grade stability—empowering users to migrate their technology stacks smoothly and reliably.
+Built on the high-performance API gateway Apache APISIX, [APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller) has undergone multiple iterations and validations, and is now capable of handling large-scale traffic management demands. The Apache APISIX community is pleased to announce the official release of [APISIX Ingress Controller 2.0](https://apisix.apache.org/docs/ingress-controller/overview/). This release delivers substantial enhancements across three foundational pillars—**comprehensive compatibility**, **adaptable architecture**, and **enterprise-grade stability**—empowering users to migrate their technology stacks smoothly and reliably.
 
 ## Highlights of Apache APISIX Ingress Controller 2.0
 

--- a/blog/en/config/picked-posts.json
+++ b/blog/en/config/picked-posts.json
@@ -1,9 +1,9 @@
 [
+    "blog/en/blog/2025/12/19/apisix-ingress-controller-2-0-release.md",
     "blog/en/blog/2025/02/24/apisix-ai-gateway-features.md",
     "blog/en/blog/2025/04/21/host-mcp-server-with-api-gateway.md",
     "blog/en/blog/2025/03/06/what-is-an-ai-gateway.md",
     "blog/en/blog/2025/02/21/why-reinvent-api-gateways.md",
     "blog/en/blog/2025/02/06/analyzing-api-gateway-adoption-rates.md",
-    "blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md",
-    "blog/en/blog/2024/10/22/apisix-integrates-with-open-appsec.md"
+    "blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md"
 ]

--- a/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX Ingress Controller 2.0：为现代流量管理而生"
+title: "Apache APISIX Ingress Controller 2.0 正式发布"
 authors:
   - name: Yilia Lin
     title: Technical Writer
@@ -12,7 +12,7 @@ keywords:
   - Gateway API
   - Apache APISIX
 description: Apache APISIX Ingress Controller 2.0 正式发布，带来全面的 Gateway API 支持、灵活的多数据面部署模式以及无需 etcd 的轻量级运维，以实现更稳健、可扩展的 Kubernetes 流量管理。
-tags: [Ecosystem]
+tags: [Community]
 image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
 ---
 

--- a/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -11,7 +11,7 @@ keywords:
   - Kubernetes Ingress
   - Gateway API
   - Apache APISIX
-description: Apache APISIX Ingress Controller 2.0 提供全面的 Gateway API 支持、灵活的多数据平面部署模式以及无需 etcd 的运维，以实现稳健、可扩展的 Kubernetes 流量管理。
+description: Apache APISIX Ingress Controller 2.0 正式发布，带来全面的 Gateway API 支持、灵活的多数据面部署模式以及无需 etcd 的轻量级运维，以实现更稳健、可扩展的 Kubernetes 流量管理。
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
 ---

--- a/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -30,7 +30,7 @@ image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
 
 ### 引入 Gateway API 扩展
 
-APISIX Ingress Controller 2.0 引入了一套在 `apisix.apache.org/v1alpha1` 组下的官方 Gateway API 扩展。这些扩展由 Gateway API 社区开发和维护，以安全可靠的方式提供生产级能力，丰富了标准规范。
+APISIX Ingress Controller 2.0 引入了一套在 `apisix.apache.org/v1alpha1` 组下的官方 Gateway API 扩展。这些扩展由 APISIX Ingress Controller 社区开发和维护，以安全可靠的方式提供生产级能力，丰富了标准规范。
 
 - **GatewayProxy**：定义了 APISIX Ingress Controller 与 APISIX 数据面之间的连接，涵盖认证、端点及全局插件，可通过 Gateway、GatewayClass 或 IngressClass 资源中的 `parametersRef` 进行引用。
 
@@ -52,8 +52,6 @@ APISIX Ingress Controller 2.0 提供了轻量级、无需 etcd 的 Standalone [A
 
 此模式专为 APISIX Ingress Controller 设计，主要面向与 [ADC（API 声明式 CLI）](https://github.com/api7/adc)的深度集成场景。
 
-> ⚠️ 此模式建议与 APISIX Ingress Controller 及 ADC 配合使用。如不完全了解其内部机制，请勿直接用于生产核心场景。
-
 ### 支持多数据平面部署模式
 
 APISIX Ingress Controller 2.0 推出了灵活的多数据面部署支持，允许单个 Controller 管理多个独立的 APISIX 实例。这一设计非常适用于需要严格隔离的环境，例如多租户、灰度生产隔离或地域化路由，同时能实现全局集中管控。
@@ -68,10 +66,7 @@ APISIX Ingress Controller 2.0 推出了灵活的多数据面部署支持，允�
 
 #### Standalone 模式（实验性）
 
-APISIX 也可脱离 etcd 独立运行，尤其适用于 Kubernetes 环境和单节点部署。它提供两种子模式：
-
-- **文件驱动**：通过 `conf/apisix.yaml` 文件管理配置。
-- **API 驱动**：配置存储于内存中，并通过专用的 `/apisix/admin/configs` 端点进行全量管理。
+APISIX 也可脱离 etcd 独立运行，尤其适用于 Kubernetes 环境和单节点部署。它通过 API 驱动模式，配置存储于内存中，并通过专用的 `/apisix/admin/configs` 端点进行全量管理。
 
 该模式巧妙融合了传统 Admin API 的便利性与 Standalone 模式的简洁性，为 Kubernetes 和单节点场景提供了高效灵活的管理体验。
 

--- a/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -30,7 +30,7 @@ image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
 
 ### 引入 Gateway API 扩展
 
-APISIX Ingress Controller 2.0 引入了一套在 `apisix.apache.org/v1alpha1` 组下的官方 Gateway API 扩展。这些扩展由 APISIX Ingress Controller 社区开发和维护，以安全可靠的方式提供生产级能力，丰富了标准规范。
+在遵循 Gateway API 设计原则的基础上，APISIX Ingress Controller 2.0 基于 Gateway API 引入了一组扩展 API `apisix.apache.org/v1alpha1`。这些扩展在保持标准资源核心语义和使用方式不变的前提下，提供了 Gateway API 当前未直接覆盖的附加能力，用于满足更复杂和多样化的实际使用场景。
 
 - **GatewayProxy**：定义了 APISIX Ingress Controller 与 APISIX 数据面之间的连接，涵盖认证、端点及全局插件，可通过 Gateway、GatewayClass 或 IngressClass 资源中的 `parametersRef` 进行引用。
 
@@ -48,7 +48,7 @@ APISIX Ingress Controller 2.0 引入了一套在 `apisix.apache.org/v1alpha1` �
 
 APISIX Ingress Controller 2.0 提供了轻量级、无需 etcd 的 Standalone [API 驱动模式](https://apisix.apache.org/zh/docs/apisix/deployment-modes/#api-driven)作为部署新选择。
 
-此部署范式将路由配置完全存储于内存而非配置文件，摆脱了对外部数据库的依赖。通过专用的独立管理 API，一次操作即可完成整体配置的替换与热加载，即时生效且无需重启进程。
+此部署范式将路由配置完全存储于内存而非配置文件，通过专用的独立管理 API，一次操作即可完成整体配置的替换与热加载，即时生效且无需重启进程。
 
 此模式专为 APISIX Ingress Controller 设计，主要面向与 [ADC（API 声明式 CLI）](https://github.com/api7/adc)的深度集成场景。
 
@@ -64,7 +64,7 @@ APISIX Ingress Controller 2.0 推出了灵活的多数据面部署支持，允�
 <img alt="APISIX Ingress Controller Admin API Mode" style="width: 60%" src="https://static.api7.ai/uploads/2025/12/19/lX98Vcaj_apisix-ingress-controller-2-admin-api-mode.webp"></img>
 </div>
 
-#### Standalone 模式（实验性）
+#### Standalone 模式
 
 APISIX 也可脱离 etcd 独立运行，尤其适用于 Kubernetes 环境和单节点部署。它通过 API 驱动模式，配置存储于内存中，并通过专用的 `/apisix/admin/configs` 端点进行全量管理。
 

--- a/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
+++ b/blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md
@@ -1,0 +1,90 @@
+---
+title: "Apache APISIX Ingress Controller 2.0：为现代流量管理而生"
+authors:
+  - name: Yilia Lin
+    title: Technical Writer
+    url: https://github.com/Yilialinn
+    image_url: https://github.com/Yilialinn.png
+keywords:
+  - Ingress Controller
+  - APISIX Ingress Controller
+  - Kubernetes Ingress
+  - Gateway API
+  - Apache APISIX
+description: Apache APISIX Ingress Controller 2.0 提供全面的 Gateway API 支持、灵活的多数据平面部署模式以及无需 etcd 的运维，以实现稳健、可扩展的 Kubernetes 流量管理。
+tags: [Ecosystem]
+image: https://static.apiseven.com/2022/10/19/634f6677742a1.png
+---
+
+> Apache APISIX Ingress Controller 2.0 正式发布，带来全面的 Gateway API 支持、灵活的多数据面部署模式以及无需 etcd 的轻量级运维，以实现更稳健、可扩展的 Kubernetes 流量管理。
+
+<!--truncate-->
+
+基于高性能 API 网关 Apache APISIX 构建的 [APISIX Ingress Controller](https://github.com/apache/apisix-ingress-controller)，历经多个版本的迭代与验证，如今已能从容应对大规模流量管理的挑战。我们很高兴地宣布 [APISIX Ingress Controller 2.0](https://apisix.apache.org/zh/docs/ingress-controller/overview/) 正式发布。此版本围绕**全面的兼容性**、**灵活的架构**与**企业级的稳定性**三大核心进行增强，致力于帮助用户平稳、高效地完成技术栈迁移。
+
+## Apache APISIX Ingress Controller 2.0 核心亮点
+
+### 全面支持 Gateway API
+
+本次发布通过新增对 TCPRoute、UDPRoute、GRPCRoute 和 TLSRoute 的支持，实现了支持 Gateway API 的重要里程碑。这些扩展为从传统 HTTP、TCP/UDP 到现代 gRPC 及 TLS 透传/终止等多种流量类型，提供了原生且感知协议的路由能力。通过这种统一的支持，企业能够在一个一致、面向未来的配置模型中管理复杂的入口需求，简化多协议部署，并平滑迈向完整的 Gateway API 体系。
+
+### 引入 Gateway API 扩展
+
+APISIX Ingress Controller 2.0 引入了一套在 `apisix.apache.org/v1alpha1` 组下的官方 Gateway API 扩展。这些扩展由 Gateway API 社区开发和维护，以安全可靠的方式提供生产级能力，丰富了标准规范。
+
+- **GatewayProxy**：定义了 APISIX Ingress Controller 与 APISIX 数据面之间的连接，涵盖认证、端点及全局插件，可通过 Gateway、GatewayClass 或 IngressClass 资源中的 `parametersRef` 进行引用。
+
+- **BackendTrafficPolicy**：为后端服务提供细粒度流量管理策略，包括负载均衡、超时、重试和主机头处理。
+
+- **Consumer**：定义 API 消费者及其凭据，实现身份认证和插件配置，从而管控 API 端点访问。
+
+- **PluginConfig**：定义可复用的插件配置模板，可供 HTTPRoute 等资源引用，实现路由逻辑与插件设置的解耦，提升可复用性和可管理性。
+
+- **HTTPRoutePolicy**：可为现有的 HTTPRoute 或 Ingress 资源附加高级流量管理与路由策略，无需修改原始资源即可增强其功能。
+
+这些扩展提供了一条标准化、受厂商支持的路径，让你能在 Gateway API 生态中直接运用 APISIX 的高级功能。
+
+### 支持 APISIX Standalone API 驱动模式
+
+APISIX Ingress Controller 2.0 提供了轻量级、无需 etcd 的 Standalone [API 驱动模式](https://apisix.apache.org/zh/docs/apisix/deployment-modes/#api-driven)作为部署新选择。
+
+此部署范式将路由配置完全存储于内存而非配置文件，摆脱了对外部数据库的依赖。通过专用的独立管理 API，一次操作即可完成整体配置的替换与热加载，即时生效且无需重启进程。
+
+此模式专为 APISIX Ingress Controller 设计，主要面向与 [ADC（API 声明式 CLI）](https://github.com/api7/adc)的深度集成场景。
+
+> ⚠️ 此模式建议与 APISIX Ingress Controller 及 ADC 配合使用。如不完全了解其内部机制，请勿直接用于生产核心场景。
+
+### 支持多数据平面部署模式
+
+APISIX Ingress Controller 2.0 推出了灵活的多数据面部署支持，允许单个 Controller 管理多个独立的 APISIX 实例。这一设计非常适用于需要严格隔离的环境，例如多租户、灰度生产隔离或地域化路由，同时能实现全局集中管控。
+
+#### Admin API 模式
+
+在传统部署架构中，APISIX 使用 etcd 作为其配置中心，管理员可通过 RESTful API 动态管理路由、上游服务等资源。该模式支持分布式集群部署，并能实现配置的实时同步。
+
+<div align="center">
+<img alt="APISIX Ingress Controller Admin API Mode" style="width: 60%" src="https://static.api7.ai/uploads/2025/12/19/lX98Vcaj_apisix-ingress-controller-2-admin-api-mode.webp"></img>
+</div>
+
+#### Standalone 模式（实验性）
+
+APISIX 也可脱离 etcd 独立运行，尤其适用于 Kubernetes 环境和单节点部署。它提供两种子模式：
+
+- **文件驱动**：通过 `conf/apisix.yaml` 文件管理配置。
+- **API 驱动**：配置存储于内存中，并通过专用的 `/apisix/admin/configs` 端点进行全量管理。
+
+该模式巧妙融合了传统 Admin API 的便利性与 Standalone 模式的简洁性，为 Kubernetes 和单节点场景提供了高效灵活的管理体验。
+
+<div align="center">
+<img alt="APISIX Ingress Controller Standalone Mode" style="width: 60%" src="https://static.api7.ai/uploads/2025/12/19/8IxjQgCP_apisix-ingress-controller-2-standalone-mode.webp"></img>
+</div>
+
+通过这种多模式策略，企业可以根据多样化的需求灵活定制入口架构，在提升控制力的同时，不牺牲可管理性。
+
+## 结语
+
+Apache APISIX Ingress Controller 2.0 是 Kubernetes 入口管理领域的一次重要飞跃。它构建了一个坚固而灵活的平台，专为应对现代多协议应用的复杂性而生。通过整合全面的 Gateway API 支持、可扩展的官方 API 扩展、轻量化的独立部署模式以及多功能的多数据平面管理能力，此版本为动态多变的云环境提供了一个强大而一致的基石。
+
+无论你正致力于统一多样化工作负载的入口访问、寻求更灵活的架构设计，还是需要具备企业级稳定性的扩展能力，APISIX Ingress Controller 2.0 都提供了一个面向未来的解决方案。它在简化运维的同时，毫不妥协地提供了强大功能，充分体现了 Apache APISIX 生态系统内社区驱动的创新活力，旨在既满足当下需求，也拥抱未来挑战。
+
+> 有关完整的功能和变更列表，请参阅完整的 [Release Changelog](https://github.com/apache/apisix-ingress-controller/blob/2.0.0/CHANGELOG.md#200)。

--- a/blog/zh/config/picked-posts.json
+++ b/blog/zh/config/picked-posts.json
@@ -1,9 +1,9 @@
 [
+    "blog/zh/blog/2025/12/19/apisix-ingress-controller-2-0-release.md",
     "blog/zh/blog/2025/04/21/host-mcp-server-with-api-gateway.md",
     "blog/zh/blog/2025/04/08/introducing-apisix-ai-gateway.md",
     "blog/zh/blog/2025/04/01/embrace-intelligent-api-management-with-ai-and-mcp.md",
     "blog/zh/blog/2025/04/01/release-apache-apisix-3.12.0.md",
     "blog/zh/blog/2025/03/24/6-essential-ai-gateway-use-cases.md",
-    "blog/zh/blog/2025/03/21/ai-gateway-vs-api-gateway-differences-explained.md",
-    "blog/zh/blog/2025/01/15/apisix-practice-in-soyoung-data-security-gateway.md"
+    "blog/zh/blog/2025/03/21/ai-gateway-vs-api-gateway-differences-explained.md"
 ]


### PR DESCRIPTION
Changes:

Add the APISIX Ingress Controller 2.0 release blog to the ecosystem catalogue
