### PR TITLE
fix(seo): optimize titles and descriptions for 50 blog posts (batch 2)

### DIFF
--- a/blog/en/blog/2020/12/16/another-way-to-implement-envoy-filter.md
+++ b/blog/en/blog/2020/12/16/another-way-to-implement-envoy-filter.md
@@ -9,7 +9,7 @@ keywords:
 - Apache APISIX
 - Envoy
 - Envoy filter
-description: Run APISIX Lua plugins as Envoy filters using apisix-seed. Extend Envoy with dynamic capabilities without writing C++ code.
+description: Run APISIX Lua plugins as Envoy filters using envoy-apisix. Extend Envoy with dynamic capabilities without writing C++ code.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2020/12/16/another-way-to-implement-envoy-filter.md
+++ b/blog/en/blog/2020/12/16/another-way-to-implement-envoy-filter.md
@@ -1,5 +1,5 @@
 ---
-title: "Envoy and Apache APISIX: Another way to implement the Envoy filter"
+title: "Run APISIX Plugins in Envoy as Filters"
 author: "Junxu Chen"
 authorURL: "https://github.com/nic-chen"
 authorImageURL: "https://avatars.githubusercontent.com/u/33000667?v=4"
@@ -9,7 +9,7 @@ keywords:
 - Apache APISIX
 - Envoy
 - Envoy filter
-description: This article describes extending Envoy with new functionality and concrete examples using the base library of the cloud-native API gateway Apache APISIX.
+description: Run APISIX Lua plugins as Envoy filters using apisix-seed. Extend Envoy with dynamic capabilities without writing C++ code.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/01/11/interview-Apache-APISIX-contributor-Wang-Pengcheng-Senior-Security-Advisor-of-PwC-South-China-Data-Security-and-Privacy-Protection-Team.md
+++ b/blog/en/blog/2021/01/11/interview-Apache-APISIX-contributor-Wang-Pengcheng-Senior-Security-Advisor-of-PwC-South-China-Data-Security-and-Privacy-Protection-Team.md
@@ -1,5 +1,5 @@
 ---
-title: Apache APISIX Contributor Interview | Pengcheng Wang from PricewaterhouseCoopers 
+title: "APISIX CVE-2020-13945: Admin API Token Flaw"
 slug: 2021/01/11/interview-apache-apisix-contributor-wang-pengcheng-senior-security-advisor-of-pwc-south-china-data-security-and-privacy-protection-team
 author: Ming Wen
 authorURL: "https://github.com/moonming"
@@ -10,7 +10,7 @@ keywords:
 - Apache APISIX
 - PricewaterhouseCoopers 
 - CVE
-description: PricewaterhouseCoopers reported a vulnerability in the Admin API default token of the API gateway Apache APISIX.
+description: PwC security advisor Pengcheng Wang reported CVE-2020-13945, an Admin API default token vulnerability in APISIX. Read the full interview.
 tags: [Vulnerabilities]
 image: https://static.apiseven.com/2022/blog/0818/cve/CVE-2020-13945.png
 ---

--- a/blog/en/blog/2021/02/08/stable-product-delivery-with-cypress.md
+++ b/blog/en/blog/2021/02/08/stable-product-delivery-with-cypress.md
@@ -8,7 +8,7 @@ keywords:
   - APISIX
   - Apache APISIX
   - Helm Chart
-description: This article describes what E2E testing is and why the API Gateway Apache APISIX dashboard uses Cypress for stable product delivery.
+description: Why APISIX Dashboard uses Cypress for E2E testing. Learn the setup, configuration, and best practices for stable product delivery.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/03/02/get-front-end-test-coverage-with-cypress.md
+++ b/blog/en/blog/2021/03/02/get-front-end-test-coverage-with-cypress.md
@@ -1,5 +1,5 @@
 ---
-title: "Get Front-End Test Coverage with Cypress"
+title: "Get E2E Test Coverage with Cypress"
 author: "Yi Sun"
 authorURL: "https://github.com/LiteSun"
 authorImageURL: "https://avatars.githubusercontent.com/u/31329157?s=400&u=e81b4bb4db2be162c1fcac6d188f5b0f82f71920&v=4"
@@ -8,7 +8,7 @@ keywords:
 - Apache APISIX
 - API Gateway
 - Cypress
-description: This article will explain how to use Cypress to get API Gateway Apache APISIX Dashboard front-end E2E coverage and what is code coverage.
+description: Collect front-end E2E test coverage with Cypress and Istanbul. Measure code coverage for APISIX Dashboard UI testing.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/07/14/the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
+++ b/blog/en/blog/2021/07/14/the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
@@ -1,5 +1,5 @@
 ---
-title: "The Road to Customized Development of Sina Weibo API Gateway"
+title: "Sina Weibo: Migrating from NGINX to APISIX"
 slug: 2021/07/06/the-road-to-customization-of-sina-weibo-api-gateway-based-on-apache-apisix
 author: "Yong Nie"
 keywords:
@@ -8,7 +8,7 @@ keywords:
 - Weibo
 - Usser Case
 - API Gateway
-description: This article analyzes the pain points of NGINX Sina Weibo when using NGINX, and why the cloud-native API gateway Apache APISIX was chosen as the company's API gateway.
+description: Sina Weibo replaced their NGINX-based API gateway with APISIX for dynamic routing, hot reloads, and DevOps-friendly management.
 tags: [Case Studies]
 image: https://static.apiseven.com/2022/blog/0817/weibo.png
 ---

--- a/blog/en/blog/2021/07/14/the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
+++ b/blog/en/blog/2021/07/14/the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
@@ -8,12 +8,12 @@ keywords:
 - Weibo
 - Use Case
 - API Gateway
-description: Sina Weibo replaced their NGINX-based API gateway with APISIX for dynamic routing, hot reloads, and DevOps-friendly management.
+description: Sina Weibo replaced their NGINX-based API gateway with APISIX for dynamic routing, hot reloading, and DevOps-friendly management.
 tags: [Case Studies]
 image: https://static.apiseven.com/2022/blog/0817/weibo.png
 ---
 
