### PR TITLE
blog: add 2026 May monthly report

### DIFF
--- a/blog/en/blog/2026/05/31/2026-may-monthly-report.md
+++ b/blog/en/blog/2026/05/31/2026-may-monthly-report.md
@@ -1,0 +1,187 @@
+---
+title: "2026 Monthly Report (May 01 - May 31)"
+keywords: ["Apache APISIX", "API Gateway", "Monthly Report", "Contributor"]
+description: Our monthly Apache APISIX community report generates insights into the project's monthly developments. The reports provide a pathway into the Apache APISIX community, ensuring that you stay well-informed and actively involved.
+tags: [Community]
+image: TODO_COVER_IMAGE_EN
+---
+
+> Recently, we've introduced and updated some new features, including new authentication plugins for Feishu and DingTalk, GraphQL request cost limiting, OpenAPI request validation, safer proxy caching, and expanded AI proxy protocol support. For more details, please read this month's newsletter.
+
+<!--truncate-->
+
+## Introduction
+
+From its inception, the Apache APISIX project has embraced the ethos of open-source community collaboration, propelling it into the ranks of the most active global open-source API gateway projects. The proverbial wisdom of 'teamwork makes the dream work' rings true in our way and is made possible by the collective effort of our community.
+
+From May 1st to May 31st, 16 contributors made 74 commits to Apache APISIX. We sincerely appreciate your contributions to Apache APISIX.
+
+## Contributor Statistics
+
+![Apache APISIX Contributors List](TODO_CONTRIBUTOR_LIST_IMAGE)
+
+![New Contributors List](TODO_NEW_CONTRIBUTORS_IMAGE)
+
+## Feature Highlights
+
+### 1. Default `hmac-auth` Signed Headers to `date`
+
+PR: https://github.com/apache/apisix/pull/13388
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR updates the `hmac-auth` plugin so `signed_headers` defaults to `["date"]`. By binding the request `Date` header into the HMAC signature unless users explicitly opt out, APISIX better aligns the default behavior with its clock-skew protection and reduces the risk of stale signed requests.
+
+### 2. Add `feishu-auth` Plugin
+
+PR: https://github.com/apache/apisix/pull/13382
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds the `feishu-auth` plugin, enabling browser-based API authentication through the Feishu (Lark) OAuth 2.0 authorization code flow. It helps teams protect internal APIs and developer portals with their existing Feishu identity system instead of building a custom authentication layer in each upstream service.
+
+### 3. Add `graphql-limit-count` Plugin
+
+PR: https://github.com/apache/apisix/pull/13372
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR introduces the `graphql-limit-count` plugin, which limits GraphQL traffic based on query AST depth within a configured time window. It gives operators a better control surface for GraphQL APIs, where deeply nested queries can be much more expensive than ordinary request-count based rate limiting suggests.
+
+### 4. Add `error-page` Plugin
+
+PR: https://github.com/apache/apisix/pull/13380
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds the `error-page` plugin for customizing APISIX-generated HTTP error responses, such as route-not-found or upstream-unavailable responses. Operators can configure response bodies and content types through plugin metadata, improving the user-facing experience for gateway-level failures.
+
+### 5. Add `dingtalk-auth` Plugin
+
+PR: https://github.com/apache/apisix/pull/13381
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds the `dingtalk-auth` plugin, integrating DingTalk OAuth 2.0 authentication into APISIX routes. The plugin verifies users through DingTalk and stores the result in an encrypted cookie session, reducing repeated calls to DingTalk APIs during a user's session.
+
+### 6. Support Absolute Callback URLs in `cas-auth`
+
+PR: https://github.com/apache/apisix/pull/13413
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR allows `cas-auth` users to configure `cas_callback_uri` as an absolute URL. This is useful in deployments where APISIX sits behind proxies or external hostnames, because the CAS `service` URL can now be set explicitly instead of being derived from the incoming request host.
+
+### 7. Honor `Vary` Header in `proxy-cache` Memory Strategy
+
+PR: https://github.com/apache/apisix/pull/13376
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR teaches the in-memory `proxy-cache` strategy to respect upstream `Vary` response headers. Requests that differ by headers such as `Accept-Encoding` can now be cached as separate variants, bringing memory-cache behavior closer to the disk strategy and preventing accidental cache collisions.
+
+### 8. Sign Request URI Cookie and Tighten Cookie Attributes in `cas-auth`
+
+PR: https://github.com/apache/apisix/pull/13331
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR strengthens `cas-auth` by signing the `CAS_REQUEST_URI` cookie with HMAC-SHA256 and validating it on callback with a constant-time comparison. It also validates the recovered redirect target as a same-origin path, helping prevent unsafe redirects when the cookie is missing, malformed, or tampered with.
+
+### 9. Support Configurable Request JSON Library
+
+PR: https://github.com/apache/apisix/pull/13386
+
+Contributor: [nic-6443](https://github.com/nic-6443)
+
+This PR adds an APISIX-level JSON library selector for request body parsing and AI upstream request body encoding. Users can choose between `cjson`, `simdjson`, and experimental `qjson`, making it easier to balance compatibility and performance for large JSON request bodies.
+
+### 10. Add `acl` Plugin
+
+PR: https://github.com/apache/apisix/pull/13349
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR introduces the `acl` plugin, which provides label-based access control for API routes. Teams can use consumer labels or external attributes such as roles, teams, or subscription tiers to enforce access policies without writing custom plugins.
+
+### 11. Add `data-mask` Plugin
+
+PR: https://github.com/apache/apisix/pull/13347
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds the `data-mask` plugin to mask or redact sensitive fields from request query parameters, headers, and bodies before they appear in access logs or logger plugin outputs. It helps reduce exposure of credentials, tokens, personal data, and payment information in observability pipelines.
+
+### 12. Add Safer `proxy-cache` Options
+
+PR: https://github.com/apache/apisix/pull/13350
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR adds `consumer_isolation` and `cache_set_cookie` options to the `proxy-cache` plugin. By isolating cache entries per consumer by default and refusing to cache `Set-Cookie` responses unless explicitly enabled, APISIX makes shared caching safer for authenticated or personalized traffic.
+
+### 13. Add `exit-transformer` Plugin
+
+PR: https://github.com/apache/apisix/pull/13343
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR introduces the `exit-transformer` plugin and extends APISIX response handling with an exit callback mechanism. Users can transform APISIX-generated exit responses, such as plugin rejections or route-not-found responses, using custom Lua functions before the response reaches the client.
+
+### 14. Add `traffic-label` Plugin
+
+PR: https://github.com/apache/apisix/pull/13342
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds the `traffic-label` plugin, which assigns configurable labels to requests using weighted random distribution rules. Labels can be written to request headers or APISIX variables, enabling traffic segmentation patterns such as experiments, routing hints, or policy-driven tagging.
+
+### 15. Add `oas-validator` Plugin
+
+PR: https://github.com/apache/apisix/pull/13344
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR introduces the `oas-validator` plugin for validating inbound HTTP requests against an OpenAPI Specification 3.x document before forwarding them upstream. Invalid requests can be rejected with a configurable status code, helping API providers enforce contracts at the gateway layer.
+
+### 16. Support Bedrock ConverseStream Streaming in `ai-proxy`
+
+PR: https://github.com/apache/apisix/pull/13307
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR extends the Bedrock provider in `ai-proxy` with ConverseStream support. APISIX can now route streaming Bedrock requests, parse AWS EventStream framing, and forward streaming model responses through the same provider abstraction used by other AI protocols.
+
+### 17. Support Dynamic Indexes in `elasticsearch-logger`
+
+PR: https://github.com/apache/apisix/pull/13334
+
+Contributor: [nic-6443](https://github.com/nic-6443)
+
+This PR enables dynamic index patterns in the `elasticsearch-logger` plugin using date/time placeholders and APISIX variables. Index names are resolved per request without mutating plugin configuration, allowing use cases such as daily index rotation or host-based log separation.
+
+### 18. Rewrite Anthropic-to-OpenAI Converter with Whitelist Body Construction
+
+PR: https://github.com/apache/apisix/pull/13321
+
+Contributor: [nic-6443](https://github.com/nic-6443)
+
+This PR rewrites the Anthropic Messages to OpenAI Chat Completions converter in `ai-proxy` to build outgoing request bodies from an explicit whitelist. The new approach avoids leaking unsupported Anthropic-specific fields to OpenAI-compatible upstreams and makes protocol translation more predictable.
+
+### 19. Add Passthrough Protocol for Unrecognized AI API Formats
+
+PR: https://github.com/apache/apisix/pull/13320
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR adds a passthrough protocol adapter to `ai-proxy` for non-empty JSON request bodies that do not match a known AI protocol. It allows APISIX to proxy OpenAI-compatible or custom endpoints such as image generation APIs without forcing every payload shape through a specialized parser.
+
+## Good First Issues
+
+The following open issue was labeled as `good first issue` in May. New contributors are welcome to take a look and join the Apache APISIX community:
+
+- [docs: hmac-auth body validation example should sign the Digest header](https://github.com/apache/apisix/issues/13395)
+
+## Conclusion
+
+The [official website](https://apisix.apache.org/) and [GitHub Issues](https://github.com/apache/apisix/issues) of Apache APISIX provide a wealth of documentation of tutorials, and real-world use cases. If you encounter any issues, you can refer to the documentation, search for keywords in Issues, or participate in discussions on Issues to share your ideas and practical experiences.

--- a/blog/en/blog/2026/05/31/2026-may-monthly-report.md
+++ b/blog/en/blog/2026/05/31/2026-may-monthly-report.md
@@ -3,7 +3,7 @@ title: "2026 Monthly Report (May 01 - May 31)"
 keywords: ["Apache APISIX", "API Gateway", "Monthly Report", "Contributor"]
 description: Our monthly Apache APISIX community report generates insights into the project's monthly developments. The reports provide a pathway into the Apache APISIX community, ensuring that you stay well-informed and actively involved.
 tags: [Community]
-image: TODO_COVER_IMAGE_EN
+image: https://api7-website-1301662268.cos.ap-guangzhou.myqcloud.com/uploads/2026/06/01/hHcHm2BY_monthly-report-cover-en.webp
 ---
 
 > Recently, we've introduced and updated some new features, including new authentication plugins for Feishu and DingTalk, GraphQL request cost limiting, OpenAPI request validation, safer proxy caching, and expanded AI proxy protocol support. For more details, please read this month's newsletter.
@@ -18,9 +18,9 @@ From May 1st to May 31st, 16 contributors made 74 commits to Apache APISIX. We s
 
 ## Contributor Statistics
 
-![Apache APISIX Contributors List](TODO_CONTRIBUTOR_LIST_IMAGE)
+![Apache APISIX Contributors List](https://api7-website-1301662268.cos.ap-guangzhou.myqcloud.com/uploads/2026/06/01/bzwKQ6n1_2026-june-contributor-list.webp)
 
-![New Contributors List](TODO_NEW_CONTRIBUTORS_IMAGE)
+![New Contributors List](https://api7-website-1301662268.cos.ap-guangzhou.myqcloud.com/uploads/2026/06/01/8FBAfGMh_Group%20427320348.webp)
 
 ## Feature Highlights
 
@@ -144,7 +144,7 @@ Contributor: [AlinsRan](https://github.com/AlinsRan)
 
 This PR introduces the `oas-validator` plugin for validating inbound HTTP requests against an OpenAPI Specification 3.x document before forwarding them upstream. Invalid requests can be rejected with a configurable status code, helping API providers enforce contracts at the gateway layer.
 
-### 16. Support Bedrock ConverseStream Streaming in `ai-proxy`
+### 16. Support Bedrock ConverseStream Streaming in `ai-proxy` Plugin
 
 PR: https://github.com/apache/apisix/pull/13307
 
@@ -152,7 +152,7 @@ Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
 
 This PR extends the Bedrock provider in `ai-proxy` with ConverseStream support. APISIX can now route streaming Bedrock requests, parse AWS EventStream framing, and forward streaming model responses through the same provider abstraction used by other AI protocols.
 
-### 17. Support Dynamic Indexes in `elasticsearch-logger`
+### 17. Support Dynamic Indexes in `elasticsearch-logger` Plugin
 
 PR: https://github.com/apache/apisix/pull/13334
 
@@ -176,11 +176,15 @@ Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
 
 This PR adds a passthrough protocol adapter to `ai-proxy` for non-empty JSON request bodies that do not match a known AI protocol. It allows APISIX to proxy OpenAI-compatible or custom endpoints such as image generation APIs without forcing every payload shape through a specialized parser.
 
-## Good First Issues
+## Good First Issue
 
-The following open issue was labeled as `good first issue` in May. New contributors are welcome to take a look and join the Apache APISIX community:
+### Issue #13395
 
-- [docs: hmac-auth body validation example should sign the Digest header](https://github.com/apache/apisix/issues/13395)
+Link: https://github.com/apache/apisix/issues/13395
+
+Description: The `hmac-auth` plugin documentation has a body-validation example where the request body `Digest` header is computed and sent, but the `Digest` header is not included in the HMAC signed headers list or the signing string. This makes the example slightly misleading: it appears to demonstrate end-to-end body integrity, but the body digest is not actually bound to the signature.
+
+Expected Behavior: Update the `hmac-auth` documentation example so the SHA-256 body digest is computed first, then included in the signing string as `digest: SHA-256=<base64 body digest>`. The `Authorization` header should also include `digest` in the signed headers list, such as `headers="@request-target date digest"`. It would also be helpful to add a short note explaining that `validate_request_body` checks the `Digest` header against the request body, and users who want the body bound to the signature should include `Digest` in the signed headers.
 
 ## Conclusion
 

--- a/blog/zh/blog/2026/05/31/2026-may-monthly-report.md
+++ b/blog/zh/blog/2026/05/31/2026-may-monthly-report.md
@@ -3,7 +3,7 @@ title: "2026 社区月报 (05.01 - 05.31)"
 keywords: ["Apache APISIX", "API 网关", "社区月报", "贡献者"]
 description: Apache APISIX 社区的月报旨在帮助社区成员更全面地了解社区的最新动态，方便大家参与到 Apache APISIX 社区中来。
 tags: [Community]
-image: TODO_COVER_IMAGE_ZH
+image: https://api7-website-1301662268.cos.ap-guangzhou.myqcloud.com/uploads/2026/06/01/THfXIpPv_monthly-report-cover-cn.webp
 ---
 
 > 最近，我们引入并更新了一些新功能，包括新增飞书与钉钉认证插件、GraphQL 请求成本限制、OpenAPI 请求校验、更安全的代理缓存，以及更丰富的 AI 代理协议支持等。有关更多细节，请阅读本期月报。
@@ -18,9 +18,9 @@ Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便
 
 ## 贡献者统计
 
-![贡献者名单](TODO_CONTRIBUTOR_LIST_IMAGE)
+![贡献者名单](https://api7-website-1301662268.cos.ap-guangzhou.myqcloud.com/uploads/2026/06/01/bzwKQ6n1_2026-june-contributor-list.webp)
 
-![新晋贡献者](TODO_NEW_CONTRIBUTORS_IMAGE)
+![新晋贡献者](https://api7-website-1301662268.cos.ap-guangzhou.myqcloud.com/uploads/2026/06/01/8FBAfGMh_Group%20427320348.webp)
 
 ## 近期亮点功能
 
@@ -144,7 +144,7 @@ Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便
 
 本 PR 引入 `oas-validator` 插件，可在请求转发到上游之前，根据 OpenAPI Specification 3.x 文档校验入站 HTTP 请求。对于不符合规范的请求，插件可以返回可配置的错误状态码，帮助 API 提供方在网关层执行契约校验。
 
-### 16. `ai-proxy` 支持 Bedrock ConverseStream 流式响应
+### 16. `ai-proxy` 插件支持 Bedrock ConverseStream 流式响应
 
 相关 PR：https://github.com/apache/apisix/pull/13307
 
@@ -152,7 +152,7 @@ Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便
 
 本 PR 为 `ai-proxy` 的 Bedrock provider 增加 ConverseStream 支持。APISIX 现在可以路由 Bedrock 流式请求，解析 AWS EventStream 帧，并通过与其他 AI 协议一致的 provider 抽象转发模型流式响应。
 
-### 17. `elasticsearch-logger` 支持动态索引
+### 17. `elasticsearch-logger` 插件支持动态索引
 
 相关 PR：https://github.com/apache/apisix/pull/13334
 
@@ -176,11 +176,15 @@ Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便
 
 本 PR 为 `ai-proxy` 新增 passthrough 协议适配器，用于处理无法匹配已知 AI 协议但包含非空 JSON 请求体的场景。这样 APISIX 可以代理 OpenAI 兼容或自定义端点，例如图像生成 API，而不必为每种请求体格式都实现专门解析器。
 
-## 适合新手参与的 Issue
+## Good First Issue
 
-以下仍处于打开状态的 issue 在 5 月被标记为 `good first issue`。欢迎新贡献者关注并参与 Apache APISIX 社区：
+### Issue #13395
 
-- [docs: hmac-auth body validation example should sign the Digest header](https://github.com/apache/apisix/issues/13395)
+链接：https://github.com/apache/apisix/issues/13395
+
+描述：`hmac-auth` 插件文档中的请求体验证示例会计算并发送 `Digest` 请求头，但该请求头没有被加入 HMAC 签名请求头列表，也没有出现在签名字符串中。这会让示例略显误导：它看起来是在演示端到端的请求体完整性校验，但实际请求体摘要并没有被签名绑定。
+
+预期行为：更新 `hmac-auth` 文档示例，先计算请求体的 SHA-256 digest，再将其以 `digest: SHA-256=<base64 body digest>` 的形式加入签名字符串。同时，`Authorization` 请求头中的签名头列表也应加入 `digest`，例如 `headers="@request-target date digest"`。此外，可以补充一小段说明：`validate_request_body` 会校验 `Digest` 请求头与请求体是否匹配；如果用户希望请求体被签名绑定，也应将 `Digest` 加入 signed headers。
 
 ## 结语
 

--- a/blog/zh/blog/2026/05/31/2026-may-monthly-report.md
+++ b/blog/zh/blog/2026/05/31/2026-may-monthly-report.md
@@ -1,0 +1,187 @@
+---
+title: "2026 社区月报 (05.01 - 05.31)"
+keywords: ["Apache APISIX", "API 网关", "社区月报", "贡献者"]
+description: Apache APISIX 社区的月报旨在帮助社区成员更全面地了解社区的最新动态，方便大家参与到 Apache APISIX 社区中来。
+tags: [Community]
+image: TODO_COVER_IMAGE_ZH
+---
+
+> 最近，我们引入并更新了一些新功能，包括新增飞书与钉钉认证插件、GraphQL 请求成本限制、OpenAPI 请求校验、更安全的代理缓存，以及更丰富的 AI 代理协议支持等。有关更多细节，请阅读本期月报。
+
+<!--truncate-->
+
+## 导语
+
+Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便崭露头角，如今已经成为全球最活跃的开源 API 网关项目之一。正如谚语所言，"众人拾柴火焰高"，这一辉煌成就，得益于整个社区伙伴的协同努力。
+
+从 2026.05.01 至 2026.05.31，有 16 名开发者提交了 74 个 commits，为 Apache APISIX 做出了重要贡献。感谢这些伙伴们对 Apache APISIX 的无私支持！正是因为你们的付出，才能让 Apache APISIX 项目不断改进、提升和壮大。
+
+## 贡献者统计
+
+![贡献者名单](TODO_CONTRIBUTOR_LIST_IMAGE)
+
+![新晋贡献者](TODO_NEW_CONTRIBUTORS_IMAGE)
+
+## 近期亮点功能
+
+### 1. `hmac-auth` 默认将 `date` 加入签名请求头
+
+相关 PR：https://github.com/apache/apisix/pull/13388
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 将 `hmac-auth` 插件的 `signed_headers` 默认值调整为 `["date"]`。除非用户显式关闭，否则请求中的 `Date` 头会被纳入 HMAC 签名，从而让默认行为更好地配合时钟偏移保护，降低过期签名请求被复用的风险。
+
+### 2. 新增 `feishu-auth` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13382
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 新增 `feishu-auth` 插件，支持通过飞书（Lark）OAuth 2.0 授权码流程对浏览器访问的 API 进行认证。使用飞书作为企业身份系统的团队，可以直接在 APISIX 层保护内部 API 和开发者门户，而无需在每个上游服务中重复实现认证逻辑。
+
+### 3. 新增 `graphql-limit-count` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13372
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 引入 `graphql-limit-count` 插件，可在指定时间窗口内基于 GraphQL 查询 AST 深度进行限流。对于执行成本会随查询复杂度显著变化的 GraphQL API，这比单纯按请求次数限流更贴近实际资源消耗。
+
+### 4. 新增 `error-page` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13380
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 新增 `error-page` 插件，用于自定义 APISIX 自身生成的 HTTP 错误响应，例如未匹配到路由或上游不可用等场景。运维人员可以通过插件元数据配置响应体和内容类型，改善网关层错误的用户体验。
+
+### 5. 新增 `dingtalk-auth` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13381
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 新增 `dingtalk-auth` 插件，将钉钉 OAuth 2.0 认证集成到 APISIX 路由中。插件会通过钉钉验证用户身份，并将结果保存在加密 Cookie 会话中，从而减少同一会话内对钉钉 API 的重复调用。
+
+### 6. `cas-auth` 支持配置绝对回调 URL
+
+相关 PR：https://github.com/apache/apisix/pull/13413
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 允许 `cas-auth` 用户将 `cas_callback_uri` 配置为绝对 URL。对于 APISIX 部署在代理或外部域名之后的场景，CAS `service` URL 可以被显式指定，不再只能从传入请求的 Host 等信息推导。
+
+### 7. `proxy-cache` 内存策略支持遵循 `Vary` 响应头
+
+相关 PR：https://github.com/apache/apisix/pull/13376
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 让 `proxy-cache` 的内存缓存策略能够识别并遵循上游返回的 `Vary` 响应头。对于只在 `Accept-Encoding` 等头部上不同的请求，APISIX 现在可以存储不同缓存变体，避免缓存键冲突，并让内存策略更接近磁盘缓存策略的行为。
+
+### 8. `cas-auth` 签名请求 URI Cookie 并强化 Cookie 属性
+
+相关 PR：https://github.com/apache/apisix/pull/13331
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 使用 HMAC-SHA256 对 `cas-auth` 中的 `CAS_REQUEST_URI` Cookie 进行签名，并在回调阶段使用常量时间比较进行校验。同时，恢复出的跳转目标会被校验为同源路径，当 Cookie 缺失、格式错误或被篡改时会回退到 `/`，降低不安全跳转风险。
+
+### 9. 支持配置请求 JSON 解析库
+
+相关 PR：https://github.com/apache/apisix/pull/13386
+
+贡献者：[nic-6443](https://github.com/nic-6443)
+
+本 PR 新增 APISIX 级别的 JSON 库选择能力，用于请求体解析和 AI 上游请求体编码。用户可以在 `cjson`、`simdjson` 和实验性的 `qjson` 之间选择，从而在大 JSON 请求体场景下更灵活地平衡兼容性与性能。
+
+### 10. 新增 `acl` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13349
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 引入 `acl` 插件，为 API 路由提供基于标签的访问控制能力。团队可以根据消费者标签或外部属性（如角色、团队、订阅等级等）执行访问策略，无需编写自定义插件。
+
+### 11. 新增 `data-mask` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13347
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 新增 `data-mask` 插件，可在请求查询参数、请求头和请求体中的敏感字段进入访问日志或日志插件输出前进行掩码或脱敏处理。这有助于减少凭证、Token、个人信息和支付信息在可观测链路中的暴露。
+
+### 12. `proxy-cache` 新增更安全的缓存选项
+
+相关 PR：https://github.com/apache/apisix/pull/13350
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 为 `proxy-cache` 插件新增 `consumer_isolation` 和 `cache_set_cookie` 选项。默认按消费者隔离缓存项，并在未显式开启时拒绝缓存带有 `Set-Cookie` 的响应，让认证流量或个性化响应的共享缓存更安全。
+
+### 13. 新增 `exit-transformer` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13343
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 引入 `exit-transformer` 插件，并为 APISIX 响应处理扩展 exit 回调机制。用户可以在插件拒绝、未匹配路由等 APISIX 生成的退出响应返回给客户端之前，通过自定义 Lua 函数对其进行转换。
+
+### 14. 新增 `traffic-label` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13342
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 新增 `traffic-label` 插件，可根据加权随机分布规则为请求分配标签。标签可以写入请求头或 APISIX 变量，适用于实验分流、路由提示、策略化打标等流量分组场景。
+
+### 15. 新增 `oas-validator` 插件
+
+相关 PR：https://github.com/apache/apisix/pull/13344
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+本 PR 引入 `oas-validator` 插件，可在请求转发到上游之前，根据 OpenAPI Specification 3.x 文档校验入站 HTTP 请求。对于不符合规范的请求，插件可以返回可配置的错误状态码，帮助 API 提供方在网关层执行契约校验。
+
+### 16. `ai-proxy` 支持 Bedrock ConverseStream 流式响应
+
+相关 PR：https://github.com/apache/apisix/pull/13307
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 为 `ai-proxy` 的 Bedrock provider 增加 ConverseStream 支持。APISIX 现在可以路由 Bedrock 流式请求，解析 AWS EventStream 帧，并通过与其他 AI 协议一致的 provider 抽象转发模型流式响应。
+
+### 17. `elasticsearch-logger` 支持动态索引
+
+相关 PR：https://github.com/apache/apisix/pull/13334
+
+贡献者：[nic-6443](https://github.com/nic-6443)
+
+本 PR 允许 `elasticsearch-logger` 插件使用日期时间占位符和 APISIX 变量配置动态索引模式。索引名称会在每个请求中解析，且不会修改插件配置对象，支持按日期轮转索引或按 Host 拆分日志等场景。
+
+### 18. 使用白名单方式重写 Anthropic 到 OpenAI 的请求体转换
+
+相关 PR：https://github.com/apache/apisix/pull/13321
+
+贡献者：[nic-6443](https://github.com/nic-6443)
+
+本 PR 将 `ai-proxy` 中 Anthropic Messages 到 OpenAI Chat Completions 的转换逻辑改为基于显式白名单构造请求体。新的方式可以避免未支持的 Anthropic 专有字段泄漏到 OpenAI 兼容上游，使协议转换更可预测。
+
+### 19. 为未识别的 AI API 格式新增透传协议
+
+相关 PR：https://github.com/apache/apisix/pull/13320
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+本 PR 为 `ai-proxy` 新增 passthrough 协议适配器，用于处理无法匹配已知 AI 协议但包含非空 JSON 请求体的场景。这样 APISIX 可以代理 OpenAI 兼容或自定义端点，例如图像生成 API，而不必为每种请求体格式都实现专门解析器。
+
+## 适合新手参与的 Issue
+
+以下仍处于打开状态的 issue 在 5 月被标记为 `good first issue`。欢迎新贡献者关注并参与 Apache APISIX 社区：
+
+- [docs: hmac-auth body validation example should sign the Digest header](https://github.com/apache/apisix/issues/13395)
+
+## 结语
+
+Apache APISIX 的项目[官网](https://apisix.apache.org/zh/)和 GitHub 上的 [Issues](https://github.com/apache/apisix/issues) 上已经积累了比较丰富的文档教程和使用经验，如果您遇到问题可以翻阅文档，用关键词在 Issues 中搜索，也可以参与 Issues 上的讨论，提出自己的想法和实践经验。


### PR DESCRIPTION
## Summary

Add the May 2026 community monthly report (EN + ZH).

## Feature Highlights Covered

1. **Default `hmac-auth` signed headers to `date`** - PR #13388
2. **Add `feishu-auth` plugin** - PR #13382
3. **Add `graphql-limit-count` plugin** - PR #13372
4. **Add `error-page` plugin** - PR #13380
5. **Add `dingtalk-auth` plugin** - PR #13381
6. **Support absolute callback URLs in `cas-auth`** - PR #13413
7. **Honor `Vary` header in `proxy-cache` memory strategy** - PR #13376
8. **Sign request URI cookie and tighten cookie attributes in `cas-auth`** - PR #13331
9. **Support configurable request JSON library** - PR #13386
10. **Add `acl` plugin** - PR #13349
11. **Add `data-mask` plugin** - PR #13347
12. **Add safer `proxy-cache` options** - PR #13350
13. **Add `exit-transformer` plugin** - PR #13343
14. **Add `traffic-label` plugin** - PR #13342
15. **Add `oas-validator` plugin** - PR #13344
16. **Support Bedrock ConverseStream streaming in `ai-proxy`** - PR #13307
17. **Support dynamic indexes in `elasticsearch-logger`** - PR #13334
18. **Rewrite Anthropic-to-OpenAI converter with whitelist body construction** - PR #13321
19. **Add passthrough protocol for unrecognized AI API formats** - PR #13320

## Contributor Statistics

- **16** contributors, **74** commits
- **6** new contributors: arpitjain099, yangkaa, hyarkoni-DN, SinhSinhAn, johannes-engler-mw, potiuk

## TODO (Manual)

- [x] Replace `TODO_COVER_IMAGE_EN` and `TODO_COVER_IMAGE_ZH` with actual cover images
- [x] Replace `TODO_CONTRIBUTOR_LIST_IMAGE` with contributor list image
- [x] Replace `TODO_NEW_CONTRIBUTORS_IMAGE` with new contributors image
