### PR TITLE
blog: manage Apache APISIX with AI coding agents (en + zh)

### DIFF
--- a/blog/en/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
+++ b/blog/en/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
@@ -16,21 +16,17 @@ description: A walkthrough of managing Apache APISIX from your AI coding agent u
 tags: [Ecosystem]
 ---
 
-Configuring an API gateway usually means remembering things: the exact Admin API path, the shape of a plugin's schema, which fields a route needs. For Apache APISIX, that knowledge is well-documented — but you still have to hold it in your head or keep a browser tab open while you work.
-
-AI coding agents change the ergonomics. What if, instead of looking up the `limit-count` schema, you could just say: *"Add key-auth to my `/orders` route and rate-limit it to 100 requests per minute"* — and your agent produced the correct configuration and applied it?
-
-That is exactly what **Agent Skills** for APISIX enable.
+Want to manage Apache APISIX using natural language? Open-source Agent Skills let AI coding agents understand your intent, generate gateway configuration, and apply it to a live gateway.
 
 <!--truncate-->
 
 ## What are Agent Skills?
 
-An Agent Skill is a plain Markdown file — `SKILL.md` — with a bit of YAML frontmatter and a body of task-specific instructions. It teaches an AI coding agent how to accomplish one focused job: configure a specific plugin, run a specific operational recipe, or reason about a specific role.
+An Agent Skill is a plain Markdown file, `SKILL.md`, with a bit of YAML frontmatter and a body of task-specific instructions. It teaches an AI coding agent how to accomplish one focused job: configure a specific plugin, run a specific operational recipe, or reason about a specific role.
 
-The format is deliberately simple and portable. Any agent that understands the Agent Skills convention can load them — including Claude Code, Cursor, GitHub Copilot, Windsurf, and OpenCode. There is no runtime, no plugin API, no lock-in: the skill is just knowledge the agent reads on demand.
+The format is deliberately simple and portable. Any agent that understands the Agent Skills convention can load them, including Claude Code, Cursor, GitHub Copilot, Windsurf, and OpenCode. There is no runtime, no plugin API, and no lock-in: the skill is simply knowledge the agent reads on demand.
 
