### PR TITLE
fix: quote blog frontmatter description

### DIFF
--- a/blog/en/blog/2022/07/30/why-we-need-apache-apisix.md
+++ b/blog/en/blog/2022/07/30/why-we-need-apache-apisix.md
@@ -10,7 +10,7 @@ keywords:
 - Nginx
 - Open Source
 - API Management
-description: APISIX solves key NGINX and Kong pain points: dynamic config, cluster management, and hot reloading. See the architecture comparison.
+description: "APISIX solves key NGINX and Kong pain points: dynamic config, cluster management, and hot reloading. See the architecture comparison."
 tags: [Ecosystem]
 image: https://static.apiseven.com/2022/11/07/636916ea65769.png
 ---


### PR DESCRIPTION
## Summary
- Quote the updated blog description introduced by #2021 so YAML frontmatter parses correctly.

## Root cause
- The description in `blog/en/blog/2022/07/30/why-we-need-apache-apisix.md` contains `: ` after `pain points`.
- Because the value was unquoted, Docusaurus/YAML parsed it as an incomplete mapping and failed the English blog build.

## Verification
- `yarn build:blog:en`