### PR TITLE
[codex] Improve technical SEO and mobile performance

### DIFF
--- a/blog/en/docusaurus.config.js
+++ b/blog/en/docusaurus.config.js
@@ -16,8 +16,16 @@ const metadatas = [
     content: 'index,follow',
   },
   {
+    property: 'og:site_name',
+    content: 'Apache APISIX',
+  },
+  {
     name: 'twitter:card',
     content: 'summary_large_image',
+  },
+  {
+    name: 'twitter:site',
+    content: '@apacheapisix',
   },
 ];
 

--- a/blog/src/css/customTheme.scss
+++ b/blog/src/css/customTheme.scss
@@ -526,3 +526,58 @@ button[class*="announcementBarClose"] {
     font-weight: 500;
   }
 }
+
+/* stylelint-disable no-descending-specificity */
+.markdown img,
+article img {
+  max-width: 100%;
+  height: auto;
+}
+
+.markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+h1,
+h2,
+h3,
+[id] {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 16px);
+}
+
+@media screen and (max-width: 996px) {
+  article {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  article p {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  article h1 {
+    font-size: 2.1rem;
+    line-height: 1.15;
+  }
+
+  article h2 {
+    font-size: 1.75rem;
+    line-height: 1.2;
+  }
+
+  article h3 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+  }
+}
+/* stylelint-enable no-descending-specificity */

--- a/blog/src/theme/CodeBlock/styles.module.css
+++ b/blog/src/theme/CodeBlock/styles.module.css
@@ -17,6 +17,8 @@
 .codeBlockContent {
   position: relative;
   direction: ltr;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .codeBlockTitle {
@@ -30,6 +32,7 @@
   margin: 0;
   padding: 0;
   border-radius: 0;
+  min-width: 100%;
 }
 
 .copyButton {
@@ -63,5 +66,11 @@
 @media print {
   .codeBlockLines {
     white-space: pre-wrap;
+  }
+}
+
+@media (hover: none) {
+  .copyButton {
+    opacity: 1;
   }
 }

--- a/blog/src/theme/NotFound/index.tsx
+++ b/blog/src/theme/NotFound/index.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react';
 import React from 'react';
 import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
 import { translate } from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import style from './styles.module.scss';
@@ -14,6 +15,9 @@ const NotFound: FC = () => (
       message: 'Page Not Found',
     })}
   >
+    <Head>
+      <meta name="robots" content="noindex,follow" />
+    </Head>
     <main className={style.container}>
       <section>
         <Fitty tagName="h1" contentEditable>404</Fitty>
@@ -31,12 +35,16 @@ const NotFound: FC = () => (
         .
       </p>
       <p>
-        You can also return to
+        You can also open the
         {' '}
-        <Link href="/">
-          the home page
-        </Link>
-        . Or, return to
+        <Link to="/">home page</Link>
+        ,
+        {' '}
+        <Link to="/docs/">documentation</Link>
+        ,
+        {' '}
+        <Link to="/blog/">blog</Link>
+        , or
         {' '}
         <a
           role="button"
@@ -45,7 +53,7 @@ const NotFound: FC = () => (
             window?.history.back();
           }}
         >
-          the source page
+          return to the source page
         </a>
         .
       </p>

--- a/blog/zh/docusaurus.config.js
+++ b/blog/zh/docusaurus.config.js
@@ -17,8 +17,16 @@ const metadatas = [
     content: 'index,follow',
   },
   {
+    property: 'og:site_name',
+    content: 'Apache APISIX',
+  },
+  {
     name: 'twitter:card',
     content: 'summary_large_image',
+  },
+  {
+    name: 'twitter:site',
+    content: '@apacheapisix',
   },
 ];
 

