### PR TITLE
fix(seo): rewrite titles and descriptions for 30 high-value blog posts

### DIFF
--- a/blog/en/blog/2021/06/10/Apache-APISIX-and-Envoy-performance-comparison.md
+++ b/blog/en/blog/2021/06/10/Apache-APISIX-and-Envoy-performance-comparison.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX v.s Envoy: Which Has the Better Performance?"
+title: "APISIX vs Envoy: Performance Benchmark Comparison"
 slug: 2021/06/10/apache-apisix-and-envoy-performance-comparison
 author: "Yuansheng Wang"
 authorURL: "https://github.com/membphis"
@@ -11,7 +11,7 @@ keywords:
 - Service Mesh
 - API Gateway
 - Performance
-description: The performance of the cloud native API gateway Apache APISIX is stronger than that of Envoy when multiple workers are enabled. 
+description: Benchmark comparison of APISIX vs Envoy on response latency and QPS, showing APISIX advantages with multiple worker processes.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/06/17/Apache-APISIX-Dashboard-Access-Control-Bypass-Vulnerability-Announcement.md
+++ b/blog/en/blog/2021/06/17/Apache-APISIX-Dashboard-Access-Control-Bypass-Vulnerability-Announcement.md
@@ -1,5 +1,5 @@
 ---
-title: APISIX Dashboard Access Control Bypass Vulnerability Advisory (CVE-2021-33190)
+title: "CVE-2021-33190: APISIX Dashboard Access Bypass"
 slug: 2021/06/17/apache-apisix-dashboard-access-control-bypass-vulnerability-announcement
 author: Zhiyuan Ju
 authorURL: "https://github.com/juzhiyuan"
@@ -8,7 +8,7 @@ keywords:
 - APISIX
 - Apache APISIX
 - Ingress Controller
-description: Cloud native API gateway Apache APISIX Dashboard Access Control bypass vulnerability announcement, please upgrade the version as soon as possible to fix this vulnerability.
+description: Security advisory for CVE-2021-33190 — APISIX Dashboard access control bypass via X-Forwarded-For header tampering. Upgrade immediately.
 tags: [Vulnerabilities]
 image: https://static.apiseven.com/2022/blog/0818/cve/CVE-2021-33190.png
 ---

--- a/blog/en/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins.md
+++ b/blog/en/blog/2021/06/21/use-Java-to-write-Apache-APISIX-plugins.md
@@ -9,7 +9,7 @@ keywords:
 - Apache APISIX
 - Java
 - plugin
-description: The cloud native API Gateway Apache APISIX already supports Java to write plugins. Users can not only write plugins in Java language, but also integrate into the Spring Cloud ecosystem.
+description: Write APISIX plugins in Java and integrate with Spring Cloud. Includes setup steps and plugin runner architecture.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/08/06/using-apache-apisix-to-improve-the-observability-of-nginx.md
+++ b/blog/en/blog/2021/08/06/using-apache-apisix-to-improve-the-observability-of-nginx.md
@@ -1,5 +1,5 @@
 ---
-title: How to Improve the Observability of Nginx with Apache APISX
+title: Improve Nginx Observability with APISIX
 author: Wei Jin
 authorURL: "https://github.com/gxthrj"
 authorImageURL: "https://avatars.githubusercontent.com/u/4413028?v=4"
@@ -9,7 +9,7 @@ keywords:
 - Apache APISIX
 - Nginx
 - observability
-description: This article will introduce NGINX observability, the relationship between Apache APISIX and Nginx, APISIX observability, and further improving observability with Apache SkyWalking.
+description: Learn how APISIX enhances Nginx observability with built-in metrics, logging, and tracing via Apache SkyWalking integration.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/08/16/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
+++ b/blog/en/blog/2021/08/16/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
@@ -1,5 +1,5 @@
 ---
-title: "Using the Apache APISIX OpenID Connect Plugin for Okta Centralized Authentication"
+title: "APISIX OpenID Connect Plugin with Okta Authentication"
 slug: 2021/08/16/using-the-apache-apisix-openid-connect-plugin-for-centralized-authentication
 author: "Peter Zhu"
 authorURL: "https://github.com/starsz"
@@ -10,7 +10,7 @@ keywords:
   - Apache APISIX
   - Okta
   - Centralized Authentication
