### PR TITLE
feat(seo): add BlogPosting JSON-LD structured data to blog posts

### DIFF
--- a/blog/src/theme/BlogPostPage/index.tsx
+++ b/blog/src/theme/BlogPostPage/index.tsx
@@ -133,6 +133,37 @@ const BlogPostPage = (props: Props): JSX.Element => {
         {tags.length > 0 && (
           <meta property="article:tag" content={tags.map((tag) => tag.label).join(',')} />
         )}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BlogPosting',
+            headline: title,
+            description,
+            datePublished: date,
+            ...(image && { image }),
+            author: authors.map((author) => ({
+              '@type': 'Person',
+              name: author.name,
+              ...(author.url && { url: author.url }),
+              ...(author.imageURL && { image: author.imageURL }),
+            })),
+            ...(tags.length > 0 && {
+              keywords: tags.map((tag) => tag.label).join(', '),
+            }),
+            publisher: {
+              '@type': 'Organization',
+              name: 'Apache APISIX',
+              logo: {
+                '@type': 'ImageObject',
+                url: 'https://apisix.apache.org/img/logo2.svg',
+              },
+            },
+            mainEntityOfPage: {
+              '@type': 'WebPage',
+              '@id': metadata.permalink,
+            },
+          })}
+        </script>
       </Seo>
 
       <BlogPostItem frontMatter={frontMatter} assets={assets} metadata={metadata} isBlogPostPage>


### PR DESCRIPTION
## Summary

- Adds `BlogPosting` JSON-LD structured data to every blog post page, enabling Google rich results (article snippets, author info, publish dates)
- Injects the schema via `<script type="application/ld+json">` inside the existing `<Seo>` (react-helmet) component in `BlogPostPage`
- Uses metadata already available in the component (title, description, date, authors, tags, image, permalink) — no new data sources needed

## What's included in the JSON-LD

| Field | Source |
|-------|--------|
| `headline` | `metadata.title` |
| `description` | `metadata.description` |
| `datePublished` | `metadata.date` (ISO 8601) |
| `image` | `assets.image` or `frontMatter.image` |
| `author[]` | `metadata.authors` (name, url, imageURL) |
| `keywords` | `metadata.tags` labels, comma-separated |
| `publisher` | Static: Apache APISIX organization + logo |
| `mainEntityOfPage` | `metadata.permalink` |

## Why

Blog posts currently only have microdata attributes (`itemType`, `itemProp`) on HTML elements. Google strongly prefers JSON-LD for structured data, and `BlogPosting` schema enables rich results like:
- Article snippets with author photo and publish date
- Better visibility in Google Discover
- Enhanced appearance in News results

## Files changed

- `blog/src/theme/BlogPostPage/index.tsx` — added JSON-LD script tag inside `<Seo>` component

Since `blog/src/` is shared between `blog/en/` and `blog/zh/` (copied at build time), this change applies to both English and Chinese blog posts.