### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ on:
         default: 'master'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "build"
   build:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,6 +14,10 @@ on:
     - cron: "0 5 * * *"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
+permissions:
+  contents: read
+
 jobs:
   # This workflow contains a single job called "build"
   check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: ❄️ Lint
 
 on: [pull_request]
 
+
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: 🍇 Markdown


### PR DESCRIPTION
Hardens 3 workflow(s) in this repo by declaring a workflow-level `permissions: contents: read`. Today those workflows inherit the legacy broad read-write GITHUB_TOKEN; the read-only default reduces blast radius if any step is compromised.

I checked each file - they read the checkout and run tests/lints; no GitHub API writes (no `gh pr/issue`, no `git push`, no release/publish/comment actions). So behavior is unchanged.

Reference: the tj-actions/changed-files compromise (CVE-2025-30066) is the canonical reason to apply least-privilege defaults.