-description: Using the openid-connect plugin of the cloud-native API gateway Apache APISIX can quickly interface with the centralized authentication solution OKat.
+description: Step-by-step guide to configure the APISIX openid-connect plugin with Okta for centralized API authentication and SSO.
 tags: [Authentication, Plugins, Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/okta.png
 ---

--- a/blog/en/blog/2021/08/25/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
+++ b/blog/en/blog/2021/08/25/Using-the-Apache-APISIX-OpenID-Connect-Plugin-for-Centralized-Authentication.md
@@ -1,5 +1,5 @@
 ---
-title: Centralized authentication using the OpenID Connect plugin for Apache APISIX
+title: "Centralized Authentication with APISIX OpenID Connect"
 slug: 2021/08/25/using-the-apache-apisix-openid-connect-plugin-for-centralized-authentication
 authors:
   - name: "Xinxin Zhu"
@@ -16,7 +16,7 @@ keywords:
   - Apache APISIX
   - Okta
   - Authorization
-description: Using the openid-connect plugin of the cloud-native API gateway Apache APISIX can quickly interface with the centralized authentication solution OKat.
+description: Simplify API authentication by using the APISIX openid-connect plugin to centralize identity verification at the gateway level.
 tags: [Authentication, Plugins, Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/openid%20connect.png
 ---

--- a/blog/en/blog/2021/10/09/apisix-ingress-techblog.md
+++ b/blog/en/blog/2021/10/09/apisix-ingress-techblog.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Apache APISIX Ingress from concept to practice
+title: "APISIX Ingress Controller: Concepts and Practice"
 author: Jintao Zhang
 authorURL: "https://github.com/tao12345666333"
 authorImageURL: "https://avatars.githubusercontent.com/u/3264292?v=4"
@@ -9,7 +9,7 @@ keywords:
 - Ingress
 - API Gateway
 - Kubernetes
-description: This article introduces the definition of API gateway Apache APISIX Ingress and its differences and advantages with K8s Ingress NGINX.
+description: Learn what APISIX Ingress Controller is, how it differs from Kubernetes Ingress NGINX, and its key advantages for API management.
 tags: [Ecosystem, Community]
 ---
 

--- a/blog/en/blog/2021/11/17/dapr-with-apisix.md
+++ b/blog/en/blog/2021/11/17/dapr-with-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "How to integrate with Dapr to build Apache APISIX Gateway Controller"
+title: "Integrate Dapr with APISIX Ingress Controller"
 author: "Shanyou Zhang"
 authorURL: "https://github.com/geffzhang"
 authorImageURL: "https://avatars.githubusercontent.com/u/439390?v=4"
@@ -9,7 +9,7 @@ keywords:
 - Kubernetes
 - API Gateway
 - Sidecar
-description: This article introduces the concepts of Dapr and Apache APISIX Ingress Controller, and shows how to integrate Dapr to create an Apache APISIX controller.
+description: Learn how to integrate Dapr sidecars with APISIX Ingress Controller on Kubernetes for microservice communication and API management.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/ecosystem/dapr.png
 ---

--- a/blog/en/blog/2021/12/10/integrate-keycloak-auth-in-apisix.md
+++ b/blog/en/blog/2021/12/10/integrate-keycloak-auth-in-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "API Gateway APISIX Integrates Keycloak for Authentication"
+title: "APISIX Keycloak Integration: OpenID Connect Auth"
 authors:
   - name: "Xinxin Zhu"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - Keycloak
 - Authentication
 - Integration
-description: This article shows you how to use OpenID-Connect protocol and Keycloak for identity authentication in API Gateway Apache APISIX through detailed steps.
+description: Step-by-step guide to configure Keycloak authentication in APISIX using the OpenID-Connect protocol for centralized identity management.
 tags: [Plugins,Authentication]
 image: https://static.apiseven.com/2022/blog/0818/plugins/keycloak.png
 ---

--- a/blog/en/blog/2021/12/24/apisix-integrate-openwhisk-plugin.md
+++ b/blog/en/blog/2021/12/24/apisix-integrate-openwhisk-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Coming soon! Apache APISIX Integrate with Apache OpenWhisk"
+title: "APISIX OpenWhisk Plugin: Serverless Integration"
 authors:
   - name: "Zeping Bai"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - Apache OpenWhisk
 - Serverless
 - Plugin
-description: The `openwhisk` plugin is combined with the API Gateway Apache APISIX authentication plugin to achieve authentication and authorization functions.
+description: Learn how the APISIX openwhisk plugin integrates serverless functions with API gateway authentication and authorization.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/openwhish.png
 ---

--- a/blog/en/blog/2022/01/17/apisix-kafka-integration.md
+++ b/blog/en/blog/2022/01/17/apisix-kafka-integration.md
@@ -1,5 +1,5 @@
 ---
-title: "APISIX integrate with Kafka for real-time log monitoring"
+title: "APISIX Kafka Integration for Real-Time Logging"
 authors:
   - name: "Zeping Bai"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - Kafka
 - logging
 - monitoring
-description: This article describes how to use the kafka-logger plugin with APISIX. Wiht enhancements, the plugin now has mature and complete functions.
+description: Configure the APISIX kafka-logger plugin to stream API logs to Apache Kafka for real-time monitoring and analysis.
 tags: [Ecosystem,Plugins]
 image: https://static.apiseven.com/2022/blog/0818/plugins/kafka.png
 ---

--- a/blog/en/blog/2022/01/21/apisix-hashicorp-vault-integration.md
+++ b/blog/en/blog/2022/01/21/apisix-hashicorp-vault-integration.md
@@ -1,5 +1,5 @@
 ---
-title: "HashiCorp Vault Secure Storage Backend in Apache APISIX Ecosystem"
+title: "APISIX + HashiCorp Vault: Secure Secret Storage"
 authors:
   - name: "Bisakh Mondal"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - Vault
 - jwt-auth
 - authentication
-description: This article describe the upcoming release of the Vault with Apache APISIX integration, and show the details of configuration.
+description: Configure HashiCorp Vault as a secure storage backend in APISIX for managing JWT secrets and sensitive credentials.
 tags: [Authentication,Ecosystem,Plugins]
 image: https://static.apiseven.com/2022/blog/0818/plugins/vault.png
 ---

--- a/blog/en/blog/2022/01/25/apisix-grpc-web-integration.md
+++ b/blog/en/blog/2022/01/25/apisix-grpc-web-integration.md
@@ -14,7 +14,7 @@ keywords:
 - gRPC
 - API Gateway
 - Ecology
-description: APISIX has broadened the scope of support for the gRPC ecosystem. This article will introduce details of using the gRPC web protocol request proxy.
+description: Configure APISIX to proxy gRPC-Web requests, enabling browser-based gRPC clients to communicate with backend gRPC services.
 tags: [Ecosystem,Plugins]
 ---
 

--- a/blog/en/blog/2022/02/10/splunk-apisix-integration.md
+++ b/blog/en/blog/2022/02/10/splunk-apisix-integration.md
@@ -1,5 +1,5 @@
 ---
-title: "Integrating Splunk HTTP Event Collector with API Gateway"
+title: "APISIX Splunk Integration: Send Logs via HEC"
 authors:
   - name: "Jinchao Shuai"
     title: "Author"
@@ -14,7 +14,7 @@ keywords:
 - API Gateway
 - Splunk
 - Observability
-description: This article describes how to interface with the Splunk HEC service through the splunk-hec-logging plugin in the cloud-native API gateway Apache APISIX.
+description: Configure the APISIX splunk-hec-logging plugin to forward API gateway logs to Splunk HTTP Event Collector for centralized monitoring.
 tags: [Ecosystem,Plugins]
 image: https://static.apiseven.com/2022/blog/0818/plugins/splunk.png
 ---

--- a/blog/en/blog/2022/02/28/apisix-integration-opentelemetry-plugin.md
+++ b/blog/en/blog/2022/02/28/apisix-integration-opentelemetry-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrade of observability capabilities, API Gateway Apache APISIX integrates OpenTelemetry"
+title: "APISIX OpenTelemetry Plugin: Distributed Tracing"
 authors:
   - name: "Haochao Zhuang"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - OpenTelemetry
 - Observability
 - Ecosystem
-description: This article introduces you to the API Gateway Apache APISIX `opentelemetry` plugin concept and how to enable and deploy the `opentelemetry` plugin.
+description: Enable distributed tracing in APISIX with the OpenTelemetry plugin. Learn setup, configuration, and deployment steps.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/opentelemetry.png
 ---

--- a/blog/en/blog/2022/03/04/apigateway-clickhouse-makes-logging-easier.md
+++ b/blog/en/blog/2022/03/04/apigateway-clickhouse-makes-logging-easier.md
@@ -15,7 +15,7 @@ keywords:
 - ClickHouse
 - Logging
 - Ecosystem
-description: This article describes how Zhendong Qi contributed `clickhouse-logger` to API gateway Apache APISIX, and how to use this plugin to simplify business architecture.
+description: Use the APISIX clickhouse-logger plugin to send API gateway logs directly to ClickHouse for efficient log storage and analysis.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/11/18/63774d2d76267.png
 ---

--- a/blog/en/blog/2022/07/04/apisix-integrates-with-hydra.md
+++ b/blog/en/blog/2022/07/04/apisix-integrates-with-hydra.md
@@ -16,7 +16,7 @@ keywords:
 - Hydra
 - OpenID Connect
 - OIDC
-description: This article describes the API gateway Apache APISIX for centralized authentication via the OpenID Connect plugin Hydra integration.
+description: Set up centralized OAuth 2.0 authentication in APISIX using the OpenID Connect plugin with Ory Hydra as the identity provider.
 tags: [Authentication, Plugins]
 image: https://static.apiseven.com/2022/blog/0818/plugins/ory.png
 ---

--- a/blog/en/blog/2022/07/22/how-is-google-cloud-tau-t2a-performing.md
+++ b/blog/en/blog/2022/07/22/how-is-google-cloud-tau-t2a-performing.md
@@ -1,5 +1,5 @@
 ---
-title: "How is Google Cloud Tau T2A performing? "
+title: "Google Cloud T2A vs T2D: ARM64 API Gateway Benchmark"
 authors:
   - name: "Shirui Zhao"
     title: "Author"
@@ -11,7 +11,7 @@ keywords:
     - Google Cloud
     - Google Cloud T2A
     - ARM64
-description: This article mainly uses the cloud native API gateway Apache APISIX to compare the performance of Google Cloud T2A and Google Cloud T2D.
+description: Performance benchmark of Google Cloud Tau T2A (ARM64) vs T2D using APISIX as the API gateway workload for comparison.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/11/11/636dc26637f24.png
 ---

--- a/blog/en/blog/2022/08/12/arm-performance-google-aws-azure-with-apisix.md
+++ b/blog/en/blog/2022/08/12/arm-performance-google-aws-azure-with-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "GCP, AWS, Azure, and OCI ARM-Based Server Performance Comparison"
+title: "ARM Server Benchmark: GCP vs AWS vs Azure vs OCI"
 authors:
   - name: "Shirui Zhao"
     title: "Author"
@@ -21,7 +21,7 @@ keywords:
 - Google
 - Oracle
 - Apache APISIX
-description: This article compares the performance of Google, AWS, Azure, and Oracle ARM-based servers in network IO-intensive scenarios through the API gateway Apache APISIX.
+description: Performance comparison of ARM-based cloud servers from Google, AWS, Azure, and Oracle using APISIX API gateway as the benchmark workload.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/10/18/634e6963ea45f.png
 ---

--- a/blog/en/blog/2022/09/08/api-monetization-using-stack.md
+++ b/blog/en/blog/2022/09/08/api-monetization-using-stack.md
@@ -1,5 +1,5 @@
 ---
-title: "API monetization using an API Management and a billing provider"
+title: "How to Monetize APIs with APISIX and Billing"
 authors:
   - name: Bobur Umurzokov
     title: Author
@@ -13,7 +13,7 @@ keywords:
 - Microservices
 - Rate limiting
 - Quota
-description: 💁🏼 This blog post gives you an idea of building your technology stack with an API Gateway and a payment provider that can help you run quickly and securely your API monetization system which simply provides flexibility for your customers.
+description: Build an API monetization system using APISIX for rate limiting and quota management with a payment provider for billing.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/10/25/6357addd22a01.png
 ---

--- a/blog/en/blog/2022/10/05/rust-apisix.md
+++ b/blog/en/blog/2022/10/05/rust-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "Rewriting the Apache APISIX response-rewrite plugin in Rust"
+title: "Write APISIX Plugins in Rust with WebAssembly"
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -10,7 +10,7 @@ keywords:
 - Apache APISIX
 - Rust
 - WebAssembly
-description: This article describes how to redevelop the response-rewrite plugin using Rust and WebAssembly.
+description: Build APISIX plugins using Rust and WebAssembly. Walkthrough of rewriting the response-rewrite plugin in Rust with Wasm support.
 tags: [Plugins]
 image: https://static.apiseven.com/2022/10/28/635b5378cdd1f.png
 ---

--- a/blog/en/blog/2022/11/09/georouting-apisix.md
+++ b/blog/en/blog/2022/11/09/georouting-apisix.md
@@ -9,7 +9,7 @@ keywords:
   - Georouting
   - GeoIP
   - Nginx
-description: Apache APISIX, the Apache-led API Gateway, comes out of the box with many plugins to implement your use case. Sometimes, however, the plugin you're looking for is not available. While creating your own is always possible, it's sometimes necessary. Today, I'll show you how to route users according to their location without writing a single line of Lua code.
+description: Route API traffic by user geolocation in APISIX without writing Lua code, using GeoIP and built-in plugins for geographic routing.
 tags: [Ecosystem]
 image: https://repository-images.githubusercontent.com/560493734/4073382d-d3de-42b8-aa58-d0a139978768
 ---

--- a/blog/en/blog/2023/01/02/accessing_apisix-dashboard_from_everywhere_with_keycloak_authentication.md
+++ b/blog/en/blog/2023/01/02/accessing_apisix-dashboard_from_everywhere_with_keycloak_authentication.md
@@ -1,5 +1,5 @@
 ---
-title: "Accessing APISIX-Dashboard from Everywhere with Keycloak Authentication"
+title: "Secure APISIX Dashboard Access with Keycloak"
 authors:
   - name: "Busico Mirto Silvio"
     title: "Author"
@@ -11,7 +11,7 @@ keywords:
   - Nginx reverse proxy
   - OpenID-Connect
   - Keycloak
-description: This guest blog shares how to expose the APISIX Dashboard using APISIX to authenticate access with the OpenID-Connect plugin and Keycloak server to manage identities.
+description: Expose the APISIX Dashboard securely using the OpenID-Connect plugin with Keycloak for identity management and authentication.
 tags:
   - Ecosystem
 cover: https://static.apiseven.com/uploads/2023/01/19/FKDU7U6j_blog01a.png

--- a/blog/en/blog/2023/03/23/mtls-everywhere.md
+++ b/blog/en/blog/2023/03/23/mtls-everywhere.md
@@ -1,5 +1,5 @@
 ---
-title: mTLS everywhere
+title: "How to Configure mTLS in APISIX"
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -11,7 +11,7 @@ keywords:
   - DevOps
   - cert-manager
 description: >
-  Security in one's information system has always been among the most critical Non-Functional Requirements. Transport Secure Layer, aka TLS, formerly SSL, is among its many pillars. In this post, I'll show how to configure TLS for Apache APISIX.
+  Configure mutual TLS (mTLS) for APISIX to secure client-to-gateway and gateway-to-upstream connections with certificate-based authentication.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2023/06/08/JXRmK9nZ_keys.jpeg
 ---

--- a/blog/en/blog/2023/12/26/access-kafka-by-apisix.md
+++ b/blog/en/blog/2023/12/26/access-kafka-by-apisix.md
@@ -9,7 +9,7 @@ keywords:
   - Kafka
   - Gateway
   - Strimzi
-description: A few days ago, I added Apache APISIX as a proxy to an Apache Kafka cluster to manage authentication and authorization. Now, I created a custom authorization plugin in Go for the Kafka cluster.
+description: Use APISIX as a proxy to a Kafka cluster with custom Go authorization plugins for authentication and access control.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2023/12/29/oJyQz1c4_A&K_Cover.png
 ---

--- a/blog/en/blog/2023/12/26/zhengcaiyun-uses-apisix.md
+++ b/blog/en/blog/2023/12/26/zhengcaiyun-uses-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "Building a Robust 'Highway' with APISIX: Gateway and Protocol Performance Optimization"
+title: "APISIX at Zhengcaiyun: Gateway Performance Optimization"
 authors:
   - name: Xiaobin Wang
     title: Author
@@ -14,7 +14,7 @@ keywords:
   - API Gateway
   - Apache APISIX
   - Zhengcaiyun
-description: 'Author: Xiaobin Wang, Apache Dubbo Committer, Senior Development Engineer at Zhengcaiyun. This article is based on a presentation given by Xiaobin Wang at the APISIX Shanghai Meetup in November 2023.'
+description: How Zhengcaiyun optimized API gateway and protocol performance with APISIX, including Dubbo integration and traffic management.
 tags: [Case Studies]
 image: https://static.apiseven.com/uploads/2023/12/08/XDJDiILW_Zheng.jpeg
 ---

--- a/blog/en/blog/2024/02/20/secure-api-practices-apisix-1.md
+++ b/blog/en/blog/2024/02/20/secure-api-practices-apisix-1.md
@@ -1,5 +1,5 @@
 ---
-title: Secure your API with these 16 Practices with Apache APISIX - part 1
+title: "16 API Security Best Practices with APISIX (Part 1)"
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -10,11 +10,7 @@ keywords:
   - Security
   - Good practices
 description: >
-  A couple of months ago, I stumbled upon this list of  Secure your API with these 16 practices to secure your API.
-  Authentication. Authorization. Data Redaction. Encryption. Error Handling. Input Validation & Data Sanitization.
-  Intrusion Detection Systems. IP Whitelisting. Logging and Monitoring.
-  Rate Limiting. Secure Dependencies. Security Headers. Token Expiry. Use of Security Standards and Frameworks.
-  Web Application Firewall. API Versioning
+  Implement 16 API security practices using APISIX: authentication, authorization, encryption, input validation, rate limiting, and more.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/15/kgIjhRXf_img-BuLDzx81CexYQAzkaF36h_large.webp
 ---

--- a/blog/en/blog/2024/02/27/secure-api-practices-apisix-2.md
+++ b/blog/en/blog/2024/02/27/secure-api-practices-apisix-2.md
@@ -1,5 +1,5 @@
 ---
-title: Secure your API with these 16 Practices with Apache APISIX - part 2
+title: "16 API Security Best Practices with APISIX (Part 2)"
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -10,11 +10,7 @@ keywords:
   - Security
   - Good practices
 description: >
-  A couple of months ago, I stumbled upon this list of  Secure your API with these 16 practices to secure your API.
-  Authentication. Authorization. Data Redaction. Encryption. Error Handling. Input Validation & Data Sanitization.
-  Intrusion Detection Systems. IP Whitelisting. Logging and Monitoring.
-  Rate Limiting. Secure Dependencies. Security Headers. Token Expiry. Use of Security Standards and Frameworks.
-  Web Application Firewall. API Versioning
+  Continue implementing API security with APISIX: security headers, WAF, IP whitelisting, logging, token expiry, and API versioning.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/15/kgIjhRXf_img-BuLDzx81CexYQAzkaF36h_large.webp
 ---

--- a/blog/en/blog/2024/10/22/apisix-integrates-with-open-appsec.md
+++ b/blog/en/blog/2024/10/22/apisix-integrates-with-open-appsec.md
@@ -1,5 +1,5 @@
 ---
-title: "Announcing Integration between Apache APISIX and open-appsec WAF"
+title: "APISIX + open-appsec: ML-Based WAF Protection"
 authors:
   - name: "Christopher Lutat"
     title: "Author"
@@ -17,7 +17,7 @@ keywords:
 - Machine Learning
 - API Security
 - Open Source
-description: Let's protect your web APIs and applications exposed by Apache APISIX against known and unknown attacks with open-appsec - the automatic, machine learning-based WAF.
+description: Protect APIs exposed by APISIX against known and zero-day attacks using open-appsec, a machine learning-based web application firewall.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/10/18/8d1iVJWL_logo%20x%20open-appsec.png
 ---

--- a/blog/en/blog/2025/07/31/load-balancing-between-ai-ml-api-with-apisix.md
+++ b/blog/en/blog/2025/07/31/load-balancing-between-ai-ml-api-with-apisix.md
@@ -15,7 +15,7 @@ keywords:
 - AI
 - AI/ML API
 - traffic management
-description: This blog provides a step-by-step guide to configure Apache APISIX for AI traffic splitting and load balancing between API versions, covering security setup, canary testing, and deployment monitoring.
+description: Step-by-step guide to configure APISIX for AI traffic splitting and load balancing between API versions with canary testing.
 tags: [Ecosystem]
 image: https://static.api7.ai/uploads/2025/07/23/d1O3mllW_apisix-ai-ml-api.webp
 ---


### PR DESCRIPTION
## Summary

- Rewrites `title` and `description` frontmatter for the **30 highest-impact blog posts** based on SEO audit scoring
- All titles shortened to ≤55 characters (previously 58-89 chars), fitting within Google SERP display limits
- All descriptions optimized to ≤155 characters with clear value propositions and primary keywords

## Why

From the SEO audit of all 320 English blog posts:
- **82 articles** had titles >55 chars (truncated in Google search results)
- **107 articles** had descriptions >155 chars (truncated by Google)
- **27 articles** had titles missing primary keywords
- **81 articles** had descriptions lacking value propositions

This PR addresses the top 30 articles by potential SEO impact — these are evergreen, high-search-volume topics.

## What changed

| # | Article | Title change | Description change |
|---|---------|-------------|-------------------|
| 1 | ARM server benchmark | 64→48 chars | 162→148 chars |
| 2 | OpenWhisk plugin | 58→47 chars, removed "Coming soon!" | Rewritten with clear value |
| 3 | AI/ML load balancing | No change | 200→136 chars |
| 4 | Dashboard + Keycloak | 71→44 chars | 166→139 chars |
| 5 | Keycloak auth | 57→48 chars | Rewritten for clarity |
| 6 | HashiCorp Vault | 65→47 chars | Rewritten with specifics |
| 7 | API security pt 1 | 67→51 chars | 447→135 chars |
| 8 | API security pt 2 | 67→51 chars | 447→130 chars |
| 9 | Nginx observability | 59→39 chars, fixed "APISX" typo | 180→127 chars |
| 10 | Ory Hydra | No title change | Rewritten with specifics |
| 11 | Kafka proxy | No title change | 193→131 chars |
| 12 | Dapr integration | 68→45 chars | Rewritten for Kubernetes context |
| 13 | open-appsec WAF | 64→45 chars | 165→146 chars |
| 14 | Ingress Controller | 63→48 chars | Rewritten with comparison angle |
| 15 | Okta OpenID Connect | 81→53 chars | Fixed "OKat" typo |
| 16 | Centralized auth OIDC | 76→53 chars | Fixed "OKat" typo, rewritten |
| 17 | Java plugin | No title change | 185→117 chars |
| 18 | OpenTelemetry | 89→48 chars | Rewritten for clarity |
| 19 | Splunk HEC | 56→44 chars | Rewritten with plugin name |
| 20 | API monetization | 63→44 chars | 238→123 chars |
| 21 | Kafka logging | 56→46 chars | Rewritten, fixed typo "Wiht" |
| 22 | Zhengcaiyun case study | 86→55 chars | 199→141 chars, removed author bio |
| 23 | APISIX vs Envoy | 58→49 chars | Rewritten with benchmark framing |
| 24 | mTLS config | 15→31 chars, added "APISIX" keyword | 243→141 chars |
| 25 | CVE-2021-33190 | 78→46 chars | 172→136 chars |
| 26 | ClickHouse logging | No title change | 162→139 chars |
| 27 | Geo-routing | No title change | 358→140 chars |
| 28 | Rust WebAssembly | 59→45 chars | Expanded from 95→140 chars |
| 29 | Google Cloud T2A | 39→52 chars, added "API gateway" keyword | Rewritten with benchmark framing |
| 30 | gRPC-Web | No title change | Rewritten for clarity |

## SEO principles applied

1. **Keyword-first titles**: Primary keyword (APISIX, plugin name, technology) appears early in the title
2. **Search-intent alignment**: Titles reframed from announcements ("Coming soon!", "Announcing") to how-to/guide format
3. **SERP-safe lengths**: All titles ≤55 chars + ` | APISIX` suffix = ≤64 chars in SERPs
4. **Description value props**: Each description tells the reader what they'll learn, not just what the article "describes"
5. **Typo fixes**: Corrected "APISX"→"APISIX", "OKat"→"Okta", "Wiht"→"With"