### PR TITLE
fix: sync plugin hub data and labels

### DIFF
--- a/config/navbar.js
+++ b/config/navbar.js
@@ -98,7 +98,7 @@ module.exports = [
       },
       {
         to: '/plugins',
-        label: 'PluginHub',
+        label: 'Plugin Hub',
         target: '_parent',
       },
       {

--- a/website/static/data/plugins.json
+++ b/website/static/data/plugins.json
@@ -8,35 +8,58 @@
       },
       {
         "name": "redirect",
-        "description": "The redirect Plugin can be used to configure redirects"
+        "description": "The redirect Plugin can be used to configure redirects",
+        "useDefaultIcon": true
       },
       {
         "name": "echo",
-        "description": "The echo Plugin is to help users understand how they can develop an APISIX Plugin"
+        "description": "The echo Plugin is to help users understand how they can develop an APISIX Plugin",
+        "useDefaultIcon": true
       },
       {
         "name": "gzip",
-        "description": "The gzip Plugin dynamically sets the behavior of gzip in Nginx"
+        "description": "The gzip Plugin dynamically sets the behavior of gzip in Nginx",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "brotli",
+        "description": "The brotli Plugin dynamically configures Brotli compression in NGINX",
+        "useDefaultIcon": true
       },
       {
         "name": "real-ip",
-        "description": "The real-ip Plugin is used to dynamically change the client's IP address and port as seen by APISIX"
+        "description": "The real-ip Plugin is used to dynamically change the client's IP address and port as seen by APISIX",
+        "useDefaultIcon": true
       },
       {
         "name": "server-info",
-        "description": "The server-info Plugin periodically reports basic server information to etcd"
+        "description": "The server-info Plugin periodically reports basic server information to etcd",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "inspect",
+        "description": "The inspect Plugin exposes runtime inspection information for APISIX",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "lago",
+        "description": "The lago Plugin reports usage and billing events to Lago",
+        "useDefaultIcon": true
       },
       {
         "name": "ext-plugin-pre-req",
-        "description": "The ext-plugin-pre-req Plugin is for running specific external Plugins in the Plugin Runner before executing the built-in Lua Plugins"
+        "description": "The ext-plugin-pre-req Plugin is for running specific external Plugins in the Plugin Runner before executing the built-in Lua Plugins",
+        "useDefaultIcon": true
       },
       {
         "name": "ext-plugin-post-req",
-        "description": "ext-plugin-post-req differs from the ext-plugin-pre-req Plugin in that it runs after executing the built-in Lua Plugins and before proxying to the Upstream"
+        "description": "ext-plugin-post-req differs from the ext-plugin-pre-req Plugin in that it runs after executing the built-in Lua Plugins and before proxying to the Upstream",
+        "useDefaultIcon": true
       },
       {
         "name": "ext-plugin-post-resp",
-        "description": "The ext-plugin-post-resp Plugin is for running specific external Plugins in the Plugin Runner before executing the built-in Lua Plugins"
+        "description": "The ext-plugin-post-resp Plugin is for running specific external Plugins in the Plugin Runner before executing the built-in Lua Plugins",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -57,15 +80,37 @@
       },
       {
         "name": "grpc-web",
-        "description": "The grpc-web Plugin is a proxy Plugin that can process gRPC Web requests from JavaScript clients to a gRPC service"
+        "description": "The grpc-web Plugin is a proxy Plugin that can process gRPC Web requests from JavaScript clients to a gRPC service",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "body-transformer",
+        "description": "The body-transformer Plugin transforms request and response bodies between structured formats",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "degraphql",
+        "description": "The degraphql Plugin translates GraphQL queries into upstream REST requests",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "exit-transformer",
+        "description": "The exit-transformer Plugin transforms response bodies before APISIX sends them to the client",
+        "useDefaultIcon": true
       },
       {
         "name": "fault-injection",
         "description": "The fault-injection Plugin can be used to test the resiliency of your application. This Plugin will be executed before the other configured Plugins"
       },
       {
+        "name": "gm",
+        "description": "The gm Plugin enables Guomi cryptographic algorithms in APISIX TLS processing",
+        "useDefaultIcon": true
+      },
+      {
         "name": "mocking",
-        "description": "The mocking Plugin is used for mocking an API. When executed, it returns random mock data in the format specified and the request is not forwarded to the Upstream"
+        "description": "The mocking Plugin is used for mocking an API. When executed, it returns random mock data in the format specified and the request is not forwarded to the Upstream",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -74,15 +119,15 @@
     "plugins": [
       {
         "name": "key-auth",
-        "description": "An authentication plugin that need to work with consumer to add key authentication to your Services"
+        "description": "An authentication plugin that needs to work with a Consumer to add key authentication to your Services"
       },
       {
         "name": "jwt-auth",
-        "description": "An authentication plugin that need to work with consumer to securely authenticate a valid user requesting access"
+        "description": "An authentication plugin that needs to work with a Consumer to securely authenticate a valid user requesting access"
       },
       {
         "name": "basic-auth",
-        "description": "An authentication plugin that need to work with consumer to add Basic Authentication to a Service or a Route"
+        "description": "An authentication plugin that needs to work with a Consumer to add Basic Authentication to a Service or a Route"
       },
       {
         "name": "authz-keycloak",
@@ -90,7 +135,8 @@
       },
       {
         "name": "authz-casdoor",
-        "description": "An authorization plugin that can be used to add centralized authentication with Casdoor"
+        "description": "An authorization plugin that can be used to add centralized authentication with Casdoor",
+        "useDefaultIcon": true
       },
       {
         "name": "wolf-rbac",
@@ -102,11 +148,12 @@
       },
       {
         "name": "cas-auth",
-        "description": "An authorization plugin can be used to access CAS (Central Authentication Service 2.0) IdP (Identity Provider) to do authentication, from the SP (service provider) perspective"
+        "description": "An authorization plugin can be used to access CAS (Central Authentication Service 2.0) IdP (Identity Provider) to do authentication, from the SP (service provider) perspective",
+        "useDefaultIcon": true
       },
       {
         "name": "hmac-auth",
-        "description": "An authentication plugin that need to work with consumer to establish the integrity of incoming requests"
+        "description": "An authentication plugin that needs to work with a Consumer to establish the integrity of incoming requests"
       },
       {
         "name": "authz-casbin",
@@ -114,15 +161,28 @@
       },
       {
         "name": "ldap-auth",
-        "description": "An authorization plugin can be used to add LDAP authentication to a Route or a Service"
+        "description": "An authorization plugin can be used to add LDAP authentication to a Route or a Service",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "jwe-decrypt",
+        "description": "The jwe-decrypt Plugin decrypts JWE tokens in incoming requests",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "multi-auth",
+        "description": "The multi-auth Plugin supports multiple authentication methods on the same Route or Service",
+        "useDefaultIcon": true
       },
       {
         "name": "opa",
-        "description": "An authorization plugin can be used to integrate with Open Policy Agente"
+        "description": "An authorization plugin can be used to integrate with Open Policy Agent",
+        "useDefaultIcon": true
       },
       {
         "name": "forward-auth",
-        "description": "The forward-auth Plugin implements a classic external authentication model"
+        "description": "The forward-auth Plugin implements a classic external authentication model",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -143,7 +203,8 @@
       },
       {
         "name": "ua-restriction",
-        "description": "The plugin allows you to restrict access to a Route or Service based on the User-Agent header with an allowlist and a denylist"
+        "description": "The plugin allows you to restrict access to a Route or Service based on the User-Agent header with an allowlist and a denylist",
+        "useDefaultIcon": true
       },
       {
         "name": "referer-restriction",
@@ -154,13 +215,29 @@
         "description": "The plugin makes corresponding access restrictions based on different objects selected"
       },
       {
-        "name": "CSRF",
+        "name": "csrf",
         "description": "Based on the Double Submit Cookie way, protect your API from CSRF attacks",
-        "beta": true
+        "useDefaultIcon": true
+      },
+      {
+        "name": "chaitin-waf",
+        "description": "The chaitin-waf Plugin integrates Chaitin SafeLine WAF inspection with APISIX",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "oas-validator",
+        "description": "The oas-validator Plugin validates requests against an OpenAPI specification",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ocsp-stapling",
+        "description": "The ocsp-stapling Plugin enables dynamic OCSP stapling for TLS certificates",
+        "useDefaultIcon": true
       },
       {
         "name": "public-api",
-        "description": "The public-api is used for exposing an API endpoint through a general HTTP API router"
+        "description": "The public-api Plugin is used for exposing an API endpoint through a general HTTP API router",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -169,11 +246,11 @@
     "plugins": [
       {
         "name": "limit-req",
-        "description": "The plugin limits request rate using the eaky bucket method"
+        "description": "The plugin limits request rate using the leaky bucket method"
       },
       {
         "name": "limit-conn",
-        "description": "The plugin  Limits request concurrency"
+        "description": "The plugin limits request concurrency"
       },
       {
         "name": "limit-count",
@@ -204,12 +281,79 @@
         "description": "The request-id Plugin adds a unique ID to each request proxied through APISIX"
       },
       {
+        "name": "attach-consumer-label",
+        "description": "The attach-consumer-label Plugin injects labels from the authenticated consumer into the request context",
+        "useDefaultIcon": true
+      },
+      {
         "name": "proxy-control",
-        "description": "The proxy-control Plugin dynamically controls the behavior of the NGINX proxy"
+        "description": "The proxy-control Plugin dynamically controls the behavior of the NGINX proxy",
+        "useDefaultIcon": true
       },
       {
         "name": "client-control",
-        "description": "The client-control Plugin can be used to dynamically control the behavior of NGINX to handle a client request, by setting the max size of the request body"
+        "description": "The client-control Plugin can be used to dynamically control the behavior of NGINX to handle a client request, by setting the max size of the request body",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "traffic-label",
+        "description": "The traffic-label Plugin evaluates labels on requests for traffic governance and routing",
+        "useDefaultIcon": true
+      }
+    ]
+  },
+  {
+    "groupName": "AI",
+    "plugins": [
+      {
+        "name": "ai-proxy",
+        "description": "The ai-proxy Plugin simplifies proxying requests to LLM providers compatible with the OpenAI API format",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-proxy-multi",
+        "description": "The ai-proxy-multi Plugin extends ai-proxy with load balancing, retries, fallbacks, and health checks for LLM providers",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-request-rewrite",
+        "description": "The ai-request-rewrite Plugin rewrites client requests with LLM-generated content before proxying upstream",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-rate-limiting",
+        "description": "The ai-rate-limiting Plugin limits LLM usage by tracking and throttling token consumption",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-prompt-decorator",
+        "description": "The ai-prompt-decorator Plugin prepends and appends predefined prompts to user input",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-prompt-template",
+        "description": "The ai-prompt-template Plugin applies predefined prompt templates and accepts values for declared variables",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-prompt-guard",
+        "description": "The ai-prompt-guard Plugin validates prompts against allow and deny patterns before forwarding them to LLM services",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-aws-content-moderation",
+        "description": "The ai-aws-content-moderation Plugin uses AWS Comprehend to detect and block toxic request content",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-aliyun-content-moderation",
+        "description": "The ai-aliyun-content-moderation Plugin uses Alibaba Cloud content moderation to inspect and block unsafe requests",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "ai-rag",
+        "description": "The ai-rag Plugin adds retrieval-augmented generation by fetching relevant context from external data sources",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -218,7 +362,7 @@
     "plugins": [
       {
         "name": "zipkin",
-        "description": "Zipkin is a OpenTracing plugin"
+        "description": "Zipkin is an OpenTracing plugin"
       },
       {
         "name": "skywalking",
@@ -226,7 +370,8 @@
       },
       {
         "name": "opentelemetry",
-        "description": "The opentelemetry Plugin can be used to report tracing data according to the OpenTelemetry specification"
+        "description": "The opentelemetry Plugin can be used to report tracing data according to the OpenTelemetry specification",
+        "useDefaultIcon": true
       },
       {
         "name": "prometheus",
@@ -234,7 +379,8 @@
       },
       {
         "name": "node-status",
-        "description": "The node-status Plugin can be used get the status of requests to APISIX by exposing an API endpoint"
+        "description": "The node-status Plugin can be used to get the status of requests to APISIX by exposing an API endpoint",
+        "useDefaultIcon": true
       },
       {
         "name": "datadog",
@@ -242,11 +388,12 @@
       },
       {
         "name": "http-logger",
-        "description": "Http-logger is a plugin which push Log data requests to HTTP/HTTPS servers"
+        "description": "The http-logger Plugin pushes log data to HTTP and HTTPS servers"
       },
       {
-        "name": "skywalking-loggerr",
-        "description": "The skywalking-logger Plugin can be used to push access log data to SkyWalking OAP server of HTTP"
+        "name": "skywalking-logger",
+        "description": "The skywalking-logger Plugin can be used to push access log data to SkyWalking OAP server of HTTP",
+        "useDefaultIcon": true
       },
       {
         "name": "tcp-logger",
@@ -258,7 +405,8 @@
       },
       {
         "name": "rocketmq-logger",
-        "description": "The rocketmq-logger Plugin provides the ability to push logs as JSON objects to your RocketMQ clusters"
+        "description": "The rocketmq-logger Plugin provides the ability to push logs as JSON objects to your RocketMQ clusters",
+        "useDefaultIcon": true
       },
       {
         "name": "udp-logger",
@@ -266,15 +414,17 @@
       },
       {
         "name": "clickhouse-logger",
-        "description": "The clickhouse-logger Plugin is used to push logs to ClickHouse database"
+        "description": "The clickhouse-logger Plugin is used to push logs to ClickHouse database",
+        "useDefaultIcon": true
       },
       {
         "name": "syslog",
-        "description": "Sys pushes Log data requests to Syslog"
+        "description": "The syslog Plugin pushes log data to Syslog"
       },
       {
         "name": "log-rotate",
-        "description": "The log-rotate Plugin is used to keep rotating access and error log files in the log directory at regular intervals"
+        "description": "The log-rotate Plugin is used to keep rotating access and error log files in the log directory at regular intervals",
+        "useDefaultIcon": true
       },
       {
         "name": "error-log-logger",
@@ -282,7 +432,7 @@
       },
       {
         "name": "sls-logger",
-        "description": "Sls-logger pushes Log data requests to ali cloud Log Server with RF5424"
+        "description": "The sls-logger Plugin pushes log data to Alibaba Cloud Log Service with RFC 5424"
       },
       {
         "name": "google-cloud-logging",
@@ -290,23 +440,33 @@
       },
       {
         "name": "splunk-hec-logging",
-        "description": "The splunk-hec-logging Plugin is used to forward logs to Splunk HTTP Event Collector (HEC) for analysis and storage"
+        "description": "The splunk-hec-logging Plugin is used to forward logs to Splunk HTTP Event Collector (HEC) for analysis and storage",
+        "useDefaultIcon": true
       },
       {
         "name": "file-logger",
-        "description": "The file-logger Plugin is used to push log streams to a specific location"
+        "description": "The file-logger Plugin is used to push log streams to a specific location",
+        "useDefaultIcon": true
       },
       {
         "name": "loggly",
-        "description": "The loggly Plugin is used to forward logs to SolarWinds Loggly for analysis and storage"
+        "description": "The loggly Plugin is used to forward logs to SolarWinds Loggly for analysis and storage",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "loki-logger",
+        "description": "The loki-logger Plugin pushes access logs to Grafana Loki",
+        "useDefaultIcon": true
       },
       {
         "name": "elasticsearch-logger",
-        "description": "The elasticsearch-logger Plugin is used to forward logs to Elasticsearch for analysis and storage"
+        "description": "The elasticsearch-logger Plugin is used to forward logs to Elasticsearch for analysis and storage",
+        "useDefaultIcon": true
       },
       {
         "name": "tencent-cloud-cls",
-        "description": "The tencent-cloud-cls Plugin uses TencentCloud CLSAPI to forward APISIX logs to your topic"
+        "description": "The tencent-cloud-cls Plugin uses TencentCloud CLSAPI to forward APISIX logs to your topic",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -315,27 +475,33 @@
     "plugins": [
       {
         "name": "serverless",
-        "description": "There are two serverless Plugins in APISIX: serverless-pre-function and serverless-post-function."
+        "description": "There are two serverless Plugins in APISIX: serverless-pre-function and serverless-post-function.",
+        "useDefaultIcon": true
       },
       {
         "name": "azure-functions",
-        "description": "The azure-functions Plugin is used to integrate APISIX with Azure Serverless Function as a dynamic upstream to proxy all requests for a particular URI to the Microsoft Azure Cloud"
+        "description": "The azure-functions Plugin is used to integrate APISIX with Azure Serverless Function as a dynamic upstream to proxy all requests for a particular URI to the Microsoft Azure Cloud",
+        "useDefaultIcon": true
       },
       {
         "name": "openwhisk",
-        "description": "The openwhisk Plugin is used to integrate APISIX with Apache OpenWhisk serverless platfor"
+        "description": "The openwhisk Plugin is used to integrate APISIX with the Apache OpenWhisk serverless platform",
+        "useDefaultIcon": true
       },
       {
         "name": "aws-lambda",
-        "description": "The aws-lambda Plugin is used for integrating APISIX with AWS Lambda as a dynamic upstream to proxy all requests for a particular URI to the AWS Cloud"
+        "description": "The aws-lambda Plugin is used for integrating APISIX with AWS Lambda as a dynamic upstream to proxy all requests for a particular URI to the AWS Cloud",
+        "useDefaultIcon": true
       },
       {
         "name": "workflow",
-        "description": "The workflow plugin is used to introduce lua-resty-expr to provide complex traffic control features"
+        "description": "The workflow plugin is used to introduce lua-resty-expr to provide complex traffic control features",
+        "useDefaultIcon": true
       },
       {
         "name": "openfunction",
-        "description": "The openfunction Plugin is used to integrate APISIX with CNCF OpenFunction serverless platform"
+        "description": "The openfunction Plugin is used to integrate APISIX with CNCF OpenFunction serverless platform",
+        "useDefaultIcon": true
       }
     ]
   },
@@ -344,15 +510,23 @@
     "plugins": [
       {
         "name": "dubbo-proxy",
-        "description": "The dubbo-proxy Plugin allows you to proxy HTTP requests to Apache Dubbo"
+        "description": "The dubbo-proxy Plugin allows you to proxy HTTP requests to Apache Dubbo",
+        "useDefaultIcon": true
+      },
+      {
+        "name": "http-dubbo",
+        "description": "The http-dubbo Plugin proxies HTTP requests to Apache Dubbo services",
+        "useDefaultIcon": true
       },
       {
         "name": "mqtt-proxy",
-        "description": "The mqtt-proxy Plugin is used for dynamic load balancing with client_id of MQTT. It only works in stream mode"
+        "description": "The mqtt-proxy Plugin is used for dynamic load balancing with client_id of MQTT. It only works in stream mode",
+        "useDefaultIcon": true
       },
       {
         "name": "kafka-proxy",
-        "description": "The kafka-proxy plugin can be used to configure advanced parameters for the kafka upstream of Apache APISIX, such as SASL authentication"
+        "description": "The kafka-proxy plugin can be used to configure advanced parameters for the kafka upstream of Apache APISIX, such as SASL authentication",
+        "useDefaultIcon": true
       }
     ]
   }


### PR DESCRIPTION
## Summary
- sync `website/static/data/plugins.json` with the current APISIX plugin set used by the Plugin Hub
- add `useDefaultIcon` fallbacks for plugins that do not have a dedicated SVG symbol and fix broken entries such as `skywalking-logger` and `csrf`
- clean up stale plugin descriptions in the data file, including the `public-api` description and other obvious copy issues, and rename the navbar label from `PluginHub` to `Plugin Hub`

## Validation
- reviewed the Plugin Hub locally in a clean browser session
- verified the new AI section and plugin links render correctly
- confirmed fallback icons resolve the previously broken icon references
- confirmed the navbar label now renders as `Plugin Hub`
