### PR TITLE
chore:  release apisix-ingress-controller 2.1.0

### DIFF
--- a/config/docs.js
+++ b/config/docs.js
@@ -17,8 +17,8 @@ module.exports = [
     shape: 'hexagon',
     color: '#2563EB',
     githubRepo: 'apache/apisix-ingress-controller',
-    version: '2.0.0',
-    releaseDate: '2025-12-17',
+    version: '2.1.0',
+    releaseDate: '2026-06-01',
     firstDocPath: '/overview',
   },
   {

--- a/config/downloads.js
+++ b/config/downloads.js
@@ -25,8 +25,8 @@ module.exports = [
     githubBranch: 'master',
     downloadPath: 'apisix/ingress-controller/1.6.0/apache-apisix-ingress-controller-1.6.0-src',
     dockerhubPath: 'apisix-ingress-controller',
-    version: '2.0.0',
-    releaseDate: '2025-12-17',
+    version: '2.1.0',
+    releaseDate: '2026-06-01',
     firstDocPath: '/overview',
   },
   {


### PR DESCRIPTION
https://github.com/apache/apisix-ingress-controller/releases/tag/2.1.0