### PR TITLE
fix(seo): publish only the latest version of each sub-project's docs (de-bloat sitemap)

### DIFF
--- a/scripts/special-process-v2md.sh
+++ b/scripts/special-process-v2md.sh
@@ -1,19 +1,39 @@
 #!/usr/bin/env bash
-# remove <!--\s*markdown-link-check-disable\s*--> and <!--\s*markdown-link-check-enable\s*-->
-# in /apisix-ingress-controller/references/v2.mdx
-# after synced docs
+# Remove the `markdown-link-check-disable` / `markdown-link-check-enable`
+# comment pairs from every apisix-ingress-controller `references/v2.mdx` that
+# exists after the docs sync — the current/master copy plus whatever versioned
+# copies were built.
+#
+# The built version set is not fixed (see SUBPROJECT_VERSIONS_TO_KEEP in
+# sync-docs.js), so glob for the files that actually exist instead of
+# hardcoding version numbers, which previously broke the build whenever the
+# referenced versions were no longer published.
+set -e
 
-BASEDIR=$(dirname $0)/..
+BASEDIR=$(dirname "$0")/..
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  sed -i '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs/apisix-ingress-controller/references/v2.mdx
-  sed -i '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.7.0/references/v2.mdx
-  sed -i '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.8.0/references/v2.mdx
+  sed_inplace() { sed -i "$@"; }
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs/apisix-ingress-controller/references/v2.mdx
-  sed -i '' '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.7.0/references/v2.mdx
-  sed -i '' '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' $BASEDIR/doc/docs-apisix-ingress-controller_versioned_docs/version-1.8.0/references/v2.mdx
+  sed_inplace() { sed -i '' "$@"; }
 else
   echo "Unsupported OS: $OSTYPE"
   exit 1
 fi
+
+shopt -s nullglob
+files=(
+  "$BASEDIR"/doc/docs/apisix-ingress-controller/references/v2.mdx
+  "$BASEDIR"/doc/docs-apisix-ingress-controller_versioned_docs/version-*/references/v2.mdx
+)
+shopt -u nullglob
+
+processed=0
+for f in "${files[@]}"; do
+  [ -f "$f" ] || continue
+  sed_inplace '/<!--\s*markdown-link-check-disable\s*-->/I,+1d; /<!--\s*markdown-link-check-enable\s*-->/I,+1d;' "$f"
+  echo "special-process-v2md: processed $f"
+  processed=$((processed + 1))
+done
+
+echo "special-process-v2md: processed ${processed} file(s)"

--- a/scripts/sync-docs.js
+++ b/scripts/sync-docs.js
@@ -18,6 +18,14 @@ const websitePath = '../doc';
 const gitMap = {};
 const projectReleases = {};
 
+// SEO: only the newest N released versions of each non-apisix sub-project
+// (ingress-controller, helm-chart, docker, *-plugin-runner) are built and
+// published. Publishing every historical release bloated the sitemap with
+// hundreds of thin/duplicate pages (e.g. ingress 0.4.0–2.0.0, docker
+// apisix-2.10.x) and orphaned 403 landing dirs. apisix itself is curated
+// separately in config/apisix-versions.js. Increase this for a wider window.
+const SUBPROJECT_VERSIONS_TO_KEEP = 1;
+
 const tasks = new Listr([
   {
     title: 'Start documents sync',
@@ -92,7 +100,9 @@ const tasks = new Listr([
                 .map((release) => (isIngressController
                   ? release.replace('remotes/origin/v', '')
                   : release.replace('remotes/origin/release/', '')))
-                .sort((a, b) => semver.compare(semver.coerce(a).version, semver.coerce(b).version));
+                .sort((a, b) => semver.compare(semver.coerce(a).version, semver.coerce(b).version))
+                // SEO: keep only the newest N released versions (see constant above).
+                .slice(-SUBPROJECT_VERSIONS_TO_KEEP);
             }
           },
         }));