-> Sina Weibo’s previous HTTP API gateway was built based on Nginx, which brought up a series of problems. After some research, we chose Apache APISIX, which is dynamic, efficient and stable to meet the fast response requirements of the business.
+> Sina Weibo's previous HTTP API gateway was built based on Nginx, which brought up a series of problems. After some research, we chose Apache APISIX, which is dynamic, efficient and stable to meet the fast response requirements of the business.
 
 <!--truncate-->
 

--- a/blog/en/blog/2021/07/14/the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
+++ b/blog/en/blog/2021/07/14/the-road-to-customization-of-Sina-Weibo-API-gateway-based-on-Apache-APISIX.md
@@ -6,7 +6,7 @@ keywords:
 - Apache APISIX
 - Sina
 - Weibo
-- Usser Case
+- Use Case
 - API Gateway
 description: Sina Weibo replaced their NGINX-based API gateway with APISIX for dynamic routing, hot reloads, and DevOps-friendly management.
 tags: [Case Studies]

--- a/blog/en/blog/2021/07/27/use-of-plugin-orchestration-in-Apache-APISIX.md
+++ b/blog/en/blog/2021/07/27/use-of-plugin-orchestration-in-Apache-APISIX.md
@@ -1,5 +1,5 @@
 ---
-title: "Apply Plugin Orchestration in Apache APISIX"
+title: "APISIX Plugin Orchestration: Low-Code Guide"
 slug: 2021/07/27/use-of-plugin-orchestration-in-apache-apisix
 author: "Zhiyuan Ju"
 authorURL: "https://github.com/juzhiyuan"
@@ -9,7 +9,7 @@ keywords:
 - Plugin Orchestration
 - Apache APISIX Dashboard
 - API Gateway
-description: Read this article to learn about Apache APISIX and basic usage scenarios, and how Apache APISIX integrates "drag and drop" plugin orchestration capabilities in a low-code trend.
+description: Build API processing pipelines with drag-and-drop plugin orchestration in APISIX Dashboard. Low-code configuration tutorial.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/08/10/apisix-nginx.md
+++ b/blog/en/blog/2021/08/10/apisix-nginx.md
@@ -1,5 +1,5 @@
 ---
-title: "APISIX: Dynamic Management for Nginx Clusters"
+title: "APISIX: Dynamic Management for NGINX Clusters"
 author: Hui Tao
 keywords:
 - API Gateway
@@ -8,7 +8,7 @@ keywords:
 - Lua
 - Dynamic Management
 date: "2021-08-10"
-description: Learn how APISIX dynamically manages Nginx clusters via REST API and etcd, enabling hot reloads without downtime.
+description: Learn how APISIX dynamically manages NGINX clusters via REST API and etcd, enabling hot reloading without downtime.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/08/10/apisix-nginx.md
+++ b/blog/en/blog/2021/08/10/apisix-nginx.md
@@ -1,5 +1,5 @@
 ---
-title: "APISIX Architecture: How to Dynamically Manage NGINX Cluster?"
+title: "APISIX: Dynamic Management for Nginx Clusters"
 author: Hui Tao
 keywords:
 - API Gateway
@@ -8,7 +8,7 @@ keywords:
 - Lua
 - Dynamic Management
 date: "2021-08-10"
-description: This article mainly introduces the principle of APISIX to implement REST API remote control of Nginx cluster based on APISIX 2.8, OpenResty 1.19.3.2 and Nginx 1.19.3.
+description: Learn how APISIX dynamically manages Nginx clusters via REST API and etcd, enabling hot reloads without downtime.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/08/18/Auth-with-Casbin-in-Apache-APISIX.md
+++ b/blog/en/blog/2021/08/18/Auth-with-Casbin-in-Apache-APISIX.md
@@ -1,5 +1,5 @@
 ---
-title: Licensing with Casbin in Apache APISIX
+title: RBAC with Casbin in APISIX
 slug: 2021/08/18/auth-with-casbin-in-apache-apisix
 author: Casbin & Apache APISIX
 keywords:
@@ -8,7 +8,7 @@ keywords:
 - Apache APISIX
 - Casbin
 - RBAC
-description: When we are using API Gateway Apache APISIX, we may need to add complex authorization logic. we can implement RBAC using APISIX's built-in Casbin plugin (authz-casbin).
+description: Implement role-based access control in APISIX using the authz-casbin plugin. Step-by-step RBAC configuration guide.
 tags: [Ecosystem, Plugins]
 image: https://static.apiseven.com/2022/blog/0818/plugins/casbin.png
 ---

--- a/blog/en/blog/2021/09/07/how-to-use-apisix-auth.md
+++ b/blog/en/blog/2021/09/07/how-to-use-apisix-auth.md
@@ -1,5 +1,5 @@
 ---
-title: Centralized Authentication with Apache APISIX and Advanced Tricks
+title: Centralized Authentication with APISIX
 author: Xinxin Zhu
 authorURL: "https://github.com/starsz"
 authorImageURL: "https://avatars.githubusercontent.com/u/25628854?v=4"
@@ -8,7 +8,7 @@ keywords:
 - Casbin
 - Authorization
 - Practical Case
-description: This article introduces the authentication function of the cloud native API gateway Apache APISIX, and introduces the importance and usage in detail.
+description: Centralize API authentication with APISIX using key-auth, JWT, and OpenID Connect plugins. Reduce backend complexity and improve security.
 tags: [Authentication, Ecosystem]
 ---
 

--- a/blog/en/blog/2021/09/14/youzan.md
+++ b/blog/en/blog/2021/09/14/youzan.md
@@ -1,5 +1,5 @@
 ---
-title: "Youzanyun PaaS for comprehensive micro-service governance with APISX"
+title: "Youzan PaaS: Microservice Governance with APISIX"
 author: "Nuojing Dai"
 keywords: 
 - Apache APISIX
@@ -7,7 +7,7 @@ keywords:
 - API Gateway
 - Microservice
 - Cloud native
-description: This article introduces how Youzan cloud-native PaaS platform uses cloud-native API gateway Apache APISIX as a product traffic gateway and the benefits it brings.
+description: Learn how Youzan uses APISIX as a traffic gateway in their cloud-native PaaS platform for microservice governance and canary releases.
 tags: [Case Studies]
 image: https://static.apiseven.com/2022/blog/0817/%E6%9C%89%E8%B5%9E%E4%BA%91.png
 ---

