### PR TITLE
perf: preload only the primary body font to improve page load speed

### DIFF
--- a/config/ssrTemplate.js
+++ b/config/ssrTemplate.js
@@ -14,10 +14,6 @@ module.exports = {
         <%~ metaAttribute %>
       <% }); %>
       <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-Medium.otf" as="font" type="font/otf" crossorigin>
-      <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-Bold.otf" as="font" type="font/otf" crossorigin>
-      <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-Light.otf" as="font" type="font/otf" crossorigin>
-      <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-Demi.otf"  as="font" type="font/otf" crossorigin>
-      <link rel="preload" href="https://static.apiseven.com/202202/MaisonNeue-ExtraBold.otf" as="font" type="font/otf" crossorigin>
       <% it.scripts.forEach((script) => { %>
         <link rel="preload" href="<%= process.env.preview ? '' : 'https://apisix-website-static.apiseven.com' %><%= it.baseUrl %><%= script %>" as="script">
       <% }); %>


### PR DESCRIPTION
## Summary

- Removes `<link rel="preload">` for 4 secondary font variants (Bold, Light, Demi, ExtraBold) from the SSR template
- Keeps only the preload for **MaisonNeue-Medium**, which is the primary `body` and heading font used on every page

## Problem

All 5 MaisonNeue font variants were being preloaded on every page via `<link rel="preload">` in `config/ssrTemplate.js`. Since these are OTF files (not WOFF2), each is relatively large. Preloading all 5:

1. **Wastes bandwidth** — most pages only use Medium for body text; Bold/Demi are used sparingly in headings, Light and ExtraBold are rarely used
2. **Competes for bandwidth** during the critical loading phase, delaying CSS, JS, and actual page content
3. **Hurts Core Web Vitals** — unnecessary preloads increase LCP and reduce Lighthouse performance scores

## Solution

Keep only the MaisonNeue-Medium preload. The other 4 fonts remain declared in `@font-face` (in `customTheme.scss`) with `font-display: optional`, so they will:
- Load on-demand when the browser encounters elements that reference them
- Not cause layout shift (thanks to `font-display: optional`)
- Not block the critical rendering path

## Expected impact

- ~4 fewer high-priority font requests on initial page load
- Several hundred KB less data competing for bandwidth during first paint
- Improved LCP and Lighthouse performance score

## Files changed

- `config/ssrTemplate.js` — removed 4 preload `<link>` tags (lines 17-20)