--- a/scripts/update-sitemap-loc.js
+++ b/scripts/update-sitemap-loc.js
@@ -33,6 +33,8 @@ const excludePatterns = [
   // path should be indexed. Matches 2-part (apisix 3.14), 3-part semver
   // (ingress 2.0.0), and prefixed (docker apisix-2.10.0) version segments.
   /\/docs\/[\w-]+\/(?:[\w-]+-)?\d+\.\d+(?:\.\d+)?\//,
+  // Doc tag aggregation pages (low-value, mirrors the /blog/tags/ rule below)
+  /\/docs\/[\w./-]+\/tags\//,
   // Development "next" docs
   /\/docs\/[\w-]+\/next\//,
   // Search pages (blocked by robots.txt)

--- a/scripts/update-sitemap-loc.js
+++ b/scripts/update-sitemap-loc.js
@@ -29,8 +29,10 @@ const sitemapXMLs = [
  *   pages, also blocked by robots.txt.
  */
 const excludePatterns = [
-  // Versioned docs: /docs/<project>/<version>/ where version is digits.digits
-  /\/docs\/[\w-]+\/\d+\.\d+\//,
+  // Versioned docs: /docs/<project>/<version>/ — only the unversioned (latest)
+  // path should be indexed. Matches 2-part (apisix 3.14), 3-part semver
+  // (ingress 2.0.0), and prefixed (docker apisix-2.10.0) version segments.
+  /\/docs\/[\w-]+\/(?:[\w-]+-)?\d+\.\d+(?:\.\d+)?\//,
   // Development "next" docs
   /\/docs\/[\w-]+\/next\//,
   // Search pages (blocked by robots.txt)


### PR DESCRIPTION
## Summary

Removes long-standing sitemap bloat from outdated sub-project documentation. The EN sitemap currently carries ~800 sub-project doc URLs — including ancient versions (ingress-controller `0.4.0`–`2.0.0`, docker `apisix-2.10.x`) and their thin `/tags/` pages — while the main APISIX docs are clean. Two root causes, plus a tag cleanup:

1. **`scripts/sync-docs.js`** built *every* release of each sub-project. apisix is curated via `config/apisix-versions.js`; the sub-projects weren't. This change keeps only the **newest** released version of each non-apisix sub-project (`SUBPROJECT_VERSIONS_TO_KEEP`, default `1`). Old tagged versions are no longer built, so they no longer exist on the site. Older versions remain available in each project's source repo (git tags).
2. **`scripts/update-sitemap-loc.js`** — the version-exclusion regex only matched 2-part versions (`/docs/apisix/3.14/`). It missed 3-part semver (`/docs/ingress-controller/2.0.0/`) and prefixed versions (`/docs/docker/apisix-2.10.0/`) — exactly why sub-project versioned docs leaked into the sitemap. Broadened to cover all three forms, and also excludes doc `/tags/` aggregation pages (mirroring the existing `/blog/tags/` rule).

**Net effect:** every versioned doc URL (`/docs/<project>/<version>/`) and doc tag page is dropped from the sitemap; the unversioned `/docs/<project>/` paths remain indexed (the same shape the main apisix docs already have). An independent review verified the broadened regex against the live production sitemap: **761 URLs excluded, zero false-positives** on current content.

> Mechanism note: the unversioned `/docs/<project>/` path serves each instance's *default* Docusaurus version. Maintainers familiar with the per-project version config should confirm that is the intended "latest" to index (no per-project `lastVersion` is set).

## ⚠️ Behavior change — needs maintainer sign-off

- This **removes previously-published sub-project doc versions from the site** (those versioned URLs will **404** after deploy). The repo has **no redirect mechanism** (`@docusaurus/plugin-client-redirects` is not installed), so ~760 old URLs hard-404 rather than 301. For thin/outdated duplicate docs this is usually net-positive for SEO, but please confirm you accept the 404s (or want redirects added for a few high-traffic ones).
- `SUBPROJECT_VERSIONS_TO_KEEP` can be raised to keep a wider window — the sitemap regex now handles >1 correctly.
- Edge note: `docker` docs contain three release series (`apisix-*`, `apisix-dashboard-*`, `dashboard-*`) in one instance; with keep=1 the single globally-highest-coerced version is retained. Harmless for indexing (the indexed landing is the unversioned path), but worth awareness.

## Test plan

- [ ] CI build passes (`yarn build`), including the 7-repo doc sync.
- [ ] After build, each sub-project has a single versioned tree + `next`; `/docs/ingress-controller/`, `/docs/docker/`, etc. still serve their unversioned docs.
- [ ] `website` / `doc` / `blog` `sitemap.xml` no longer contains `/docs/<project>/<old-version>/` or `/docs/<project>/tags/` URLs (the "Filtered out N URLs" log should rise).
- [ ] Spot-check: `/docs/ingress-controller/2.0.0/...` and `/docs/docker/apisix-2.10.0/...` are absent from the sitemap.

## Verification done

The version slice (`slice(-1)` on the ascending semver sort) and both regexes were validated locally against real URL shapes (2-part, 3-part, docker-prefixed, and tag pages → excluded; latest/unversioned and normal doc paths → kept), and an independent review confirmed apisix is unaffected (it's set separately from the curated list). Full doc-sync + build verification is delegated to CI (it clones the sub-project repos, which can't be exercised locally).
