### PR TITLE
fix(seo): shorten title tag suffix to prevent truncation in search results

### DIFF
--- a/blog/en/docusaurus.config.js
+++ b/blog/en/docusaurus.config.js
@@ -22,7 +22,7 @@ const metadatas = [
 ];
 
 module.exports = {
-  title: 'Apache APISIX® -- Cloud-Native API Gateway and AI Gateway',
+  title: 'Apache APISIX',
   tagline:
     'APISIX is a dynamic, high-performance API Gateway with features like load balancing, canary release, authentication, and observability. As an AI Gateway, it enables AI proxying, LLM load balancing, retries, fallbacks, token-based rate limiting, and security to enhance AI agent efficiency and reliability.',
   url: 'https://apisix.apache.org',

--- a/blog/zh/docusaurus.config.js
+++ b/blog/zh/docusaurus.config.js
@@ -23,7 +23,7 @@ const metadatas = [
 ];
 
 module.exports = {
-  title: 'Apache APISIX® -- Cloud-Native API Gateway and AI Gateway',
+  title: 'Apache APISIX',
   tagline:
     'APISIX is a dynamic, high-performance API Gateway with features like load balancing, canary release, authentication, and observability. As an AI Gateway, it enables AI proxying, LLM load balancing, retries, fallbacks, token-based rate limiting, and security to enhance AI agent efficiency and reliability.',
   url: 'https://apisix.apache.org',

--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -15,7 +15,7 @@ const getEditUrl = (props) => {
 };
 
 module.exports = {
-  title: 'Apache APISIX® -- Cloud-Native API Gateway and AI Gateway',
+  title: 'Apache APISIX',
   tagline:
     'APISIX is a dynamic, high-performance API Gateway with features like load balancing, canary release, authentication, and observability. As an AI Gateway, it enables AI proxying, LLM load balancing, retries, fallbacks, token-based rate limiting, and security to enhance AI agent efficiency and reliability.',
   url: 'https://apisix.apache.org',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,7 +1,7 @@
 const { ssrTemplate } = require('../config/ssrTemplate');
 
 module.exports = {
-  title: 'Apache APISIX® -- Cloud-Native API Gateway and AI Gateway',
+  title: 'Apache APISIX',
   tagline:
     'APISIX is a dynamic, high-performance API Gateway with features like load balancing, canary release, authentication, and observability. As an AI Gateway, it enables AI proxying, LLM load balancing, retries, fallbacks, token-based rate limiting, and security to enhance AI agent efficiency and reliability.',
   url: 'https://apisix.apache.org',

--- a/website/src/pages/ai-gateway.tsx
+++ b/website/src/pages/ai-gateway.tsx
@@ -26,7 +26,7 @@ const ChakraTestPage: React.FC = () => (
       />
       <meta
         property="og:site_name"
-        content="Apache APISIX® -- Cloud-Native API Gateway and AI Gateway"
+        content="Apache APISIX"
       />
       <meta
         property="og:description"

--- a/website/src/pages/contribute.tsx
+++ b/website/src/pages/contribute.tsx
@@ -43,7 +43,7 @@ const Contribute: FC = () => {
     <Layout>
       <Head>
         <title>
-          Good first issue - Apache APISIX® - Cloud-Native API Gateway and AI Gateway
+          Good first issue | Apache APISIX
         </title>
 
         <meta

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -46,6 +46,7 @@ const Index: FC = () => (
   <Layout>
     <ThemeResetComponent />
     <Head>
+      <title>Apache APISIX® -- Cloud-Native API Gateway and AI Gateway</title>
       <meta
         name="twitter:title"
         content="Apache APISIX® - Cloud-Native API Gateway and AI Gateway"


### PR DESCRIPTION
## Summary

Shorten the site title from 57 characters to 13 characters so page titles are no longer truncated in Google search results.

## Problem

The site title (`siteConfig.title`) was:

```
Apache APISIX® -- Cloud-Native API Gateway and AI Gateway
```

This 57-character string is appended to every page title via Docusaurus' default template: `{pageTitle} | {siteTitle}`. Since Google displays ~60 characters for title tags, virtually **every page title was truncated**:

| Page | Title tag (chars) | Google shows |
|------|:-----------------:|-------------|
| Getting Started | 73 | `Getting Started \| Apache APISIX® -- Cloud-Nat...` |
| limit-count plugin | 78 | `limit-count \| Apache APISIX® -- Cloud-Native...` |
| Blog post | 80+ | `Free tier API with Apache APISIX \| Apache API...` |

Truncated titles hurt click-through rates (CTR) because users cannot see the full page title or brand name.

## Changes

| File | Change |
|------|--------|
| `website/docusaurus.config.js` | `title` -> `'Apache APISIX'` |
| `doc/docusaurus.config.js` | `title` -> `'Apache APISIX'` |
| `blog/en/docusaurus.config.js` | `title` -> `'Apache APISIX'` |
| `blog/zh/docusaurus.config.js` | `title` -> `'Apache APISIX'` |
| `website/src/pages/index.tsx` | Add explicit `<title>` to preserve full keyword-rich homepage title |
| `website/src/pages/contribute.tsx` | Shorten hard-coded `<title>` suffix |
| `website/src/pages/ai-gateway.tsx` | Update `og:site_name` to match |

## Result

| Page | Before | After |
|------|--------|-------|
| Homepage | `Apache APISIX® -- Cloud-Native API Gateway and AI Gateway` | `Apache APISIX® -- Cloud-Native API Gateway and AI Gateway` (unchanged, explicit) |
| Getting Started | `Getting Started \| Apache APISIX® -- Cloud-Nat...` | `Getting Started \| Apache APISIX` (31 chars) |
| Blog post | `Free tier API with Apache APISIX \| Apache API...` | `Free tier API with Apache APISIX \| Apache APISIX` (49 chars) |
| AI Gateway | `APISIX AI Gateway - LLM Proxy...` | unchanged (has its own `<title>`) |

The `tagline`, `meta description`, and `navbar.title` are all unchanged.