### PR TITLE
fix: change onBrokenLinks to 'warn' to prevent doc build failures

### DIFF
--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -55,7 +55,7 @@ module.exports = {
       },
     },
   },
-  onBrokenLinks: 'log',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   noIndex: false,
   presets: [


### PR DESCRIPTION
## Summary

Fix doc workspace build failures caused by navbar links to website workspace paths being treated as errors.

## Problem

The doc build started failing on May 13, 2026 with error:
```
[06:48:20] Build website's all parts [failed]
[06:48:20] → Build failed for: doc
Error: Build failed for: doc
```

**Root cause:** The doc workspace's `docusaurus.config.js` had `onBrokenLinks: 'log'`, which caused Docusaurus to fail the build when encountering navbar links to paths that exist in the website workspace but not in the doc workspace (like `/`, `/blog`, `/learning-center`, `/downloads`, `/help`, `/team`, `/showcase`, `/plugins`).

## Solution

Changed `onBrokenLinks: 'log'` to `onBrokenLinks: 'warn'` in `doc/docusaurus.config.js`.

This allows the build to complete successfully while still alerting developers about actual broken documentation links. The navbar links are intentionally cross-workspace references and should not fail the build.

## Testing

- [ ] Local build test: `yarn workspace doc build`
- [ ] CI build should pass

## Related

- Failed CI run: https://github.com/apache/apisix-website/actions/runs/25147485898
- The issue was not related to PR #2034 (April monthly report) which was successfully merged on April 30, 2026