### PR TITLE
feat: give the Learning Center index its own meta description

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -103,6 +103,8 @@ module.exports = {
         blogSidebarCount: 'ALL',
         blogSidebarTitle: 'Learning Center',
         blogTitle: 'Learning Center',
+        blogDescription:
+          'Practical guides to API gateway concepts — authentication, rate limiting, security, observability — plus comparisons of Apache APISIX with Kong, Envoy, and NGINX.',
         showReadingTime: true,
       },
     ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -104,7 +104,7 @@ module.exports = {
         blogSidebarTitle: 'Learning Center',
         blogTitle: 'Learning Center',
         blogDescription:
-          'Practical guides to API gateway concepts — authentication, rate limiting, security, observability — plus comparisons of Apache APISIX with Kong, Envoy, and NGINX.',
+          'Practical guides to API gateway concepts — authentication, rate limiting, security, mutual TLS — plus comparisons of Apache APISIX with Kong, Envoy, and NGINX.',
         showReadingTime: true,
       },
     ],

--- a/website/src/theme/BlogListPage/index.tsx
+++ b/website/src/theme/BlogListPage/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import BlogListPage from '@theme-original/BlogListPage';
+import Head from '@docusaurus/Head';
+
+/**
+ * Wraps the default blog list page so the Learning Center index carries its
+ * own meta description. The description passed through Layout props is
+ * rendered inside LayoutHead, where the trailing themeConfig `metadatas`
+ * block deliberately overrides it with the site-wide default; a <Head>
+ * rendered here sits after LayoutHead in the tree, so react-helmet lets it
+ * win. Other blog instances (events, articles) are rendered untouched.
+ */
+
+type Props = React.ComponentProps<typeof BlogListPage> & {
+  metadata: { permalink: string; blogDescription: string };
+};
+
+const LEARNING_CENTER_PREFIX = '/learning-center';
+
+const BlogListPageWrapper: React.FC<Props> = (props) => {
+  const { metadata } = props;
+  const isLearningCenter = metadata.permalink.startsWith(LEARNING_CENTER_PREFIX);
+
+  return (
+    <>
+      <BlogListPage {...props} />
+      {isLearningCenter && metadata.blogDescription && (
+        <Head>
+          <meta name="description" content={metadata.blogDescription} />
+          <meta property="og:description" content={metadata.blogDescription} />
+        </Head>
+      )}
+    </>
+  );
+};
+
+export default BlogListPageWrapper;


### PR DESCRIPTION
## Problem

The Learning Center index has 23,450 impressions with only 0.33% CTR in GSC (last 28 days). One reason: it renders the site-wide default meta description (the generic APISIX tagline) instead of describing what the Learning Center actually offers.

Root cause: blog **list** pages pass `description` through Layout props, which `LayoutHead` renders early — and the trailing `themeConfig.metadatas` block deliberately overrides it (react-helmet last-wins). So setting `blogDescription` alone has no effect.

## Fix

- Add `blogDescription` to the `learning-center` blog instance.
- Add a `BlogListPage` wrapper (same `@theme-original` pattern as the existing `BlogPostPage` wrapper from #2058) that re-emits `description` / `og:description` at content level — after `LayoutHead` in the tree — where react-helmet lets it win.
- Scoped to `/learning-center/`: articles and events list pages are untouched.

## Verification (production build)

- `/learning-center/` now carries the new description, exactly one `meta name=description` + one `og:description`.
- Homepage, `/articles/`, and individual Learning Center articles keep their existing descriptions.