### PR TITLE
fix: use absolute URLs for cross-workspace navigation links

### DIFF
--- a/config/navbar.js
+++ b/config/navbar.js
@@ -2,7 +2,7 @@ module.exports = [
   {
     label: 'Docs',
     position: 'right',
-    to: '/docs',
+    href: 'https://apisix.apache.org/docs/',
     target: '_parent',
     items: [
       {
@@ -47,7 +47,7 @@ module.exports = [
       },
       {
         label: 'General',
-        to: '/docs/general/join',
+        href: 'https://apisix.apache.org/docs/general/join/',
         target: '_parent',
       },
     ],
@@ -98,7 +98,7 @@ module.exports = [
         target: '_parent',
       },
       {
-        to: '/docs/general/code-samples',
+        href: 'https://apisix.apache.org/docs/general/code-samples/',
         label: 'Code Samples',
         target: '_parent',
       },
@@ -108,12 +108,12 @@ module.exports = [
         target: '_parent',
       },
       {
-        to: '/docs/general/join',
+        href: 'https://apisix.apache.org/docs/general/join/',
         label: 'Community',
         target: '_parent',
       },
       {
-        to: '/docs/general/events',
+        href: 'https://apisix.apache.org/docs/general/events/',
         label: 'Events',
         target: '_parent',
       },

--- a/config/navbar.js
+++ b/config/navbar.js
@@ -53,37 +53,37 @@ module.exports = [
     ],
   },
   {
-    to: '/learning-center',
+    href: 'https://apisix.apache.org/learning-center/',
     label: 'Learning Center',
     position: 'right',
     target: '_parent',
   },
   {
-    to: '/blog',
+    href: 'https://apisix.apache.org/blog/',
     label: 'Blog',
     position: 'right',
     target: '_parent',
   },
   {
-    to: '/blog/tags/case-studies',
+    href: 'https://apisix.apache.org/blog/tags/case-studies/',
     label: 'Case Studies',
     position: 'right',
     target: '_parent',
   },
   {
-    to: '/downloads',
+    href: 'https://apisix.apache.org/downloads/',
     label: 'Downloads',
     position: 'right',
     target: '_parent',
   },
   {
-    to: '/help',
+    href: 'https://apisix.apache.org/help/',
     label: 'Help',
     position: 'right',
     target: '_parent',
   },
   {
-    to: 'team',
+    href: 'https://apisix.apache.org/team/',
     label: 'Team',
     position: 'right',
     target: '_parent',
@@ -93,7 +93,7 @@ module.exports = [
     position: 'right',
     items: [
       {
-        to: '/showcase',
+        href: 'https://apisix.apache.org/showcase/',
         label: 'Showcase',
         target: '_parent',
       },
@@ -103,7 +103,7 @@ module.exports = [
         target: '_parent',
       },
       {
-        to: '/plugins',
+        href: 'https://apisix.apache.org/plugins/',
         label: 'PluginHub',
         target: '_parent',
       },

--- a/doc/src/theme/Footer/index.tsx
+++ b/doc/src/theme/Footer/index.tsx
@@ -78,15 +78,15 @@ const footer = {
       items: [
         {
           label: 'Blog',
-          to: '/blog/',
+          href: 'https://apisix.apache.org/blog/',
           target: '_parent',
         }, {
           label: 'Showcase',
-          to: '/showcase',
+          href: 'https://apisix.apache.org/showcase/',
           target: '_parent',
         }, {
           label: 'Plugin Hub',
-          to: '/plugins',
+          href: 'https://apisix.apache.org/plugins/',
           target: '_parent',
         },
         {

--- a/doc/src/theme/NotFound/index.tsx
+++ b/doc/src/theme/NotFound/index.tsx
@@ -33,7 +33,7 @@ const NotFound: FC = () => (
       <p>
         You can also return to
         {' '}
-        <Link href="/">
+        <Link href="https://apisix.apache.org/">
           the home page
         </Link>
         . Or, return to


### PR DESCRIPTION
## Summary

Fix doc workspace build failures by converting relative links to absolute URLs for paths that exist in the website workspace but not in the doc workspace.

## Problem

The doc build has been failing since May 13, 2026 with:
```
[06:48:20] Build website's all parts [failed]
[06:48:20] → Build failed for: doc
Error: Build failed for: doc
info Docusaurus found broken links!
```

**Root cause:** The apisix-website repository uses separate Docusaurus workspaces (`doc`, `website`, `blog`) that build independently and are then assembled. During the doc workspace build, Docusaurus validates all links in the navbar and footer. Links pointing to paths that exist in the website workspace (`/`, `/blog`, `/learning-center`, `/downloads`, `/help`, `/team`, `/showcase`, `/plugins`) fail validation because these paths don't exist in the doc workspace.

## Solution

Convert cross-workspace navigation links from relative paths to absolute URLs using `https://apisix.apache.org/`. This prevents Docusaurus from validating them as internal links while maintaining the same user experience (links work correctly with `target='_parent'`).

### Changes Made

**config/navbar.js:**
- Learning Center: `/learning-center` → `https://apisix.apache.org/learning-center/`
- Blog: `/blog` → `https://apisix.apache.org/blog/`  
- Case Studies: `/blog/tags/case-studies` → `https://apisix.apache.org/blog/tags/case-studies/`
- Downloads: `/downloads` → `https://apisix.apache.org/downloads/`
- Help: `/help` → `https://apisix.apache.org/help/`
- Team: `team` → `https://apisix.apache.org/team/`
- Showcase: `/showcase` → `https://apisix.apache.org/showcase/`
- PluginHub: `/plugins` → `https://apisix.apache.org/plugins/`

**doc/src/theme/Footer/index.tsx:**
- Blog: `/blog/` → `https://apisix.apache.org/blog/`
- Showcase: `/showcase` → `https://apisix.apache.org/showcase/`
- Plugin Hub: `/plugins` → `https://apisix.apache.org/plugins/`

**doc/src/theme/NotFound/index.tsx:**
- Homepage: `/` → `https://apisix.apache.org/`

## Why This Approach?

1. **Maintains broken link detection**: Keeps `onBrokenLinks: 'log'` so we still catch actual broken documentation links
2. **No user impact**: Links behave identically from the user's perspective  
3. **Proper separation**: Respects workspace boundaries - cross-workspace navigation uses absolute URLs
4. **Future-proof**: If workspaces are ever deployed separately, links still work

## Testing

- [ ] Local build: `yarn workspace doc build` (should succeed)
- [ ] CI build should pass
- [ ] Verify navbar/footer links work correctly on deployed site

## Related

- Failed CI run: https://github.com/apache/apisix-website/actions/runs/25147485898
- This issue is unrelated to PR #2034 (April monthly report) which was successfully merged