--- a/config/ssrTemplate.js
+++ b/config/ssrTemplate.js
@@ -6,6 +6,11 @@ module.exports = {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="ahrefs-site-verification" content="c2f7370ecf46173f4fb25f114e74c97e0a2976d4f02f61c9b00a9d7d34e34698">
       <meta name="generator" content="Docusaurus v<%= it.version %>">
+      <link rel="preconnect" href="https://static.apiseven.com" crossorigin>
+      <link rel="preconnect" href="https://apisix-website-static.apiseven.com" crossorigin>
+      <link rel="preconnect" href="https://static.api7.ai" crossorigin>
+      <link rel="dns-prefetch" href="https://analytics.apache.org">
+      <link rel="dns-prefetch" href="https://widget.kapa.ai">
       <% if (it.noIndex) { %>
         <meta name="robots" content="noindex, nofollow" />
       <% } %>
@@ -22,21 +27,29 @@ module.exports = {
       <% }); %>
       <!-- Matomo from the ASF -->
       <script>
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before
+        window._paq = window._paq || [];
+        function loadMatomo() {
+          var _paq = window._paq;
+          /* tracker methods like "setCustomDimension" should be called before
       "trackPageView" */
-        /* We explicitly disable cookie tracking to avoid privacy issues */
-        _paq.push(['disableCookies']);
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-          var u="https://analytics.apache.org/";
-          _paq.push(['setTrackerUrl', u+'matomo.php']);
-          _paq.push(['setSiteId', '17']);
-          var d=document, g=d.createElement('script'),
-      s=d.getElementsByTagName('script')[0];
-          g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
+          /* We explicitly disable cookie tracking to avoid privacy issues */
+          _paq.push(['disableCookies']);
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="https://analytics.apache.org/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '17']);
+            var d=document, g=d.createElement('script'),
+        s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          })();
+        }
+        if ('requestIdleCallback' in window) {
+          window.requestIdleCallback(loadMatomo, { timeout: 3000 });
+        } else {
+          window.addEventListener('load', loadMatomo, { once: true });
+        }
       </script>
       <!-- End Matomo Code -->
     </head>

--- a/doc/docusaurus.config.js
+++ b/doc/docusaurus.config.js
@@ -252,8 +252,16 @@ module.exports = {
         content: 'index,follow',
       },
       {
+        property: 'og:site_name',
+        content: 'Apache APISIX',
+      },
+      {
         name: 'twitter:card',
         content: 'summary_large_image',
+      },
+      {
+        name: 'twitter:site',
+        content: '@apacheapisix',
       },
     ],
   },

--- a/doc/src/css/customTheme.scss
+++ b/doc/src/css/customTheme.scss
@@ -524,3 +524,58 @@ button[class*="announcementBarClose"] {
     font-weight: 500;
   }
 }