--- a/blog/en/blog/2021/11/04/skywalking.md
+++ b/blog/en/blog/2021/11/04/skywalking.md
@@ -1,5 +1,5 @@
 ---
-title: "The observability of Apache APISIX"
+title: "APISIX Observability with SkyWalking"
 authors:
   - name: "Haochao Zhuang"
     title: "Author"
@@ -16,7 +16,7 @@ keywords:
 - SkyWalking
 - Apache
 - Prometheus
-description: This article introduces the observability capabilities of Apache APISIX and how to improve the observability capabilities of Apache APISIX through Apache SkyWalking.
+description: Deploy SkyWalking to monitor APISIX metrics, traces, and logs. Step-by-step guide for full API gateway observability.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/skywalking.png
 ---

--- a/blog/en/blog/2021/11/12/apisix-datadog.md
+++ b/blog/en/blog/2021/11/12/apisix-datadog.md
@@ -8,7 +8,7 @@ keywords:
 - Datadog
 - Observability
 - Cloud Monitoring
-description: This article introduces how the cloud-native API gateway Apache APISIX uses the datadog plugin to integrate with the Datadog monitoring platform.
+description: Integrate APISIX with Datadog for real-time API monitoring. Configure the datadog plugin for metrics collection and dashboard visualization.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/Datadog.png
 ---

--- a/blog/en/blog/2021/11/30/use-apisix-ingress-in-kubesphere.md
+++ b/blog/en/blog/2021/11/30/use-apisix-ingress-in-kubesphere.md
@@ -7,7 +7,7 @@ keywords:
 - KubeSphere
 - Apache APISIX
 - API Gateway
-- Kubenetes
+- Kubernetes
 - Ingress Controller
 - Monitor
 description: Deploy APISIX Ingress Controller in KubeSphere with built-in monitoring. Configure cluster and project gateways step by step.

--- a/blog/en/blog/2021/11/30/use-apisix-ingress-in-kubesphere.md
+++ b/blog/en/blog/2021/11/30/use-apisix-ingress-in-kubesphere.md
@@ -1,5 +1,5 @@
 ---
-title: "Using APISIX Ingress to access custom monitoring in KubeSphere"
+title: "APISIX Ingress with KubeSphere Monitoring"
 author: "Haili Zhang"
 authorURL: "https://github.com/webup"
 authorImageURL: "https://avatars.githubusercontent.com/u/2936504?v=4"
@@ -10,7 +10,7 @@ keywords:
 - Kubenetes
 - Ingress Controller
 - Monitor
-description: This article uses Apache APISIX Ingress Controller as an example to introduce how to quickly use different gateways for Kubernetes clusters and monitor status through KubeSphere.
+description: Deploy APISIX Ingress Controller in KubeSphere with built-in monitoring. Configure cluster and project gateways step by step.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2021/12/07/apisix-integrate-skywalking-plugin.md
+++ b/blog/en/blog/2021/12/07/apisix-integrate-skywalking-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "Apache APISIX Integrates with SkyWalking for Log Processing"
+title: "APISIX SkyWalking Log Plugins Guide"
 authors: 
   - name: "Haochao Zhuang"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - Apache SkyWalking
 - Log Process
 - Plugin
-description: This paper mainly introduces two Apache APISIX integrated SkyWalking log plugins to provide a more convenient operation and environment for log processing in Apache APISIX.
+description: Configure APISIX SkyWalking log plugins for centralized API log processing. Collect error logs and access logs with tracing context.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/skywalking.png
 ---

--- a/blog/en/blog/2021/12/08/apisix-integrate-rocketmq-logger-plugin.md
+++ b/blog/en/blog/2021/12/08/apisix-integrate-rocketmq-logger-plugin.md
@@ -15,7 +15,7 @@ keywords:
 - API
 - Log processing
 - Monitoring function
