### PR TITLE
fix(website): auto-recover the 404 page from stale builds after redeploy

### DIFF
--- a/blog/src/theme/NotFound/index.tsx
+++ b/blog/src/theme/NotFound/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import type { FC } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { translate } from '@docusaurus/Translate';
@@ -8,57 +8,89 @@ import Link from '@docusaurus/Link';
 import style from './styles.module.scss';
 import Fitty from './Fitty';
 
-const NotFound: FC = () => (
-  <Layout
-    title={translate({
-      id: 'theme.NotFound.title',
-      message: 'Page Not Found',
-    })}
-  >
-    <Head>
-      <meta name="robots" content="noindex,follow" />
-    </Head>
-    <main className={style.container}>
-      <section>
-        <Fitty tagName="h1" contentEditable>404</Fitty>
-        <Fitty tagName="h2">
-          Page Not Found
-        </Fitty>
-      </section>
-      <p>
-        We could not find what you were looking for.
-      </p>
-      <p>
-        If you think this link should not be broken, please
-        {' '}
-        <Link href="https://github.com/apache/apisix-website/issues/new/choose" target="_blank" rel="noreferrer">submit an Issue</Link>
-        .
-      </p>
-      <p>
-        You can also open the
-        {' '}
-        <Link to="/">home page</Link>
-        ,
-        {' '}
-        <Link to="/docs/">documentation</Link>
-        ,
-        {' '}
-        <Link to="/blog/">blog</Link>
-        , or
-        {' '}
-        <a
-          role="button"
-          href="#"
-          onClick={() => {
-            window?.history.back();
-          }}
-        >
-          return to the source page
-        </a>
-        .
-      </p>
-    </main>
-  </Layout>
-);
+const NotFound: FC = () => {
+  useEffect(() => {
+    // The site is rebuilt and republished frequently, and each build replaces the
+    // previous one's content-hashed chunks. A page still open from an older build
+    // can client-navigate to a route that is missing from its stale route manifest
+    // and land here, even though the server serves that page fine. Recover with a
+    // single hard reload so the current build is fetched.
+    //
+    // Only do this when the 404 surfaced during a client-side navigation, not on
+    // the document the server returned directly — that is a genuine 404 and is
+    // left untouched. A per-path guard reloads at most once as a safety backstop.
+    try {
+      if (typeof window === 'undefined' || !window.performance) {
+        return;
+      }
+      const [nav] = window.performance.getEntriesByType('navigation');
+      const { pathname } = window.location;
+      if (!nav || new URL(nav.name).pathname === pathname) {
+        return;
+      }
+      const guardKey = `apisix-404-reload:${pathname}`;
+      if (window.sessionStorage.getItem(guardKey)) {
+        return;
+      }
+      window.sessionStorage.setItem(guardKey, '1');
+      window.location.reload();
+    } catch {
+      // performance / sessionStorage / URL unavailable — leave the 404 as-is.
+    }
+  }, []);
+
+  return (
+    <Layout
+      title={translate({
+        id: 'theme.NotFound.title',
+        message: 'Page Not Found',
+      })}
+    >
+      <Head>
+        <meta name="robots" content="noindex,follow" />
+      </Head>
+      <main className={style.container}>
+        <section>
+          <Fitty tagName="h1" contentEditable>404</Fitty>
+          <Fitty tagName="h2">
+            Page Not Found
+          </Fitty>
+        </section>
+        <p>
+          We could not find what you were looking for.
+        </p>
+        <p>
+          If you think this link should not be broken, please
+          {' '}
+          <Link href="https://github.com/apache/apisix-website/issues/new/choose" target="_blank" rel="noreferrer">submit an Issue</Link>
+          .
+        </p>
+        <p>
+          You can also open the
+          {' '}
+          <Link to="/">home page</Link>
+          ,
+          {' '}
+          <Link to="/docs/">documentation</Link>
+          ,
+          {' '}
+          <Link to="/blog/">blog</Link>
+          , or
+          {' '}
+          <a
+            role="button"
+            href="#"
+            onClick={() => {
+              window?.history.back();
+            }}
+          >
+            return to the source page
+          </a>
+          .
+        </p>
+      </main>
+    </Layout>
+  );
+};
 
 export default NotFound;