+
+/* stylelint-disable no-descending-specificity */
+.markdown img,
+article img {
+  max-width: 100%;
+  height: auto;
+}
+
+.markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+h1,
+h2,
+h3,
+[id] {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 16px);
+}
+
+@media screen and (max-width: 996px) {
+  article {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  article p {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  article h1 {
+    font-size: 2.1rem;
+    line-height: 1.15;
+  }
+
+  article h2 {
+    font-size: 1.75rem;
+    line-height: 1.2;
+  }
+
+  article h3 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+  }
+}
+/* stylelint-enable no-descending-specificity */

--- a/doc/src/pages/edit.tsx
+++ b/doc/src/pages/edit.tsx
@@ -57,7 +57,7 @@ const Edit: FC = () => {
         />
         <meta name="twitter:site" content="@apacheapisix" />
         <meta
-          name="og:description"
+          property="og:description"
           content="Apache APISIX is a dynamic, real-time, high-performance Cloud-Native API gateway, based on the Nginx library and etcd."
         />
       </Head>

--- a/doc/src/theme/CodeBlock/styles.module.css
+++ b/doc/src/theme/CodeBlock/styles.module.css
@@ -17,6 +17,8 @@
 .codeBlockContent {
   position: relative;
   direction: ltr;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .codeBlockTitle {
@@ -30,6 +32,7 @@
   margin: 0;
   padding: 0;
   border-radius: 0;
+  min-width: 100%;
 }
 
 .copyButton {
@@ -63,5 +66,11 @@
 @media print {
   .codeBlockLines {
     white-space: pre-wrap;
+  }
+}
+
+@media (hover: none) {
+  .copyButton {
+    opacity: 1;
   }
 }

--- a/doc/src/theme/NotFound/index.tsx
+++ b/doc/src/theme/NotFound/index.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react';
 import React from 'react';
 import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
 import { translate } from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import style from './styles.module.scss';
@@ -14,6 +15,9 @@ const NotFound: FC = () => (
       message: 'Page Not Found',
     })}
   >
+    <Head>
+      <meta name="robots" content="noindex,follow" />
+    </Head>
     <main className={style.container}>
       <section>
         <Fitty tagName="h1" contentEditable>404</Fitty>
@@ -31,12 +35,16 @@ const NotFound: FC = () => (
         .
       </p>
       <p>
-        You can also return to
+        You can also open the
         {' '}
-        <Link href="/">
-          the home page
-        </Link>
-        . Or, return to
+        <Link to="/">home page</Link>
+        ,
+        {' '}
+        <Link to="/docs/">documentation</Link>
+        ,
+        {' '}
+        <Link to="/blog/">blog</Link>
+        , or
         {' '}
         <a
           role="button"
@@ -45,7 +53,7 @@ const NotFound: FC = () => (
             window?.history.back();
           }}
         >
-          the source page
+          return to the source page
         </a>
         .
       </p>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -155,16 +155,16 @@ module.exports = {
         content: 'index,follow',
       },
       {
+        property: 'og:site_name',
+        content: 'Apache APISIX',
+      },
+      {
         name: 'twitter:card',
         content: 'summary_large_image',
       },
       {
         name: 'twitter:site',
         content: '@apacheapisix',
-      },
-      {
-        property: 'og:site_name',
-        content: 'Apache APISIX',
       },
       {
         property: 'og:type',

--- a/website/src/components/AIGateway/AvifImage.tsx
+++ b/website/src/components/AIGateway/AvifImage.tsx
@@ -3,15 +3,21 @@ import type { ImageProps } from '@chakra-ui/react';
 import { Image } from '@chakra-ui/react';
 
 const AvifImage: React.FC<ImageProps> = ({ src, alt, ...props }) => {
+  const imageProps = {
+    decoding: 'async',
+    loading: 'lazy',
+    ...props,
+  };
+
   if (src?.toLowerCase().includes('.svg') || src?.includes('imageMogr2/')) {
-    return <Image src={src} alt={alt} {...props} />;
+    return <Image src={src} alt={alt} {...imageProps} />;
   }
 
   return (
     <picture>
       <source srcSet={`${src}?imageMogr2/format/avif`} type="image/avif" />
       <source srcSet={`${src}?imageMogr2/format/webp`} type="image/webp" />
-      <Image src={src} alt={alt} {...props} />
+      <Image src={src} alt={alt} {...imageProps} />
     </picture>
   );
 };

--- a/website/src/components/AIGateway/Hero.tsx
+++ b/website/src/components/AIGateway/Hero.tsx
@@ -59,10 +59,11 @@ const Hero: React.FC = () => {
             display="flex"
             alignItems="center"
           >
-            <Box w="full">
+            <Box w="full" minH={{ base: '260px', md: '360px' }}>
               <AvifImage
                 src="https://static.api7.ai/uploads/2025/04/17/zdPVQ1zg_apisix-ai-gateway.png"
                 alt="Apache APISIX AI Gateway architecture overview"
+                loading="eager"
                 animation={fadeInAnimation}
                 w="full"
                 transform="scale(1.1)"

--- a/website/src/components/HeroCanvas.tsx
+++ b/website/src/components/HeroCanvas.tsx
@@ -50,8 +50,6 @@ const HeroCanvas: FC = () => {
     let camera; let mesh; let scene; let renderer; let material; let
       geometry;
 
-    window.addEventListener('resize', onWindowResize, false);
-
     if (screenWidth > 1100) {
       canvasHeight = screenHeight;
       canvasWidth = screenWidth / 2;
@@ -63,7 +61,7 @@ const HeroCanvas: FC = () => {
     canvasRef.current.width = canvasWidth;
     canvasRef.current.height = canvasHeight;
 
-    canvasRef.current.addEventListener('mousemove', (event) => {
+    const handleCanvasMouseMove = (event: MouseEvent) => {
       const ctx = {
         x: (event.clientX),
         y: (event.clientY),
@@ -96,7 +94,10 @@ const HeroCanvas: FC = () => {
           material.uniforms.u_fragMouse.value.y = fragMouse.y;
         },
       });
-    });
+    };
+
+    window.addEventListener('resize', onWindowResize, false);
+    canvasRef.current.addEventListener('mousemove', handleCanvasMouseMove);
 
     function getRandom(a, b) {
       return a + (b - a) * Math.random();
@@ -114,8 +115,6 @@ const HeroCanvas: FC = () => {
         if (entry.isIntersecting && isLoaded) {
           if (isLoaded && !isRendering) {
             animate();
-          } else {
-            console.log('Loading');
           }
         } else {
           if (animationFrame) {
@@ -210,7 +209,7 @@ const HeroCanvas: FC = () => {
 
       controls.update();
 
-      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.5));
       onWindowResize();
 
       isLoaded = true;
@@ -249,6 +248,8 @@ const HeroCanvas: FC = () => {
     }
 
     return () => {
+      window.removeEventListener('resize', onWindowResize, false);
+      canvasRef.current?.removeEventListener('mousemove', handleCanvasMouseMove);
       // eslint-disable-next-line prefer-spread
       scene.remove.apply(scene, scene.children);
       canvasObserver.disconnect();

--- a/website/src/css/customTheme.scss
+++ b/website/src/css/customTheme.scss
@@ -530,3 +530,58 @@ button[class*="announcementBarClose"] {
     font-weight: 500;
   }
 }
+
+/* stylelint-disable no-descending-specificity */
+.markdown img,
+article img {
+  max-width: 100%;
+  height: auto;
+}
+
+.markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+h1,
+h2,
+h3,
+[id] {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 16px);
+}
+
+@media screen and (max-width: 996px) {
+  article {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  article p {
+    font-size: 17px;
+    line-height: 1.75;
+  }
+
+  article h1 {
+    font-size: 2.1rem;
+    line-height: 1.15;
+  }
+
+  article h2 {
+    font-size: 1.75rem;
+    line-height: 1.2;
+  }
+
+  article h3 {
+    font-size: 1.35rem;
+    line-height: 1.25;
+  }
+}
+/* stylelint-enable no-descending-specificity */

--- a/website/src/css/landing-sections/hero.scss
+++ b/website/src/css/landing-sections/hero.scss
@@ -37,7 +37,7 @@
 .hero-ctas {
   display: flex;
   align-items: center;
-  animation-delay: 0.5;
+  animation-delay: 0.5s;
 }
 
 .hero-sec-wrap {
@@ -156,5 +156,52 @@
 
   .hero-subtitle {
     width: 40vw;
+  }
+}
+
+@media (max-width: 996px) {
+  .hero-title,
+  .hero-subtitle,
+  .hero-ctas {
+    animation: none;
+  }
+
+  .hero-sec-wrap {
+    min-height: calc(100svh - var(--ifm-navbar-height));
+    height: auto;
+    padding: 72px 0 48px;
+  }
+
+  .hero-text {
+    width: 100%;
+    padding: 0 24px;
+    align-content: center;
+  }
+
+  .hero-title {
+    width: 100%;
+    max-width: 680px;
+    font-size: clamp(2.4rem, 12vw, 4.2rem);
+    line-height: 1.05;
+  }
+
+  .hero-subtitle {
+    width: 100%;
+    max-width: 680px;
+    padding-right: 0;
+    margin: 18px 0;
+  }
+
+  .hero-ctas {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-title,
+  .hero-subtitle,
+  .hero-ctas {
+    animation: none;
   }
 }

--- a/website/src/pages/ai-gateway.tsx
+++ b/website/src/pages/ai-gateway.tsx
@@ -30,7 +30,12 @@ const ChakraTestPage: React.FC = () => (
         property="og:description"
         content="An AI gateway manages traffic between applications and LLM providers. Apache APISIX AI Gateway provides LLM load balancing, token rate limiting, MCP support, and security for AI agents."
       />
+      <meta
+        property="og:image"
+        content="https://static.api7.ai/uploads/2025/04/17/zdPVQ1zg_apisix-ai-gateway.png"
+      />
 
+      <meta name="twitter:card" content="summary_large_image" />
       <meta
         name="twitter:title"
         content="What is an AI Gateway? APISIX AI Gateway for LLMs &amp; AI Agents"
@@ -38,6 +43,10 @@ const ChakraTestPage: React.FC = () => (
       <meta
         name="twitter:description"
         content="An AI gateway manages traffic between applications and LLM providers. Apache APISIX AI Gateway provides LLM load balancing, token rate limiting, MCP support, and security for AI agents."
+      />
+      <meta
+        name="twitter:image"
+        content="https://static.api7.ai/uploads/2025/04/17/zdPVQ1zg_apisix-ai-gateway.png"
       />
 
       <script type="application/ld+json">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -50,6 +50,10 @@ const Index: FC = () => (
       <title>{translate({ id: 'homepage.meta.title', message: 'Apache APISIX - Open Source API Gateway & AI Gateway' })}</title>
       <link rel="canonical" href="https://apisix.apache.org/" />
       <meta
+        name="description"
+        content="Apache APISIX is a dynamic, high-performance, open-source API gateway and AI gateway. Features include load balancing, authentication, rate limiting, AI proxying, LLM load balancing, and 100+ plugins."
+      />
+      <meta
         property="og:title"
         content="Apache APISIX - Open Source API Gateway &amp; AI Gateway"
       />

--- a/website/src/theme/NotFound/index.tsx
+++ b/website/src/theme/NotFound/index.tsx
@@ -2,6 +2,7 @@
 import type { FC } from 'react';
 import React from 'react';
 import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
 import { translate } from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
 import style from './styles.module.scss';
@@ -14,6 +15,9 @@ const NotFound: FC = () => (
       message: 'Page Not Found',
     })}
   >
+    <Head>
+      <meta name="robots" content="noindex,follow" />
+    </Head>
     <main className={style.container}>
       <section>
         <Fitty tagName="h1" contentEditable>404</Fitty>
@@ -31,12 +35,16 @@ const NotFound: FC = () => (
         .
       </p>
       <p>
-        You can also return to
+        You can also open the
         {' '}
-        <Link href="/">
-          the home page
-        </Link>
-        . Or, return to
+        <Link to="/">home page</Link>
+        ,
+        {' '}
+        <Link to="/docs/">documentation</Link>
+        ,
+        {' '}
+        <Link to="/blog/">blog</Link>
+        , or
         {' '}
         <a
           role="button"
@@ -45,7 +53,7 @@ const NotFound: FC = () => (
             window?.history.back();
           }}
         >
-          the source page
+          return to the source page
         </a>
         .
       </p>

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -18,6 +18,7 @@ Disallow: /docs/apisix/3.12/
 Disallow: /docs/apisix/3.13/
 Disallow: /docs/apisix/3.14/
 Disallow: /docs/apisix/3.15/
+Disallow: /docs/apisix/3.16/
 Disallow: /docs/apisix/next/
 Disallow: /docs/ingress-controller/3.10/
 Disallow: /docs/ingress-controller/3.11/
@@ -25,6 +26,7 @@ Disallow: /docs/ingress-controller/3.12/
 Disallow: /docs/ingress-controller/3.13/
 Disallow: /docs/ingress-controller/3.14/
 Disallow: /docs/ingress-controller/3.15/
+Disallow: /docs/ingress-controller/3.16/
 Disallow: /docs/ingress-controller/next/
 Disallow: /docs/helm-chart/3.10/
 Disallow: /docs/helm-chart/3.11/
@@ -32,6 +34,7 @@ Disallow: /docs/helm-chart/3.12/
 Disallow: /docs/helm-chart/3.13/
 Disallow: /docs/helm-chart/3.14/
 Disallow: /docs/helm-chart/3.15/
+Disallow: /docs/helm-chart/3.16/
 Disallow: /docs/helm-chart/next/
 Disallow: /docs/docker/3.10/
 Disallow: /docs/docker/3.11/
@@ -39,6 +42,7 @@ Disallow: /docs/docker/3.12/
 Disallow: /docs/docker/3.13/
 Disallow: /docs/docker/3.14/
 Disallow: /docs/docker/3.15/
+Disallow: /docs/docker/3.16/
 Disallow: /docs/docker/next/
 Disallow: /docs/java-plugin-runner/3.10/
 Disallow: /docs/java-plugin-runner/3.11/
@@ -46,6 +50,7 @@ Disallow: /docs/java-plugin-runner/3.12/
 Disallow: /docs/java-plugin-runner/3.13/
 Disallow: /docs/java-plugin-runner/3.14/
 Disallow: /docs/java-plugin-runner/3.15/
+Disallow: /docs/java-plugin-runner/3.16/
 Disallow: /docs/java-plugin-runner/next/
 Disallow: /docs/go-plugin-runner/3.10/
 Disallow: /docs/go-plugin-runner/3.11/
@@ -53,6 +58,7 @@ Disallow: /docs/go-plugin-runner/3.12/
 Disallow: /docs/go-plugin-runner/3.13/
 Disallow: /docs/go-plugin-runner/3.14/
 Disallow: /docs/go-plugin-runner/3.15/
+Disallow: /docs/go-plugin-runner/3.16/
 Disallow: /docs/go-plugin-runner/next/
 Disallow: /docs/python-plugin-runner/3.10/
 Disallow: /docs/python-plugin-runner/3.11/
@@ -60,6 +66,7 @@ Disallow: /docs/python-plugin-runner/3.12/
 Disallow: /docs/python-plugin-runner/3.13/
 Disallow: /docs/python-plugin-runner/3.14/
 Disallow: /docs/python-plugin-runner/3.15/
+Disallow: /docs/python-plugin-runner/3.16/
 Disallow: /docs/python-plugin-runner/next/
 
 # Chinese equivalents
@@ -69,6 +76,7 @@ Disallow: /zh/docs/apisix/3.12/
 Disallow: /zh/docs/apisix/3.13/
 Disallow: /zh/docs/apisix/3.14/
 Disallow: /zh/docs/apisix/3.15/
+Disallow: /zh/docs/apisix/3.16/
 Disallow: /zh/docs/apisix/next/
 Disallow: /zh/docs/ingress-controller/3.10/
 Disallow: /zh/docs/ingress-controller/3.11/
@@ -76,6 +84,7 @@ Disallow: /zh/docs/ingress-controller/3.12/
 Disallow: /zh/docs/ingress-controller/3.13/
 Disallow: /zh/docs/ingress-controller/3.14/
 Disallow: /zh/docs/ingress-controller/3.15/
+Disallow: /zh/docs/ingress-controller/3.16/
 Disallow: /zh/docs/ingress-controller/next/
 Disallow: /zh/docs/helm-chart/3.10/
 Disallow: /zh/docs/helm-chart/3.11/
@@ -83,6 +92,7 @@ Disallow: /zh/docs/helm-chart/3.12/
 Disallow: /zh/docs/helm-chart/3.13/
 Disallow: /zh/docs/helm-chart/3.14/
 Disallow: /zh/docs/helm-chart/3.15/
+Disallow: /zh/docs/helm-chart/3.16/
 Disallow: /zh/docs/helm-chart/next/
 Disallow: /zh/docs/docker/3.10/
 Disallow: /zh/docs/docker/3.11/
@@ -90,6 +100,7 @@ Disallow: /zh/docs/docker/3.12/
 Disallow: /zh/docs/docker/3.13/
 Disallow: /zh/docs/docker/3.14/
 Disallow: /zh/docs/docker/3.15/
+Disallow: /zh/docs/docker/3.16/
 Disallow: /zh/docs/docker/next/
 Disallow: /zh/docs/java-plugin-runner/3.10/
 Disallow: /zh/docs/java-plugin-runner/3.11/
@@ -97,6 +108,7 @@ Disallow: /zh/docs/java-plugin-runner/3.12/
 Disallow: /zh/docs/java-plugin-runner/3.13/
 Disallow: /zh/docs/java-plugin-runner/3.14/
 Disallow: /zh/docs/java-plugin-runner/3.15/
+Disallow: /zh/docs/java-plugin-runner/3.16/
 Disallow: /zh/docs/java-plugin-runner/next/
 Disallow: /zh/docs/go-plugin-runner/3.10/
 Disallow: /zh/docs/go-plugin-runner/3.11/
@@ -104,6 +116,7 @@ Disallow: /zh/docs/go-plugin-runner/3.12/
 Disallow: /zh/docs/go-plugin-runner/3.13/
 Disallow: /zh/docs/go-plugin-runner/3.14/
 Disallow: /zh/docs/go-plugin-runner/3.15/
+Disallow: /zh/docs/go-plugin-runner/3.16/
 Disallow: /zh/docs/go-plugin-runner/next/
 Disallow: /zh/docs/python-plugin-runner/3.10/
 Disallow: /zh/docs/python-plugin-runner/3.11/
@@ -111,6 +124,7 @@ Disallow: /zh/docs/python-plugin-runner/3.12/
 Disallow: /zh/docs/python-plugin-runner/3.13/
 Disallow: /zh/docs/python-plugin-runner/3.14/
 Disallow: /zh/docs/python-plugin-runner/3.15/
+Disallow: /zh/docs/python-plugin-runner/3.16/
 Disallow: /zh/docs/python-plugin-runner/next/
 
 Sitemap: https://apisix.apache.org/sitemap.xml


### PR DESCRIPTION
## Summary

- Add technical SEO metadata improvements, resource hints, and deferred Matomo loading.
- Improve mobile/Core Web Vitals behavior for the homepage, AI Gateway page, docs, blog, code blocks, images, and 404 pages.
- Add robots rules for low-value versioned docs paths and fix a small Open Graph metadata issue.

## Validation

- `git diff --cached --check`
- `yarn eslint website/src/pages/index.tsx website/src/pages/ai-gateway.tsx website/src/components/AIGateway/AvifImage.tsx website/src/components/AIGateway/Hero.tsx website/src/components/HeroCanvas.tsx website/src/theme/NotFound/index.tsx blog/src/theme/NotFound/index.tsx doc/src/theme/NotFound/index.tsx doc/src/pages/edit.tsx`
- `yarn stylelint website/src/css/customTheme.scss website/src/css/landing-sections/hero.scss doc/src/css/customTheme.scss blog/src/css/customTheme.scss doc/src/theme/CodeBlock/styles.module.css blog/src/theme/CodeBlock/styles.module.css`
- `yarn build:website`

Notes:

- Full `yarn build` was not used as the primary validation because the local environment requires synced generated docs/blog artifacts and GitHub API data. Those environment-dependent blockers are documented outside this PR.
- `yarn build:website` completed successfully. Docusaurus emitted expected warnings for isolated website builds, including missing cross-package docs/blog links and outdated Browserslist data, but exited successfully.