-For Apache APISIX, these skills are published in the open-source [api7/a6](https://github.com/api7/a6) repository. `a6` is an open-source, Apache-2.0 licensed command-line tool that wraps the APISIX Admin API; it is not part of an official Apache Software Foundation release. The skills teach an agent how to drive `a6` to configure a live gateway. Agents can already call the APISIX Admin API directly — `a6` and these skills simply make that ergonomic, and they are one approach among several.
+For Apache APISIX, these skills are published in the open-source [api7/a6](https://github.com/api7/a6) repository. `a6` is an open-source, Apache-2.0 licensed command-line tool that wraps the APISIX Admin API; it is not part of an official Apache Software Foundation release. The skills teach an agent how to drive `a6` to configure a live gateway. Agents can already call the APISIX Admin API directly; `a6` and these skills simply make that ergonomic, and they are one approach among several.
 
 ## Describe the outcome, not the commands
 
@@ -53,20 +49,22 @@ plugins:
     rejected_code: 429
 ```
 
+The example assumes that the `orders` route and `orders-upstream` already exist. Before applying any generated change to a live gateway, inspect the diff or generated configuration and confirm that it targets the intended route and upstream.
+
 ```bash
 a6 route update orders -f route.yaml
 ```
 
-You reviewed a diff and confirmed an outcome; you did not look up a single schema field.
+In a real workflow, you review the proposed change and confirm the outcome before applying it; you do not need to look up every schema field yourself.
 
 ## What's covered
 
-The skill set spans the full surface of day-to-day APISIX work, organized into four kinds:
+The skill set covers common day-to-day APISIX work, organized into four kinds:
 
-- **Plugins** — one skill per plugin, from `key-auth`, `jwt-auth`, and `limit-count` to `ai-proxy`, `prometheus`, and `zipkin`. Each covers configuration, examples, and common patterns.
-- **Recipes** — multi-step operational tasks like canary releases, blue-green deployments, circuit breaking, health checks, and mTLS.
-- **Personas** — role-oriented guidance for API developers and platform operators, with decision frameworks for choosing routes vs. services and which skills to load for a task.
-- **Core** — shared conventions for working with the `a6` CLI.
+- **Plugins** - one skill per plugin, from `key-auth`, `jwt-auth`, and `limit-count` to `ai-proxy`, `prometheus`, and `zipkin`. Each covers configuration, examples, and common patterns.
+- **Recipes** - multi-step operational tasks like canary releases, blue-green deployments, circuit breaking, health checks, and mTLS.
+- **Personas** - role-oriented guidance for API developers and platform operators, with decision frameworks for choosing routes versus services and which skills to load for a task.
+- **Core** - shared conventions for working with the `a6` CLI.
 
 ## Try it
 
@@ -80,9 +78,9 @@ cp -r a6/skills/* ~/.claude/skills/
 
 Then describe what you want your gateway to do, in plain language.
 
-You can browse the full, searchable catalog — every plugin, recipe, and persona skill, with the commands each one runs — on the [AI Agent Skills page](https://docs.api7.ai/apisix/ai-agent-skills). The skills are Apache-2.0 licensed and openly developed in the [api7/a6](https://github.com/api7/a6) repository, where contributions are welcome.
+You can browse the full, searchable catalog, every plugin, recipe, and persona skill, with the commands each one runs, on the [AI Agent Skills page](https://docs.api7.ai/apisix/ai-agent-skills). The skills are Apache-2.0 licensed and openly developed in the [api7/a6](https://github.com/api7/a6) repository, where contributions are welcome.
 
-AI agents are becoming a primary interface for infrastructure. Teaching them to speak APISIX fluently — in the open, with plain Markdown anyone can read and improve — is a natural next step for the project's ecosystem.
+AI agents are becoming a primary interface for infrastructure. Teaching them to speak APISIX fluently, in the open, with plain Markdown anyone can read and improve, is a natural next step for the project's ecosystem.
 
 ## Further reading
 

--- a/blog/en/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
+++ b/blog/en/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
@@ -1,0 +1,90 @@
+---
+title: "Manage Apache APISIX with AI Coding Agents"
+authors:
+  - name: "Ming Wen"
+    title: "Author"
+    url: "https://github.com/moonming"
+    image_url: "https://github.com/moonming.png"
+keywords:
+  - Apache APISIX
+  - API Gateway
+  - AI Agent
+  - Agent Skills
+  - Claude Code
+  - AI Gateway
+description: A walkthrough of managing Apache APISIX from your AI coding agent using open-source Agent Skills — describe the outcome you want, and the agent runs the real gateway commands.
+tags: [Ecosystem]
+---
+
+Configuring an API gateway usually means remembering things: the exact Admin API path, the shape of a plugin's schema, which fields a route needs. For Apache APISIX, that knowledge is well-documented — but you still have to hold it in your head or keep a browser tab open while you work.
+
+AI coding agents change the ergonomics. What if, instead of looking up the `limit-count` schema, you could just say: *"Add key-auth to my `/orders` route and rate-limit it to 100 requests per minute"* — and your agent produced the correct configuration and applied it?
+
+That is exactly what **Agent Skills** for APISIX enable.
+
+<!--truncate-->
+
+## What are Agent Skills?
+
+An Agent Skill is a plain Markdown file — `SKILL.md` — with a bit of YAML frontmatter and a body of task-specific instructions. It teaches an AI coding agent how to accomplish one focused job: configure a specific plugin, run a specific operational recipe, or reason about a specific role.
+
+The format is deliberately simple and portable. Any agent that understands the Agent Skills convention can load them — including Claude Code, Cursor, GitHub Copilot, Windsurf, and OpenCode. There is no runtime, no plugin API, no lock-in: the skill is just knowledge the agent reads on demand.
+
+For Apache APISIX, these skills are published in the open-source [api7/a6](https://github.com/api7/a6) repository. `a6` is an open-source, Apache-2.0 licensed command-line tool that wraps the APISIX Admin API; it is not part of an official Apache Software Foundation release. The skills teach an agent how to drive `a6` to configure a live gateway. Agents can already call the APISIX Admin API directly — `a6` and these skills simply make that ergonomic, and they are one approach among several.
+
+## Describe the outcome, not the commands
+
+Here is the loop in practice. You tell your agent what you want:
+
+> *"Add key-auth to my `/orders` route and rate-limit it to 100 rpm."*
+
+The agent recognizes the intent, loads the `a6-plugin-key-auth` and `a6-plugin-limit-count` skills, generates the route configuration, and applies it with the file-based `a6` command:
+
+```yaml
+# route.yaml
+uri: /orders
+upstream_id: orders-upstream
+plugins:
+  key-auth: {}
+  limit-count:
+    count: 100
+    time_window: 60
+    key: remote_addr
+    rejected_code: 429
+```
+
+```bash
+a6 route update orders -f route.yaml
+```
+
+You reviewed a diff and confirmed an outcome; you did not look up a single schema field.
+
+## What's covered
+
+The skill set spans the full surface of day-to-day APISIX work, organized into four kinds:
+
+- **Plugins** — one skill per plugin, from `key-auth`, `jwt-auth`, and `limit-count` to `ai-proxy`, `prometheus`, and `zipkin`. Each covers configuration, examples, and common patterns.
+- **Recipes** — multi-step operational tasks like canary releases, blue-green deployments, circuit breaking, health checks, and mTLS.
+- **Personas** — role-oriented guidance for API developers and platform operators, with decision frameworks for choosing routes vs. services and which skills to load for a task.
+- **Core** — shared conventions for working with the `a6` CLI.
+
+## Try it
+
+Skills are just files. Clone the repository and drop them into your agent's skills directory:
+
+```bash
+git clone https://github.com/api7/a6.git
+mkdir -p ~/.claude/skills
+cp -r a6/skills/* ~/.claude/skills/
+```
+
+Then describe what you want your gateway to do, in plain language.
+
+You can browse the full, searchable catalog — every plugin, recipe, and persona skill, with the commands each one runs — on the [AI Agent Skills page](https://docs.api7.ai/apisix/ai-agent-skills). The skills are Apache-2.0 licensed and openly developed in the [api7/a6](https://github.com/api7/a6) repository, where contributions are welcome.
+
+AI agents are becoming a primary interface for infrastructure. Teaching them to speak APISIX fluently — in the open, with plain Markdown anyone can read and improve — is a natural next step for the project's ecosystem.
+
+## Further reading
+
+- [Apache APISIX AI Gateway](https://apisix.apache.org/ai-gateway/) — LLM proxying, load balancing, token-based rate limiting, and MCP support
+- [AI Agent Skills for Apache APISIX](https://docs.api7.ai/apisix/ai-agent-skills) — the full, searchable skills catalog

--- a/blog/zh/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
+++ b/blog/zh/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
@@ -16,29 +16,25 @@ description: 通过开源的 Agent Skills，从你的 AI 编码 Agent 管理 Apa
 tags: [Ecosystem]
 ---
 
-配置 API 网关通常意味着要记住很多东西：Admin API 的确切路径、某个插件的 schema 结构、一条路由需要哪些字段。对 Apache APISIX 来说，这些知识都有完善的文档——但你仍然得把它记在脑子里，或者一边干活一边开着浏览器查。
-
-AI 编码 Agent 改变了这种体验。如果你不用去查 `limit-count` 的 schema，而是直接说一句：*“给我的 `/orders` 路由加上 key-auth，并限流到每分钟 100 次请求”*——然后你的 Agent 就生成正确的配置并应用上去，会怎么样？
-
-这正是 APISIX 的 **Agent Skills** 所要实现的。
+想用自然语言管理 Apache APISIX？开源 Agent Skills 让 AI 编码 Agent 理解你的意图，生成并执行真实的网关配置。
 
 <!--truncate-->
 
 ## 什么是 Agent Skills？
 
-一个 Agent Skill 就是一个纯 Markdown 文件——`SKILL.md`——带一小段 YAML frontmatter，以及一段针对具体任务的说明正文。它教会 AI 编码 Agent 完成一件聚焦的事：配置某个特定插件、执行某个特定的运维流程，或围绕某个特定角色进行决策。
+一个 Agent Skill，本质上就是一个纯 Markdown 文件：`SKILL.md`。文件开头是一小段 YAML frontmatter，后面则是针对具体任务的说明。它可以教会 AI 编码智能体完成一件明确的事情，比如配置某个插件、执行某项运维流程，或者从特定角色的角度做出决策。
 
-这个格式刻意保持简单和可移植。任何理解 Agent Skills 约定的 Agent 都能加载它们——包括 Claude Code、Cursor、GitHub Copilot、Windsurf 和 OpenCode。没有运行时、没有插件 API、没有锁定：skill 只是 Agent 按需读取的知识。
+这种格式刻意保持简单，也方便迁移。任何理解 Agent Skills 约定的 Agent 都能加载它们，包括 Claude Code、Cursor、GitHub Copilot、Windsurf 和 OpenCode。它不需要运行时，也没有插件 API 或锁定，skill 只是 Agent 按需读取的知识。
 
-针对 Apache APISIX，这些 skills 发布在开源的 [api7/a6](https://github.com/api7/a6) 仓库中。`a6` 是一个开源的、Apache-2.0 许可的命令行工具，它封装了 APISIX 的 Admin API；它不是 Apache 软件基金会官方发行版的一部分。这些 skills 教会 Agent 如何驱动 `a6` 来配置一个运行中的网关。Agent 本就可以直接调用 APISIX 的 Admin API——`a6` 和这些 skills 只是让这件事更顺手，它是众多可行方式中的一种。
+针对 Apache APISIX 的这些 skills，已经发布在开源的 [api7/a6](https://github.com/api7/a6) 仓库中。`a6` 是一个开源、采用 Apache-2.0 许可的命令行工具，用于封装 APISIX Admin API；它不是 Apache 软件基金会官方发行版的一部分。这些 skills 会告诉智能体如何使用 `a6` 配置正在运行的网关。当然，智能体也可以直接调用 APISIX 的 Admin API。`a6` 加上这些 skills，只是让这条路径更顺手，也是众多可行方案中的一种。
 
-## 描述结果，而不是命令
+## 描述结果，而不是记住命令
 
-来看实际的循环。你告诉 Agent 你想要什么：
+我们来看一个具体例子。你只需要告诉智能体想要的结果：
 
 > *“给 `/orders` 路由加上 key-auth，并限流到每分钟 100 次。”*
 
-Agent 识别出意图，加载 `a6-plugin-key-auth` 和 `a6-plugin-limit-count` 两个 skill，生成路由配置，并用基于文件的 `a6` 命令应用它：
+智能体识别出你的意图，加载 `a6-plugin-key-auth` 和 `a6-plugin-limit-count` 两个 skill，生成路由配置，再通过基于文件的 `a6` 命令将配置应用到网关：
 
 ```yaml
 # route.yaml
@@ -53,24 +49,26 @@ plugins:
     rejected_code: 429
 ```
 
+这个示例假设 `orders` 路由和 `orders-upstream` 已经存在。在把任何由智能体生成的变更应用到运行中的网关之前，请先检查 diff（变更对比）或生成的配置，确认它确实指向预期的路由和上游。
+
 ```bash
 a6 route update orders -f route.yaml
 ```
 
-你审查了一份 diff、确认了一个结果；而你没有去查任何一个 schema 字段。
+在真实工作流中，正确的顺序仍然是先审查变更、确认结果，再执行应用。区别在于，你不再需要手动查阅每一个 schema 字段。
 
 ## 覆盖了哪些内容
 
-这套 skill 覆盖了日常 APISIX 工作的完整面，分为四类：
+这套 skills 覆盖了 APISIX 中许多常见的日常工作，主要分为四类：
 
-- **Plugins（插件）**——每个插件一个 skill，从 `key-auth`、`jwt-auth`、`limit-count` 到 `ai-proxy`、`prometheus`、`zipkin`。每个都涵盖配置、示例和常见模式。
-- **Recipes（方案）**——多步运维任务，如金丝雀发布、蓝绿部署、熔断、健康检查和 mTLS。
-- **Personas（角色）**——面向 API 开发者和平台运维的角色化指引，包含选择路由还是服务、以及针对某个任务加载哪些 skill 的决策框架。
-- **Core（核心）**——使用 `a6` CLI 的共享约定。
+- **Plugins（插件）**——每个插件对应一个 skill，涵盖 `key-auth`、`jwt-auth`、`limit-count`、`ai-proxy`、`prometheus`、`zipkin` 等。每个 skill 都包含配置方式、示例和常见用法。
+- **Recipes（方案）**——面向多步骤运维任务，例如金丝雀发布、蓝绿部署、熔断、健康检查和 mTLS。
+- **Personas（角色）**——面向 API 开发者和平台运维人员的使用指引，包括如何选择路由或服务，以及针对具体任务应加载哪些 skill。
+- **Core（核心）**——使用 `a6` CLI 时需要遵循的通用约定。
 
 ## 试试看
 
-Skills 就是文件。克隆仓库，把它们放进你 Agent 的 skills 目录即可：
+Skills 就是文件。克隆仓库，再把它们放入智能体的 skills 目录即可：
 
 ```bash
 git clone https://github.com/api7/a6.git
@@ -78,13 +76,13 @@ mkdir -p ~/.claude/skills
 cp -r a6/skills/* ~/.claude/skills/
 ```
 
-然后用自然语言描述你希望网关做什么。
+完成安装后，你就可以用自然语言描述希望网关完成的工作。
 
-你可以在 [AI Agent Skills 页面](https://docs.api7.ai/apisix/ai-agent-skills) 浏览完整的、可搜索的目录——每一个插件、方案和角色 skill，以及它们各自运行的命令。这些 skills 采用 Apache-2.0 许可，在 [api7/a6](https://github.com/api7/a6) 仓库中开放开发，欢迎贡献。
+你可以在 [AI Agent Skills 页面](https://docs.api7.ai/apisix/ai-agent-skills) 浏览完整且可搜索的目录，查看每个插件、方案和角色 skill，以及它们对应的命令。这些 skills 采用 Apache-2.0 许可，在 [api7/a6](https://github.com/api7/a6) 仓库中开放开发，也欢迎社区贡献。
 
-AI Agent 正在成为基础设施的主要交互界面。用开放的方式——用任何人都能阅读和改进的纯 Markdown——教会它们流利地“说” APISIX，是这个项目生态自然的下一步。
+AI 智能体正在成为操作基础设施的一种重要交互界面。用开放的方式，通过任何人都能阅读、修改和改进的纯 Markdown，让智能体能够流利地“说” APISIX，正是这个项目生态自然延伸出的下一步。
 
 ## 延伸阅读
 
-- [Apache APISIX AI Gateway](https://apisix.apache.org/ai-gateway/)——LLM 代理、负载均衡、基于 token 的限流,以及 MCP 支持
+- [Apache APISIX AI Gateway](https://apisix.apache.org/ai-gateway/)——LLM 代理、负载均衡、基于 token 的限流，以及 MCP 支持
 - [Apache APISIX 的 AI Agent Skills](https://docs.api7.ai/apisix/ai-agent-skills)——完整的、可搜索的 skills 目录

--- a/blog/zh/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
+++ b/blog/zh/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md
@@ -1,0 +1,90 @@
+---
+title: "用 AI 编码 Agent 管理 Apache APISIX"
+authors:
+  - name: "Ming Wen"
+    title: "Author"
+    url: "https://github.com/moonming"
+    image_url: "https://github.com/moonming.png"
+keywords:
+  - Apache APISIX
+  - API Gateway
+  - AI Agent
+  - Agent Skills
+  - Claude Code
+  - AI Gateway
+description: 通过开源的 Agent Skills，从你的 AI 编码 Agent 管理 Apache APISIX——描述你想要的结果，Agent 就会执行真实的网关命令。
+tags: [Ecosystem]
+---
+
+配置 API 网关通常意味着要记住很多东西：Admin API 的确切路径、某个插件的 schema 结构、一条路由需要哪些字段。对 Apache APISIX 来说，这些知识都有完善的文档——但你仍然得把它记在脑子里，或者一边干活一边开着浏览器查。
+
+AI 编码 Agent 改变了这种体验。如果你不用去查 `limit-count` 的 schema，而是直接说一句：*“给我的 `/orders` 路由加上 key-auth，并限流到每分钟 100 次请求”*——然后你的 Agent 就生成正确的配置并应用上去，会怎么样？
+
+这正是 APISIX 的 **Agent Skills** 所要实现的。
+
+<!--truncate-->
+
+## 什么是 Agent Skills？
+
+一个 Agent Skill 就是一个纯 Markdown 文件——`SKILL.md`——带一小段 YAML frontmatter，以及一段针对具体任务的说明正文。它教会 AI 编码 Agent 完成一件聚焦的事：配置某个特定插件、执行某个特定的运维流程，或围绕某个特定角色进行决策。
+
+这个格式刻意保持简单和可移植。任何理解 Agent Skills 约定的 Agent 都能加载它们——包括 Claude Code、Cursor、GitHub Copilot、Windsurf 和 OpenCode。没有运行时、没有插件 API、没有锁定：skill 只是 Agent 按需读取的知识。
+
+针对 Apache APISIX，这些 skills 发布在开源的 [api7/a6](https://github.com/api7/a6) 仓库中。`a6` 是一个开源的、Apache-2.0 许可的命令行工具，它封装了 APISIX 的 Admin API；它不是 Apache 软件基金会官方发行版的一部分。这些 skills 教会 Agent 如何驱动 `a6` 来配置一个运行中的网关。Agent 本就可以直接调用 APISIX 的 Admin API——`a6` 和这些 skills 只是让这件事更顺手，它是众多可行方式中的一种。
+
+## 描述结果，而不是命令
+
+来看实际的循环。你告诉 Agent 你想要什么：
+
+> *“给 `/orders` 路由加上 key-auth，并限流到每分钟 100 次。”*
+
+Agent 识别出意图，加载 `a6-plugin-key-auth` 和 `a6-plugin-limit-count` 两个 skill，生成路由配置，并用基于文件的 `a6` 命令应用它：
+
+```yaml
+# route.yaml
+uri: /orders
+upstream_id: orders-upstream
+plugins:
+  key-auth: {}
+  limit-count:
+    count: 100
+    time_window: 60
+    key: remote_addr
+    rejected_code: 429
+```
+
+```bash
+a6 route update orders -f route.yaml
+```
+
+你审查了一份 diff、确认了一个结果；而你没有去查任何一个 schema 字段。
+
+## 覆盖了哪些内容
+
+这套 skill 覆盖了日常 APISIX 工作的完整面，分为四类：
+
+- **Plugins（插件）**——每个插件一个 skill，从 `key-auth`、`jwt-auth`、`limit-count` 到 `ai-proxy`、`prometheus`、`zipkin`。每个都涵盖配置、示例和常见模式。
+- **Recipes（方案）**——多步运维任务，如金丝雀发布、蓝绿部署、熔断、健康检查和 mTLS。
+- **Personas（角色）**——面向 API 开发者和平台运维的角色化指引，包含选择路由还是服务、以及针对某个任务加载哪些 skill 的决策框架。
+- **Core（核心）**——使用 `a6` CLI 的共享约定。
+
+## 试试看
+
+Skills 就是文件。克隆仓库，把它们放进你 Agent 的 skills 目录即可：
+
+```bash
+git clone https://github.com/api7/a6.git
+mkdir -p ~/.claude/skills
+cp -r a6/skills/* ~/.claude/skills/
+```
+
+然后用自然语言描述你希望网关做什么。
+
+你可以在 [AI Agent Skills 页面](https://docs.api7.ai/apisix/ai-agent-skills) 浏览完整的、可搜索的目录——每一个插件、方案和角色 skill，以及它们各自运行的命令。这些 skills 采用 Apache-2.0 许可，在 [api7/a6](https://github.com/api7/a6) 仓库中开放开发，欢迎贡献。
+
+AI Agent 正在成为基础设施的主要交互界面。用开放的方式——用任何人都能阅读和改进的纯 Markdown——教会它们流利地“说” APISIX，是这个项目生态自然的下一步。
+
+## 延伸阅读
+
+- [Apache APISIX AI Gateway](https://apisix.apache.org/ai-gateway/)——LLM 代理、负载均衡、基于 token 的限流,以及 MCP 支持
+- [Apache APISIX 的 AI Agent Skills](https://docs.api7.ai/apisix/ai-agent-skills)——完整的、可搜索的 skills 目录


### PR DESCRIPTION
## What

An educational blog post (English + Chinese) introducing **Agent Skills for Apache APISIX**: how to manage a live APISIX gateway from an AI coding agent (Claude Code, Cursor, Copilot, Windsurf, OpenCode) by describing an outcome in natural language.

- `blog/en/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md`
- `blog/zh/blog/2026/07/10/manage-apache-apisix-with-ai-agents.md`