--- a/doc/src/theme/NotFound/index.tsx
+++ b/doc/src/theme/NotFound/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import type { FC } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { translate } from '@docusaurus/Translate';
@@ -8,57 +8,89 @@ import Link from '@docusaurus/Link';
 import style from './styles.module.scss';
 import Fitty from './Fitty';
 
-const NotFound: FC = () => (
-  <Layout
-    title={translate({
-      id: 'theme.NotFound.title',
-      message: 'Page Not Found',
-    })}
-  >
-    <Head>
-      <meta name="robots" content="noindex,follow" />
-    </Head>
-    <main className={style.container}>
-      <section>
-        <Fitty tagName="h1" contentEditable>404</Fitty>
-        <Fitty tagName="h2">
-          Page Not Found
-        </Fitty>
-      </section>
-      <p>
-        We could not find what you were looking for.
-      </p>
-      <p>
-        If you think this link should not be broken, please
-        {' '}
-        <Link href="https://github.com/apache/apisix-website/issues/new/choose" target="_blank" rel="noreferrer">submit an Issue</Link>
-        .
-      </p>
-      <p>
-        You can also open the
-        {' '}
-        <Link to="/">home page</Link>
-        ,
-        {' '}
-        <Link to="/docs/">documentation</Link>
-        ,
-        {' '}
-        <Link to="/blog/">blog</Link>
-        , or
-        {' '}
-        <a
-          role="button"
-          href="#"
-          onClick={() => {
-            window?.history.back();
-          }}
-        >
-          return to the source page
-        </a>
-        .
-      </p>
-    </main>
-  </Layout>
-);
+const NotFound: FC = () => {
+  useEffect(() => {
+    // The site is rebuilt and republished frequently, and each build replaces the
+    // previous one's content-hashed chunks. A page still open from an older build
+    // can client-navigate to a route that is missing from its stale route manifest
+    // and land here, even though the server serves that page fine. Recover with a
+    // single hard reload so the current build is fetched.
+    //
+    // Only do this when the 404 surfaced during a client-side navigation, not on
+    // the document the server returned directly — that is a genuine 404 and is
+    // left untouched. A per-path guard reloads at most once as a safety backstop.
+    try {
+      if (typeof window === 'undefined' || !window.performance) {
+        return;
+      }
+      const [nav] = window.performance.getEntriesByType('navigation');
+      const { pathname } = window.location;
+      if (!nav || new URL(nav.name).pathname === pathname) {
+        return;
+      }
+      const guardKey = `apisix-404-reload:${pathname}`;
+      if (window.sessionStorage.getItem(guardKey)) {
+        return;
+      }
+      window.sessionStorage.setItem(guardKey, '1');
+      window.location.reload();
+    } catch {
+      // performance / sessionStorage / URL unavailable — leave the 404 as-is.
+    }
+  }, []);
+
+  return (
+    <Layout
+      title={translate({
+        id: 'theme.NotFound.title',
+        message: 'Page Not Found',
+      })}
+    >
+      <Head>
+        <meta name="robots" content="noindex,follow" />
+      </Head>
+      <main className={style.container}>
+        <section>
+          <Fitty tagName="h1" contentEditable>404</Fitty>
+          <Fitty tagName="h2">
+            Page Not Found
+          </Fitty>
+        </section>
+        <p>
+          We could not find what you were looking for.
+        </p>
+        <p>
+          If you think this link should not be broken, please
+          {' '}
+          <Link href="https://github.com/apache/apisix-website/issues/new/choose" target="_blank" rel="noreferrer">submit an Issue</Link>
+          .
+        </p>
+        <p>
+          You can also open the
+          {' '}
+          <Link to="/">home page</Link>
+          ,
+          {' '}
+          <Link to="/docs/">documentation</Link>
+          ,
+          {' '}
+          <Link to="/blog/">blog</Link>
+          , or
+          {' '}
+          <a
+            role="button"
+            href="#"
+            onClick={() => {
+              window?.history.back();
+            }}
+          >
+            return to the source page
+          </a>
+          .
+        </p>
+      </main>
+    </Layout>
+  );
+};
 
 export default NotFound;