-description: The rocketmq-logger log plugin added by the API gateway Apache APISIX can help you connect with the RocketMQ cluster more conveniently when using APISIX.
+description: Push APISIX request logs to RocketMQ clusters as JSON. Configure the rocketmq-logger plugin for centralized API log collection.
 tags: [Plugins,Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/plugins/RocketMQy.png
 ---

--- a/blog/en/blog/2021/12/15/deploy-apisix-in-kubernetes.md
+++ b/blog/en/blog/2021/12/15/deploy-apisix-in-kubernetes.md
@@ -16,7 +16,7 @@ keywords:
 - APISIX Dashboard
 - Deployment
 - Cluster
-description: API Gateway Apache APISIX currently supports multiple ways to install and deploy. This article focuses on how to deploy APISIX and Dashboard in a Kubernetes environment.
+description: Deploy APISIX and Dashboard in Kubernetes using Helm Chart. Step-by-step guide with configuration examples and best practices.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/ecosystem/kubernetes.png
 ---

--- a/blog/en/blog/2021/12/17/exposure-istio-with-apisix-ingress.md
+++ b/blog/en/blog/2021/12/17/exposure-istio-with-apisix-ingress.md
@@ -1,5 +1,5 @@
 ---
-title: "Secure Exposure of Istio Services with APISIX Ingress"
+title: "Expose Istio Services with APISIX Ingress"
 authors:
   - name: "Jintao Zhang"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - Kubernetes
 - APISIX Ingress Controller
 - Service Mesh
-description: This article shows how to use Istio Service Mesh and API Gateway Apache APISIX to expose services from a Service Mesh-enabled Kubernetes cluster outside the cluster.
+description: Expose Kubernetes services from an Istio service mesh using APISIX Ingress Controller. Step-by-step integration guide.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2022/02/11/cve-2022-24112.md
+++ b/blog/en/blog/2022/02/11/cve-2022-24112.md
@@ -1,10 +1,10 @@
 ---
-title: "Apache APISIX Vulnerability for Rewriting X-REAL-IP Header (CVE-2022-24112)"
+title: "CVE-2022-24112: APISIX batch-requests IP Bypass"
 keywords: 
 - Vulnerability
 - Header
 - IP restrictions
-description: In versions prior to Apache APISIX 2.12.1, there is a risk of rewriting X-REAL-IP header after enabling the Apache APISIX `batch- requests` plugin. 
+description: The APISIX batch-requests plugin allowed X-REAL-IP header rewriting, bypassing IP restrictions (CVE-2022-24112). Upgrade to 2.12.1+.
 tags: [Vulnerabilities]
 image: https://static.apiseven.com/2022/blog/0818/cve/CVE-2022-24112.png
 ---

--- a/blog/en/blog/2022/02/16/file-logger-api-gateway.md
+++ b/blog/en/blog/2022/02/16/file-logger-api-gateway.md
@@ -1,5 +1,5 @@
 ---
-title: "How to develop plugin in API Gateway"
+title: "Build an APISIX Plugin: file-logger Tutorial"
 authors:
   - name: "Qi Guo"
     title: "Author"
@@ -13,7 +13,7 @@ keywords:
 - API Gateway
 - Logging
 - file logger
-description: This article introduces the specific steps for front-end engineers to develop file-logger plugins on the cloud-native API gateway Apache APISIX.
+description: Step-by-step guide to developing a custom APISIX plugin. Learn the full workflow by building the file-logger plugin from scratch.
 tags: [Plugins,Ecosystem]
 ---
 

--- a/blog/en/blog/2022/02/23/csrf-api-gateway.md
+++ b/blog/en/blog/2022/02/23/csrf-api-gateway.md
@@ -15,7 +15,7 @@ keywords:
 - cross-site request forgery
 - CSRF
 - API Gateway
-description: This article introduces `csrf`, the CSRF security plugin for API Gateway, and details how to secure your API information in APISIX with the help of the `csrf` plugin.
+description: Prevent cross-site request forgery attacks using the APISIX CSRF plugin. Step-by-step configuration guide with examples.
 tags: [Plugins,Ecosystem]
 ---
 

--- a/blog/en/blog/2022/02/25/consul-api-gateway.md
+++ b/blog/en/blog/2022/02/25/consul-api-gateway.md
@@ -14,7 +14,7 @@ keywords:
 - Consul
 - Service Discovery
 - Servici Register
-description: Apache APISIX supports the Consul KV-based service discovery registry. This article will walk you through the process of implementing service discovery and service registry in APISIX.
+description: Integrate Consul KV with APISIX for service discovery and registration. Configure upstream resolution with health checks.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/ecosystem/HashiCorp%20Consul.png
 ---

--- a/blog/en/blog/2022/02/25/consul-api-gateway.md
+++ b/blog/en/blog/2022/02/25/consul-api-gateway.md
@@ -13,7 +13,7 @@ keywords:
 - API Gateway
 - Consul
 - Service Discovery
-- Servici Register
+- Service Register
 description: Integrate Consul KV with APISIX for service discovery and registration. Configure upstream resolution with health checks.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/ecosystem/HashiCorp%20Consul.png

--- a/blog/en/blog/2022/03/01/apisix-integration-public-api-plugin.md
+++ b/blog/en/blog/2022/03/01/apisix-integration-public-api-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: "API Gateway Apache APISIX provides enhancements on API Management"
+title: "APISIX public-api Plugin: Protect Internal APIs"
 authors:
   - name: "Zeping Bai"
     title: "Author"
@@ -14,7 +14,7 @@ keywords:
 - API Gateway
 - Security
 - Ecosystem
-description: You can protect custom APIs in APISIX plugins through the public-api plugin of Apache APISIX, a cloud-native API gateway, and introduce its application scenarios.
+description: Protect internal plugin APIs from public access using the APISIX public-api plugin. Learn configuration and use cases.
 tags: [Plugins,Ecosystem]
 ---
 

--- a/blog/en/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
+++ b/blog/en/blog/2022/03/04/apisix-uses-coredns-enable-service-discovery.md
@@ -16,7 +16,7 @@ keywords:
 - Service Discovery
 - Service Register
 - Ecosystem
-description: The cloud-native API Gateway Apache APISIX integrates multiple service discovery capabilities. This article will show you how to configure CoreDNS in APISIX.
+description: Configure CoreDNS as a service discovery backend in APISIX. Dynamic upstream resolution with DNS-based service registry.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/ecosystem/CoreDNS.png
 ---

--- a/blog/en/blog/2022/04/20/cve-2022-29266.md
+++ b/blog/en/blog/2022/04/20/cve-2022-29266.md
@@ -1,10 +1,10 @@
 ---
-title: "The Vulnerability of Leaking Information in Error Response from jwt-auth Plugin（CVE-2022-29266）"
+title: "CVE-2022-29266: jwt-auth Secret Leak Fix"
 keywords: 
 - Vulnerability
 - jwt-auth
 - Error Response
-description: In APISIX 2.13.0 and previous versions, there is a problem of information leakage caused by the `jwt- auth` plugin.
+description: APISIX jwt-auth plugin leaked secrets in error responses (CVE-2022-29266). Upgrade to 2.13.1+ to fix. Patch available for older versions.
 tags: [Vulnerabilities]
 image: https://static.apiseven.com/2022/blog/0818/cve/CVE-2022-29266-1.png
 ---

--- a/blog/en/blog/2022/06/07/installation-performance-test-of-apigateway-apisix-on-aws-graviton3.md
+++ b/blog/en/blog/2022/06/07/installation-performance-test-of-apigateway-apisix-on-aws-graviton3.md
@@ -1,5 +1,5 @@
 ---
-title: "Installation and performance testing of API Gateway Apache APISIX on AWS Graviton3"
+title: "APISIX Performance on AWS Graviton3 vs Graviton2"
 authors:
   - name: "Shirui Zhao"
     title: "Author"
@@ -15,7 +15,7 @@ keywords:
 - AWS
 - AWS Graviton3
 - ARM64
-description: This article uses APISIX to compare the performance of AWS Graviton3 and AWS Graviton2. AWS Graviton3 shows the power performance in the API gateway.
+description: Benchmark APISIX on AWS Graviton3 (C7g) vs Graviton2 (C6g). Deployment guide and performance comparison on ARM64.
 tags: [Ecosystem]
 ---
 

--- a/blog/en/blog/2022/06/14/beeto-with-apache-apisix.md
+++ b/blog/en/blog/2022/06/14/beeto-with-apache-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "Practice of localized application with API gateway in the Middle East"
+title: "How Beeto Uses APISIX for API Management"
 authors:
   - name: "Lilin Hu"
     title: "Author"
@@ -14,7 +14,7 @@ keywords:
 - the Middle East
 - Traffic
 - Security
-description: This article introduces how the Middle East social software Beeto uses APISIX to achieve localized deployment in security and scalability.
+description: Learn how Beeto, a Middle East social app, uses APISIX for localized API deployment with enhanced security and scalability.
 tags: [Case Studies]
 image: https://static.apiseven.com/2022/blog/0817/beeto.png
 ---

--- a/blog/en/blog/2022/07/06/use-keycloak-with-api-gateway-to-secure-apis.md
+++ b/blog/en/blog/2022/07/06/use-keycloak-with-api-gateway-to-secure-apis.md
@@ -1,5 +1,5 @@
 ---
-title: "Use Keycloak with API Gateway to secure APIs"
+title: "Secure APIs with Keycloak and APISIX"
 authors:
   - name: "Xinxin Zhu"
     title: "Apache APISIX Committer"
@@ -15,7 +15,7 @@ keywords:
   - Authentication
   - OpenID Connect
   - Keycloak
-description: This article describes how to secure your API with API Gateway Apache APISIX and Keycloak, and introduces OpenID Connect related concepts and interaction flow.
+description: Integrate Keycloak with APISIX using the OpenID Connect plugin. Configure SSO authentication for your APIs step by step.
 tags: [Authentication, Plugins]
 image: https://static.apiseven.com/2022/blog/0818/plugins/keycloak.png
 ---

--- a/blog/en/blog/2022/07/30/why-we-need-apache-apisix.md
+++ b/blog/en/blog/2022/07/30/why-we-need-apache-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: Why do you need Apache APISIX when you have NGINX and Kong?
+title: Why Choose APISIX Over NGINX and Kong?
 author: "Fei Han"
 authorURL: "https://github.com/hf400159"
 authorImageURL: "https://github.com/hf400159.png"
@@ -10,7 +10,7 @@ keywords:
 - Nginx
 - Open Source
 - API Management
-description: This article introduces how the cloud native API gateway Apache APISIX solves the business pain points and usage scenarios brought by Nginx and Kong.
+description: APISIX solves key NGINX and Kong pain points: dynamic config, cluster management, and hot reloads. See the architecture comparison.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/11/07/636916ea65769.png
 ---

--- a/blog/en/blog/2022/07/30/why-we-need-apache-apisix.md
+++ b/blog/en/blog/2022/07/30/why-we-need-apache-apisix.md
@@ -10,7 +10,7 @@ keywords:
 - Nginx
 - Open Source
 - API Management
-description: APISIX solves key NGINX and Kong pain points: dynamic config, cluster management, and hot reloads. See the architecture comparison.
+description: APISIX solves key NGINX and Kong pain points: dynamic config, cluster management, and hot reloading. See the architecture comparison.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/11/07/636916ea65769.png
 ---

--- a/blog/en/blog/2022/08/28/fault-injection-testing-with-api-gateway.md
+++ b/blog/en/blog/2022/08/28/fault-injection-testing-with-api-gateway.md
@@ -11,7 +11,7 @@ keywords:
 - Testing
 - Fault Injection
 - Microservices
-description: The blog post describes how Apache APISIX is useful for testing the robustness and resilience of microservices APIs. Throughout the post, we also get to know the types of possible failure injections with the Fault Injection Plugin.
+description: Test microservice resilience using the APISIX fault-injection plugin. Simulate errors, delays, and aborts to verify circuit breakers and retries.
 tags: [Plugins]
 image: https://static.apiseven.com/2022/10/20/6350b3f63a715.png
 ---

--- a/blog/en/blog/2022/09/13/why-is-apache-apisix-the-best-api-gateway.md
+++ b/blog/en/blog/2022/09/13/why-is-apache-apisix-the-best-api-gateway.md
@@ -11,7 +11,7 @@ keywords:
   - API Management Platform
   - The Best API Gateway
   - Apache APISIX
-description: Why is Apache APISIX the best API Gateway? We will compare multiple API gateways (Kong, Tyk, Gloo) in terms of the popularity among developers, open source licenses, performances, and the ecosystem as a whole.
+description: Compare APISIX with Kong, Tyk, and Gloo across performance, community activity, open source licenses, and ecosystem features.
 tags: [Community]
 image: https://static.apiseven.com/2022/11/05/6365f2b8be5a7.png
 ---

--- a/blog/en/blog/2022/12/07/web-caching-client.md
+++ b/blog/en/blog/2022/12/07/web-caching-client.md
@@ -1,5 +1,5 @@
 ---
-title: "Web resource caching: Client-Side"
+title: "Web Caching: Client-Side HTTP Cache Guide"
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -10,7 +10,7 @@ keywords:
   - HTTP
   - Cache
   - Performance
-description: "The subject of Web resource caching is as old as the World Wide Web itself. However, I'd like to offer an as-exhaustive-as-possible catalog of how one can improve performance by caching. Web resource caching can happen in two different places: client-side - on the browser and server-side. This post is dedicated to the former; the next post will focus on the latter."
+description: "Master client-side HTTP caching: Cache-Control, ETag, Last-Modified, and freshness strategies. A complete guide to browser caching."
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/12/13/63981dcbe4b0c.jpg
 ---

--- a/blog/en/blog/2022/12/14/web-caching-server.md
+++ b/blog/en/blog/2022/12/14/web-caching-server.md
@@ -1,5 +1,5 @@
 ---
-title: "Web resource caching: Server-Side"
+title: "Web Caching: Server-Side Cache Strategies"
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -10,7 +10,7 @@ keywords:
   - HTTP
   - Cache
   - Performance
-description: "The subject of Web resource caching is as old as the World Wide Web itself. However, I'd like to offer an as-exhaustive-as-possible catalog of how one can improve performance by caching. Web resource caching can happen in two different places: client-side - on the browser and server side. In the previous post, I explained the former; this post focuses on the latter."
+description: "Implement server-side caching with Varnish, Redis, Memcached, and API gateways. Compare reverse proxy caching strategies for web performance."
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/12/13/63981be362ec4.jpg
 ---

--- a/blog/en/blog/2023/01/18/consul-with-apisix.md
+++ b/blog/en/blog/2023/01/18/consul-with-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Integrate API Gateway and Consul? Not Consul K/V"
+title: "APISIX with Consul Service Discovery (Not KV)"
 authors:
   - name: "Yihao LI"
     title: "Author"
@@ -10,7 +10,7 @@ keywords:
 - Consul
 - Service Discovery
 - Service Register
-description: Apache APISIX supports the Consul service discovery registry. This article will walk you through the process of implementing service discovery and service registry in APISIX.
+description: Integrate Consul native service discovery with APISIX. Configure service registration and upstream resolution without Consul KV.
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/blog/0818/ecosystem/HashiCorp%20Consul.png
 ---

--- a/blog/en/blog/2023/03/02/security-policy-auditable.md
+++ b/blog/en/blog/2023/03/02/security-policy-auditable.md
@@ -12,7 +12,7 @@ keywords:
   - Spring Security
   - Solutions Architecture
 description: >
-  Last week, I wrote about putting the right feature at the right place. I used rate limiting as an example, moving it from a library inside the application to the API Gateway. Today, I'll use another example: authentication and authorization.
+  Move authentication and authorization to your API gateway for auditable, centralized security. Compare app-level vs gateway-level approaches.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2023/06/08/pzULiHZO_opa-horizontal-color.svg
 ---

--- a/blog/en/blog/2023/04/14/10-api-management-trends-2023.md
+++ b/blog/en/blog/2023/04/14/10-api-management-trends-2023.md
@@ -1,5 +1,5 @@
 ---
-title: Top 10 API Management Trends for 2023
+title: Top 10 API Management Trends in 2023
 authors:
   - name: API7.ai
     title: Author
@@ -9,7 +9,7 @@ keywords:
   - Apache APISIX
   - API Management
   - Microservices
-description: "10 major trends in API management: API security, standardization, cloud-based API management solutions, low-code API platforms, API marketplaces, emerging API protocols, AI and APIs, developer experience, API analytics, and serverless architecture."
+description: "Explore 10 API management trends: security, standardization, cloud platforms, low-code, AI integration, and developer experience."
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2023/04/12/PtHsoEJS_top-10-trends.png
 canonical_url: "https://api7.ai/blog/10-api-management-trends-2023"

--- a/blog/en/blog/2023/05/04/apache-apisix-chaos-engineering.md
+++ b/blog/en/blog/2023/05/04/apache-apisix-chaos-engineering.md
@@ -1,5 +1,5 @@
 ---
-title: Building a More Robust Apache APISIX Ingress Controller With Litmus Chaos
+title: Chaos Engineering for APISIX Ingress Controller
 authors:
   - name: API7.ai
     title: Author
@@ -9,7 +9,7 @@ keywords:
   - Apache APISIX
   - Chaos Engineering
   - APISIX Ingress Controller
-description: Chaos engineering is a powerful tool for ensuring system reliability and performance, and its application in designing Chaos experiments for Ingress Controllers can help organizations identify weaknesses in their applications and infrastructure.
+description: Design chaos experiments for APISIX Ingress Controller using LitmusChaos. Test resilience with pod failures and network disruptions.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2023/04/20/yeuKN9nu_Building%20a%20More%20Robust%20Apache%20APISIX%20Ingress%20Controller%20With%20Litmus%20Chaos.png
 canonical_url: "https://api7.ai/blog/apache-apisix-chaos-engineering"

--- a/blog/en/blog/2023/06/30/apisix-mqtt-proxy.md
+++ b/blog/en/blog/2023/06/30/apisix-mqtt-proxy.md
@@ -1,5 +1,5 @@
 ---
-title: Connecting IoT Devices to the Cloud with APISIX MQTT Proxy
+title: APISIX as an MQTT Proxy for IoT Devices
 authors:
   - name: Navendu Pottekkat
     title: Author
@@ -10,7 +10,7 @@ keywords:
   - MQTT
   - Cloud
   - TLS
-description: A guide to using Apache APISIX as an MQTT proxy to connect IoT devices to the cloud.
+description: Use APISIX as an MQTT proxy to connect IoT devices to the cloud. Configure stream routes, TLS, and load balancing for MQTT traffic.
 tags: [Plugins]
 image: https://static.apiseven.com/uploads/2023/06/23/kdd9TigM_mqtt-apisix-cover.png
 ---

--- a/blog/en/blog/2023/12/14/apisix-plugins-priority-leaky-abstraction.md
+++ b/blog/en/blog/2023/12/14/apisix-plugins-priority-leaky-abstraction.md
@@ -1,5 +1,5 @@
 ---
-title: Apache APISIX plugin priority, a leaky abstraction?
+title: APISIX Plugin Priority and Execution Phases
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -11,8 +11,7 @@ keywords:
   - priority
   - abstraction
 description: >
-    Apache APISIX builds upon the OpenResty reverse-proxy to offer a plugin-based architecture. The main benefit of such an architecture is that it brings structure to the configuration of routes. It's a help at scale, when managing hundreds or thousands of routes.
-    In this post, I'd like to describe how plugins, priority, and phases play together and what pitfalls you must be aware of.
+    Understand how APISIX plugin priority and execution phases interact. Avoid common pitfalls when ordering plugins across rewrite and access phases.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2023/12/09/acT4tzVw_puzzle-3486885.jpg
 ---

--- a/blog/en/blog/2023/12/14/migu-video-adopts-apisix.md
+++ b/blog/en/blog/2023/12/14/migu-video-adopts-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Supercharge Large-Scale Video Operations with APISIX"
+title: "Migu Video: APISIX at Large-Scale Streaming"
 authors:
   - name: Yu Xia
     title: Author
@@ -13,7 +13,7 @@ keywords:
   - Apache APISIX
   - Migu Video
   - API gateway best practice
-description: Explore the ultimate guide on optimizing large-scale video operations using APISIX in Migu Video.
+description: Migu Video deploys APISIX for large-scale streaming operations. Real-world architecture, traffic management, and performance results.
 tags: [Case Studies]
 image: https://static.apiseven.com/uploads/2023/12/06/ZYrbfw7r_Migu-video.png
 ---

--- a/blog/en/blog/2023/12/19/datavisor-uses-apisix.md
+++ b/blog/en/blog/2023/12/19/datavisor-uses-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: "Enhancing Security and Performance: DataVisor's Dynamic Use of APISIX"
+title: "DataVisor Case Study: Custom APISIX Plugins"
 authors:
   - name: Xiaobiao Zhao
     title: Author
@@ -15,7 +15,7 @@ keywords:
   - Apache APISIX
   - DataVisor
   - API gateway best practice
-description:  DataVisor not only uses APISIX in its production environment but also enhances APISIX through customization, and these efforts have proven successful in optimizing DataVisor's production processes.
+description: DataVisor uses customized APISIX plugins for risk control APIs. Learn their production deployment, custom plugins, and performance gains.
 tags: [Case Studies]
 image: https://static.apiseven.com/uploads/2023/12/05/gM8zRGh1_Cover_Datavisor.png
 ---

--- a/blog/en/blog/2024/02/07/unlock-observability-for-apisix-with-deepflow.md
+++ b/blog/en/blog/2024/02/07/unlock-observability-for-apisix-with-deepflow.md
@@ -1,5 +1,5 @@
 ---
-title: "Unlock All-in-One Observability for APISIX with DeepFlow"
+title: "APISIX Observability with DeepFlow and eBPF"
 authors:
   - name: Qian Li
     title: Author
@@ -9,7 +9,7 @@ keywords:
   - APISIX
   - DeepFlow
   - Observability
-description: This article aims to elucidate how to leverage DeepFlow's zero-code feature based on eBPF to construct an observability solution for APISIX.
+description: Build zero-code observability for APISIX using DeepFlow and eBPF. Unified tracing, metrics, logs, and profiling without code changes.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/07/nQJ5SWsx_deepflow-cover-en.jpeg
 ---

--- a/blog/en/blog/2024/02/13/apisix-owasp-coraza-core-ruleset.md
+++ b/blog/en/blog/2024/02/13/apisix-owasp-coraza-core-ruleset.md
@@ -1,5 +1,5 @@
 ---
-title: Hardening Apache APISIX with the OWASP's Coraza and Core Ruleset
+title: Protect APIs with OWASP Coraza WAF in APISIX
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -10,9 +10,7 @@ keywords:
   - OWASP
   - Coraza
 description: >
-  The Open Worldwide Application Security Project is an online community that produces freely available articles, methodologies, documentation, tools, and technologies in the fields of IoT, system software and web application security. The OWASP provides free and open resources. It is led by a non-profit called The OWASP Foundation. The OWASP Top 10 - 2021 is the published result of recent research based on comprehensive data compiled from over 40 partner organizations.
-  The OWASP regularly publishes a Top 10 vulnerability report. The report targets vulnerabilities in web applications.
-  In this post, I'd like to describe how to fix some of them via the Apache APISIX API Gateway.
+  Deploy the Coraza WAF with OWASP Core Rule Set in APISIX to protect APIs against the OWASP Top 10 vulnerabilities including injection and XSS.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/02/10/vVlFQu7C_img-HDlf4Xx9m1iqS0Ico3oBZ.png
 ---

--- a/blog/en/blog/2024/04/11/implement-idempotency-key-apisix.md
+++ b/blog/en/blog/2024/04/11/implement-idempotency-key-apisix.md
@@ -1,5 +1,5 @@
 ---
-title: Implementing the Idempotency-Key specification on Apache APISIX
+title: Implement Idempotency-Key in APISIX
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -13,10 +13,7 @@ keywords:
   - plugin
   - coding
 description: >
-  Last week, I wrote an analysis of the IETF Idempotency-Key specification. The specification aims to avoid duplicated requests. In short, the idea is for the client to send a unique key along with the request:
-  If the server doesn't know the key, it proceeds as usual and then stores the response.
-  If the server knows the key, it short-circuits any further processing and immediately returns the stored response.
-  This post shows how to implement it with Apache APISIX.
+  Build an APISIX plugin implementing the IETF Idempotency-Key spec to prevent duplicate API requests and ensure safe retries.
 tags: [Plugin]
 image: https://static.apiseven.com/uploads/2024/04/09/0rfsRevo_stormtrooper-2899993.jpg
 ---

--- a/blog/en/blog/2024/05/02/cve-2024-32638.md
+++ b/blog/en/blog/2024/05/02/cve-2024-32638.md
@@ -1,10 +1,10 @@
 ---
-title: "HTTP Request Smuggling in forward-auth Plugin (CVE-2024-32638)"
+title: "CVE-2024-32638: APISIX forward-auth Smuggling"
 keywords: 
 - Vulnerability
 - forward-auth
 - Smuggling
-description: Enabling the `forward-auth` plugin allows Apache APISIX to trigger illegal requests (HTTP Request Smuggling), resulting in a security vulnerability.
+description: APISIX forward-auth plugin allows HTTP request smuggling in versions 3.8.0 and 3.9.0 (CVE-2024-32638). Upgrade to 3.8.1+ or 3.9.1+.
 tags: [Vulnerabilities]
 image: https://static.apiseven.com/uploads/2024/05/06/Wq940JRt_CVE-2024-32638.png
 ---

--- a/blog/en/blog/2024/07/11/watermarking-infrastructure.md
+++ b/blog/en/blog/2024/07/11/watermarking-infrastructure.md
@@ -1,5 +1,5 @@
 ---
-title: Dynamic watermarking with imgproxy and Apache APISIX
+title: Dynamic Image Watermarking with APISIX
 authors:
   - name: Nicolas Fränkel
     title: Author
@@ -11,8 +11,7 @@ keywords:
   - image processing
   - imgproxy
 description: >
-  Last week, I described how to add a dynamic watermark to your images on the JVM. I didn't find any library, so I had to develop the feature, or, more precisely, an embryo of a feature, by myself. Depending on your tech stack, you must search for an existing library or roll up your sleeves. For example, Rust offers such an out-of-the-box library. Worse, this approach might be impossible to implement if you don't have access to the source image.
-  Another alternative is to use ready-made components, namely imgproxy and Apache APISIX. I already combined them to resize images on-the-fly.
+  Add dynamic watermarks to images on-the-fly using imgproxy and APISIX. No source code changes needed for infrastructure-level watermarking.
 tags: [Ecosystem]
 image: https://static.apiseven.com/uploads/2024/07/04/j2xS06dA_faucet-1684902.jpg
 ---

--- a/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
+++ b/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud vs Open Source vs Commercial API Gateways: Which One Fits Your Needs?"
+title: "Cloud vs Open Source vs Commercial API Gateways"
 authors:
   - name: Ming Wen
     title: Author

--- a/blog/en/blog/2025/04/01/embrace-intelligent-api-management-with-ai-and-mcp.md
+++ b/blog/en/blog/2025/04/01/embrace-intelligent-api-management-with-ai-and-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: "APISIX-MCP: Embracing Intelligent API Management with AI + MCP"
+title: "APISIX-MCP: Manage APIs with Natural Language"
 authors:
   - name: Zhihuang Lin
     title: API7 Engineer
@@ -18,7 +18,7 @@ keywords:
   - natural language interaction
   - API resource management
   - MCP services
-description: "Discover how APISIX-MCP leverages AI for intuitive API management, simplifying resource management through natural language interactions."
+description: "Use APISIX-MCP to manage API routes and upstreams through natural language. Create, update, and delete resources via AI integration."
 image: https://static.api7.ai/uploads/2025/04/01/b53YPObN_apisix-mcp.webp
 tags: [Ecosystem]
 ---

--- a/blog/en/blog/2025/04/21/host-mcp-server-with-api-gateway.md
+++ b/blog/en/blog/2025/04/21/host-mcp-server-with-api-gateway.md
@@ -1,5 +1,5 @@
 ---
-title: "From stdio to HTTP SSE: Host Your MCP Server with APISIX API Gateway"
+title: "Host MCP Servers via HTTP SSE with APISIX"
 authors:
   - name: Ming Wen
     title: author
@@ -16,7 +16,7 @@ keywords:
   - MCP
   - MCP Server
   - mcp-bridge
-description: Discover APISIX-MCP, leveraging AI for effortless API management. Simplify resource operations with natural language in Apache APISIX.
+description: Convert stdio-based MCP servers to scalable HTTP SSE services using the APISIX mcp-bridge plugin. Step-by-step deployment guide.
 tags: [Ecosystem]
 image: https://static.api7.ai/uploads/2025/04/23/USwzplCO_apisix-mcp-briget-cover-final.webp
 ---

--- a/blog/en/blog/2025/06/18/mcp-monetization-navigating-ai-economy.md
+++ b/blog/en/blog/2025/06/18/mcp-monetization-navigating-ai-economy.md
@@ -13,7 +13,7 @@ keywords:
   - API Management
   - Model Context Protocol
   - MCP
-description: "Discover how API gateways like Apache APISIX enable MCP monetization, driving success in the AI economy through scalable, secure, and efficient AI model deployment."
+description: "Learn how MCP monetization reshapes the AI economy by redefining how AI agents discover, access, and pay for services via API gateways."
 tags: [Ecosystem]
 image: https://static.api7.ai/uploads/2025/03/07/Qs4WrU0I_apisix-ai-gateway.webp
 ---

--- a/blog/en/blog/2025/07/29/announcing-integration-of-apisix-and-ai-ml-api.md
+++ b/blog/en/blog/2025/07/29/announcing-integration-of-apisix-and-ai-ml-api.md
@@ -1,5 +1,5 @@
 ---
-title: "Announcing APISIX Integration with AI/ML API"
+title: "APISIX Integrates AI/ML API: 300+ LLMs"
 authors:
   - name: "Yilia Lin"
     title: "Technical Writer"
@@ -11,7 +11,7 @@ keywords:
 - AI
 - AI/ML API
 - AI plugins
-description: "Apache APISIX supports 300+ LLMs through the integration with AI/ML API. Get your secure, single-endpoint access to AI models like GPT-4 and Claude, and more."
+description: "APISIX now supports 300+ LLMs via AI/ML API integration. Access GPT-4, Claude, and more through a single secure endpoint."
 tags: [Ecosystem]
 image: https://static.api7.ai/uploads/2025/07/23/d1O3mllW_apisix-ai-ml-api.webp
 ---


### PR DESCRIPTION
## Summary

SEO title and meta description optimization for 50 blog articles ranked 31-80 by SEO impact score. This is the second batch following PR #2020 (batch 1: top 30 articles).

## Changes

Rewrites frontmatter `title` and `description` fields across 50 blog posts to:

- **Shorten titles to ≤55 characters** — prevents truncation in Google SERPs (with ` | APISIX` suffix added by Docusaurus, total stays ≤64 chars)
- **Compress descriptions to ≤155 characters** — ensures full display in search snippets
- **Place primary keywords early** in titles for better ranking signals
- **Replace vague "this article describes..." phrasing** with clear value propositions
- **Align with search intent** — action-oriented titles that match what users actually search for

## Examples

| File | Before Title | After Title |
|------|-------------|------------|
| `beeto-with-apache-apisix.md` | Practice of localized application with API gateway in the Middle East (69c) | How Beeto Uses APISIX for API Management (41c) |
| `cve-2022-29266.md` | The Vulnerability of Leaking Information in Error Response from jwt-auth Plugin（CVE-2022-29266） (88c) | CVE-2022-29266: jwt-auth Secret Leak Fix (40c) |
| `why-we-need-apache-apisix.md` | Why do you need Apache APISIX when you have NGINX and Kong? (59c) | Why Choose APISIX Over NGINX and Kong? (39c) |
| `file-logger-api-gateway.md` | How to develop plugin in API Gateway (36c, keyword-missing) | Build an APISIX Plugin: file-logger Tutorial (45c) |
| `apisix-owasp-coraza-core-ruleset.md` | Hardening Apache APISIX with the OWASP's Coraza and Core Ruleset (63c) | Protect APIs with OWASP Coraza WAF in APISIX (46c) |

## SEO Rules Applied

1. Titles ≤55 chars with primary keyword in first 30 chars
2. Descriptions ≤155 chars with clear value proposition
3. Use "APISIX" (not "Apache APISIX") in titles to save space — brand suffix handles the full name
4. Search-intent framing over narrative framing
5. CVE titles include CVE ID + short impact summary

## Files Changed

50 blog post markdown files under `blog/en/blog/`

## Related PRs

- PR #2020 — Batch 1: top 30 articles (ranks 1-30)
- PR #2015 — External canonical URL removal (57 files)
- PR #2017 — Title tag optimization (brand suffix)