### PR TITLE
fix: use spawn instead of exec to avoid maxBuffer overflow in build

### DIFF
--- a/scripts/generate-website.js
+++ b/scripts/generate-website.js
@@ -9,7 +9,13 @@ const exec = util.promisify(require('node:child_process').exec);
 // Streams stdout/stderr to a log file via spawn (no maxBuffer limit).
 function runBuild(cmd, logFilePath) {
   return new Promise((resolve) => {
+    let logStreamFailed = false;
     const logStream = fs.createWriteStream(logFilePath);
+
+    logStream.on('error', () => {
+      logStreamFailed = true;
+    });
+
     const child = spawn(cmd, { shell: true, stdio: ['ignore', 'pipe', 'pipe'] });
 
     child.stdout.pipe(logStream, { end: false });
@@ -17,7 +23,7 @@ function runBuild(cmd, logFilePath) {
 
     child.on('close', (code) => {
       logStream.end(() => {
-        resolve({ failed: code !== 0 });
+        resolve({ failed: code !== 0 || logStreamFailed });
       });
     });
 

--- a/scripts/generate-website.js
+++ b/scripts/generate-website.js
@@ -3,7 +3,32 @@ const util = require('util');
 const fs = require('fs');
 const path = require('path');
 const { chdir } = require('node:process');
+const { spawn } = require('node:child_process');
 const exec = util.promisify(require('node:child_process').exec);
+
+// Streams stdout/stderr to a log file via spawn (no maxBuffer limit).
+function runBuild(cmd, logFilePath) {
+  return new Promise((resolve) => {
+    const logStream = fs.createWriteStream(logFilePath);
+    const child = spawn(cmd, { shell: true, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    child.stdout.pipe(logStream, { end: false });
+    child.stderr.pipe(logStream, { end: false });
+
+    child.on('close', (code) => {
+      logStream.end(() => {
+        resolve({ failed: code !== 0 });
+      });
+    });
+
+    child.on('error', (err) => {
+      logStream.write(`\nError: ${err.message}\n`);
+      logStream.end(() => {
+        resolve({ failed: true });
+      });
+    });
+  });
+}
 
 // Detect CI environment
 const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
@@ -60,56 +85,28 @@ const tasks = new Listr([
         { name: 'website', cmd: 'yarn run build:website' },
       ];
 
-      // Execute all builds in parallel, capturing output
-      const results = await Promise.allSettled(
-        buildSteps.map((step) => exec(step.cmd)),
+      const results = await Promise.all(
+        buildSteps.map((step) => {
+          const logFilePath = path.join(logDir, `${step.name}.log`);
+          return runBuild(step.cmd, logFilePath);
+        }),
       );
 
-      // Check for failures and save logs to files
       const failures = [];
       const logFiles = [];
 
       results.forEach((result, index) => {
         const step = buildSteps[index];
         const logFilePath = path.join(logDir, `${step.name}.log`);
-        let logContent = '';
-
-        if (result.status === 'fulfilled') {
-          // Write raw stdout and stderr without extra formatting
-          if (result.value.stdout) {
-            logContent += result.value.stdout;
-          }
-          if (result.value.stderr) {
-            if (logContent) logContent += '\n';
-            logContent += result.value.stderr;
-          }
-        } else {
+        logFiles.push({ path: logFilePath, step: step.name, failed: result.failed });
+        if (result.failed) {
           failures.push(step.name);
-          // Write raw stdout and stderr for failed builds
-          if (result.reason.stdout) {
-            logContent += result.reason.stdout;
-          }
-          if (result.reason.stderr) {
-            if (logContent) logContent += '\n';
-            logContent += result.reason.stderr;
-          }
-          // Add error message at the end if available
-          if (result.reason.message && !result.reason.stderr?.includes(result.reason.message)) {
-            if (logContent) logContent += '\n';
-            logContent += `Error: ${result.reason.message}\n`;
-          }
         }
-
-        // Write to log file
-        fs.writeFileSync(logFilePath, logContent);
-        logFiles.push({ path: logFilePath, step: step.name, failed: result.status === 'rejected' });
       });
 
-      // Store in context for later use
       ctx.buildLogFiles = logFiles;
       ctx.buildFailures = failures;
 
-      // If any build failed, throw error
       if (failures.length > 0) {
         throw new Error(`Build failed for: ${failures.join(', ')}`);
       }


### PR DESCRIPTION
## Summary

- Replace `child_process.exec()` with `child_process.spawn()` for build steps in `generate-website.js` to eliminate `stdout maxBuffer length exceeded` errors.

## Problem

After #2002 changed `onBrokenLinks` from `'ignore'` to `'log'`, the `doc` workspace build now outputs ~33,000 lines of broken link warnings to stdout. Since `generate-website.js` uses `exec()` (which buffers all output in memory), this exceeds Node.js's default `maxBuffer` limit (1MB), causing the `doc` build to be marked as failed even though Docusaurus compilation itself succeeds.

**Failed CI run**: https://github.com/apache/apisix-website/actions/runs/22993146365/job/66758664427

## Solution

Replace `exec()` with `spawn()` for build commands. `spawn()` streams stdout/stderr directly to log files on disk instead of buffering in memory, so there is no buffer size limit regardless of how much output the build produces.

### Key changes:
- Add `runBuild()` helper that uses `spawn()` with piped streams to log files
- Detect build failures via exit code (spawn) instead of promise rejection (exec)
- Preserve all existing behavior: parallel builds, log file output, failure reporting
- Keep `exec()` for simple `cp` commands (tiny output, no risk)