--- a/website/src/theme/NotFound/index.tsx
+++ b/website/src/theme/NotFound/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import type { FC } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { translate } from '@docusaurus/Translate';
@@ -8,57 +8,89 @@ import Link from '@docusaurus/Link';
 import style from './styles.module.scss';
 import Fitty from './Fitty';
 
-const NotFound: FC = () => (
-  <Layout
-    title={translate({
-      id: 'theme.NotFound.title',
-      message: 'Page Not Found',
-    })}
-  >
-    <Head>
-      <meta name="robots" content="noindex,follow" />
-    </Head>
-    <main className={style.container}>
-      <section>
-        <Fitty tagName="h1" contentEditable>404</Fitty>
-        <Fitty tagName="h2">
-          Page Not Found
-        </Fitty>
-      </section>
-      <p>
-        We could not find what you were looking for.
-      </p>
-      <p>
-        If you think this link should not be broken, please
-        {' '}
-        <Link href="https://github.com/apache/apisix-website/issues/new/choose" target="_blank" rel="noreferrer">submit an Issue</Link>
-        .
-      </p>
-      <p>
-        You can also open the
-        {' '}
-        <Link to="/">home page</Link>
-        ,
-        {' '}
-        <Link to="/docs/">documentation</Link>
-        ,
-        {' '}
-        <Link to="/blog/">blog</Link>
-        , or
-        {' '}
-        <a
-          role="button"
-          href="#"
-          onClick={() => {
-            window?.history.back();
-          }}
-        >
-          return to the source page
-        </a>
-        .
-      </p>
-    </main>
-  </Layout>
-);
+const NotFound: FC = () => {
+  useEffect(() => {
+    // The site is rebuilt and republished frequently, and each build replaces the
+    // previous one's content-hashed chunks. A page still open from an older build
+    // can client-navigate to a route that is missing from its stale route manifest
+    // and land here, even though the server serves that page fine. Recover with a
+    // single hard reload so the current build is fetched.
+    //
+    // Only do this when the 404 surfaced during a client-side navigation, not on
+    // the document the server returned directly — that is a genuine 404 and is
+    // left untouched. A per-path guard reloads at most once as a safety backstop.
+    try {
+      if (typeof window === 'undefined' || !window.performance) {
+        return;
+      }
+      const [nav] = window.performance.getEntriesByType('navigation');
+      const { pathname } = window.location;
+      if (!nav || new URL(nav.name).pathname === pathname) {
+        return;
+      }
+      const guardKey = `apisix-404-reload:${pathname}`;
+      if (window.sessionStorage.getItem(guardKey)) {
+        return;
+      }
+      window.sessionStorage.setItem(guardKey, '1');
+      window.location.reload();
+    } catch {
+      // performance / sessionStorage / URL unavailable — leave the 404 as-is.
+    }
+  }, []);
+
+  return (
+    <Layout
+      title={translate({
+        id: 'theme.NotFound.title',
+        message: 'Page Not Found',
+      })}
+    >
+      <Head>
+        <meta name="robots" content="noindex,follow" />
+      </Head>
+      <main className={style.container}>
+        <section>
+          <Fitty tagName="h1" contentEditable>404</Fitty>
+          <Fitty tagName="h2">
+            Page Not Found
+          </Fitty>
+        </section>
+        <p>
+          We could not find what you were looking for.
+        </p>
+        <p>
+          If you think this link should not be broken, please
+          {' '}
+          <Link href="https://github.com/apache/apisix-website/issues/new/choose" target="_blank" rel="noreferrer">submit an Issue</Link>
+          .
+        </p>
+        <p>
+          You can also open the
+          {' '}
+          <Link to="/">home page</Link>
+          ,
+          {' '}
+          <Link to="/docs/">documentation</Link>
+          ,
+          {' '}
+          <Link to="/blog/">blog</Link>
+          , or
+          {' '}
+          <a
+            role="button"
+            href="#"
+            onClick={() => {
+              window?.history.back();
+            }}
+          >
+            return to the source page
+          </a>
+          .
+        </p>
+      </main>
+    </Layout>
+  );
+};
 
 export default NotFound;


### PR DESCRIPTION
## What

When a stale build serves the **404 page** for a URL that actually exists, recover automatically with a single guarded hard reload. Implemented in the existing custom `theme/NotFound` component, which is already swizzled in all three Docusaurus instances (`website`, `doc`, `blog`).

## Why — the "first visit 404, works after refresh" bug

Users report that pages (e.g. `/docs/apisix/plugins/ai-proxy/`, `/blog/tags/case-studies/`) render a 404 when navigated to **from another page**, but load fine after a refresh. The server always returns `200` for a hard load — so this is not a missing page.

Root cause is a **stale client route manifest after a redeploy**:

- The site rebuilds and republishes frequently — **every push to `master` plus a daily 05:00 UTC cron** (`.github/workflows/deploy.yml`), which also re-pulls upstream docs, so content (and content-hashed chunk filenames) changes.
- Each build emits a new `main.<hash>.js` carrying that build's route list, and publish replaces the previous build wholesale (`actions-gh-pages` orphan force-push to `asf-site`).
- A browser still showing a page from an older build holds that build's route manifest. Client-side navigation to a route that only exists in a **newer** build finds no match in the stale manifest, so React Router renders the catch-all `@theme/NotFound`. A hard reload re-fetches the page against the live build, whose manifest includes the route, so it works.

Evidence: three different `main.<hash>.js` bundles were observed served concurrently across pages of the live site, confirming multiple builds coexisting behind the CDN. HTML is cached `max-age=3600` while hashed assets are `max-age=864000`. The ASF publish pipeline exposes no per-project cache-purge/TTL control (`.asf.yaml` `publish:` has no such option), so the skew cannot be closed from the deploy side by this project alone — an in-repo recovery is the part we control.

## How

In `src/theme/NotFound/index.tsx` (all three instances), on mount:

- Read `performance.getEntriesByType('navigation')[0].name` — the path the **document** was loaded with.
- If it differs from the current path, this 404 surfaced during a **client-side navigation** (the stale-manifest case) → `window.location.reload()` once, fetching the current build.
- If it matches the current path, the server returned this page directly → a **genuine 404**, left untouched (no wasted reload on real broken links).
- A per-path `sessionStorage` guard (`apisix-404-reload:<path>`) reloads at most once as a backstop. The detection is inherently loop-proof: after a reload the document loads at the current path, so the load-path now equals the current path and no further reload fires.
- SSR-safe: all access is inside `useEffect` behind `typeof window` checks and a `try/catch`.

### Why not a `window` `error`/`unhandledrejection` listener?

An earlier revision of this PR tried that. It does **not** work in this Docusaurus version (`2.0.0-beta.6`): a failed route-chunk preload is swallowed internally (`PendingNavigation` does `.catch((e) => console.warn(e))`, and `react-loadable` catches in `_loadModule`), so the error never reaches `window`. And the user-visible symptom here is the **404 page** (a route-manifest miss), not a chunk-load error — so `theme/NotFound` is the correct seam.

## Test plan

- [x] ESLint (airbnb + `react-hooks`) clean on all three files — only the offline `import/no-unresolved` for `react` (missing `node_modules` in the check env) remains; no rules-of-hooks, formatting, or `no-empty` issues.
- [x] `@typescript-eslint` parses the TS/JSX without syntax errors.
- [x] Logic review: genuine direct-load 404 → load-path == current → no reload; client-nav stale 404 → load-path != current → one reload → server serves current build; loop-proof by construction.
- [ ] CI production build of all three instances.

> Note: the real failure (a route present only in a newer build) cannot be reproduced on a local dev server, which always serves the current build. Verification here is limited to lint/parse and logic review.

## Notes

This is an in-repo mitigation fully under the project's control. The root-cause fix — purge the CDN on deploy / shorten HTML TTL, or retain previous builds' assets — lives in the ASF publish/Fastly layer and would benefit all ASF Docusaurus sites; it can be pursued separately with ASF Infra.
