### PR TITLE
fix: repair dead-URL redirects and add 301s for removed doc versions

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -46,11 +46,11 @@ RedirectMatch 301 "^/zh/docs/apisix/getting-started/$" "/zh/docs/apisix/getting-
 RedirectMatch 301 "^/docs/apisix/3\.2/plugins/(.*)$" "https://apache-apisix.netlify.app/docs/apisix/3.2/plugins/$1"
 RedirectMatch 301 "^/zh/docs/apisix/3\.2/plugins/(.*)$" "https://apache-apisix.netlify.app/zh/docs/apisix/3.2/plugins/$1"
 
-Redirect 301 "/docs/apisix/install" "/docs/apisix/how-to-build/"
-Redirect 301 "/docs/apisix/architecture-design/plugin/" "/docs/apisix/architecture-design/plugin-config/"
-Redirect 301 "/docs/apisix/2.13/FAQ/plugins.md/" "/docs/apisix/2.13/architecture-design/plugin/"
+Redirect 301 "/docs/apisix/install" "/docs/apisix/building-apisix/"
+Redirect 301 "/docs/apisix/architecture-design/plugin/" "/docs/apisix/terminology/plugin-config/"
+Redirect 301 "/docs/apisix/2.13/FAQ/plugins.md/" "/docs/apisix/terminology/plugin-config/"
 Redirect 301 "/docs/ingress-controller/practices/proxy-the-httpbin-service-with-ingress" "/docs/ingress-controller/tutorials/proxy-the-httpbin-service-with-ingress/"
-Redirect 301 "/docs/apisix/admin-api/terminology/plugin-config.md/" "/docs/apisix/architecture-design/plugin-config/"
+Redirect 301 "/docs/apisix/admin-api/terminology/plugin-config.md/" "/docs/apisix/terminology/plugin-config/"
 Redirect 301 "/docs/general/community/" "/docs/general/join/"
 Redirect 301 "/docs/general/subscribe-guide/" "/docs/general/join/"
 
@@ -62,11 +62,11 @@ Redirect 301 "/blog/2021/08/25/Auth-with-Casbin-in-Apache-APISIX/" "/blog/2021/0
 Redirect 301 "/blog/2022/03/02/apisix-integration-graphql-plugin/" "/blog/2022/03/02/apisix-integration-graphql/"
 Redirect 301 "/blog/2022/09/21/apache-apisix-v3-preview" "/blog/2022/11/02/apache-apisix-v3-preview"
 
-Redirect 301 "/zh/docs/apisix/install" "/zh/docs/apisix/how-to-build/"
-Redirect 301 "/zh/docs/apisix/architecture-design/plugin/" "/zh/docs/apisix/architecture-design/plugin-config/"
-Redirect 301 "/zh/docs/apisix/2.13/FAQ/plugins.md/" "/zh/docs/apisix/2.13/architecture-design/plugin/"
+Redirect 301 "/zh/docs/apisix/install" "/zh/docs/apisix/building-apisix/"
+Redirect 301 "/zh/docs/apisix/architecture-design/plugin/" "/zh/docs/apisix/terminology/plugin-config/"
+Redirect 301 "/zh/docs/apisix/2.13/FAQ/plugins.md/" "/zh/docs/apisix/terminology/plugin-config/"
 Redirect 301 "/zh/docs/ingress-controller/practices/proxy-the-httpbin-service-with-ingress" "/zh/docs/ingress-controller/tutorials/proxy-the-httpbin-service-with-ingress/"
-Redirect 301 "/zh/docs/apisix/admin-api/terminology/plugin-config.md/" "/zh/docs/apisix/architecture-design/plugin-config/"
+Redirect 301 "/zh/docs/apisix/admin-api/terminology/plugin-config.md/" "/zh/docs/apisix/terminology/plugin-config/"
 Redirect 301 "/zh/docs/general/community/" "/zh/docs/general/join/"
 Redirect 301 "/zh/docs/general/subscribe-guide/" "/zh/docs/general/join/"
 
@@ -79,9 +79,9 @@ Redirect 301 "/zh/blog/2022/03/02/apisix-integration-graphql-plugin/" "/zh/blog/
 
 # Ingress-controller pages from the pre-2.0 IA. These used to redirect to
 # 1.8.0, but only the newest release is built now, so 1.8.0 URLs 404 —
-# retarget to the closest page in the current IA. Keep these BEFORE the
-# generic version-stripping rules below: stripped old-version URLs land on
-# these paths as their second hop.
+# retarget to the closest page in the current IA. Stripped old-version URLs
+# from the rules further down land on these paths as their second hop (each
+# hop is a fresh request, re-evaluated from the top of this file).
 RedirectMatch 301 "^(/zh)?/docs/ingress-controller/concepts/(apisix_route|apisix_upstream|apisix_plugin_config|apisix_tls|apisix_consumer|apisix_cluster_config|apisix_global_rule)/$" "$1/docs/ingress-controller/reference/apisix-ingress-controller/api-reference/"
 RedirectMatch 301 "^(/zh)?/docs/ingress-controller/concepts/annotations/$" "$1/docs/ingress-controller/reference/apisix-ingress-controller/annotation/"
 RedirectMatch 301 "^(/zh)?/docs/ingress-controller/design/$" "$1/docs/ingress-controller/concepts/deployment-architecture/"
@@ -146,7 +146,7 @@ RedirectMatch 301 "^/zh/help/?$" "/zh/"
 # retargeting rules above as a second hop. The apisix project itself is NOT
 # covered here: its 3.10+ versions are still built, and 2.x/3.x legacy
 # redirects for it are handled at the infra layer.
-RedirectMatch 301 "^(/zh)?/docs/ingress-controller/[01]\.\d+\.\d+/(.+)$" "$1/docs/ingress-controller/$2"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/[01]\.\d+\.\d+/(.*)$" "$1/docs/ingress-controller/$2"
 RedirectMatch 301 "^(/zh)?/docs/docker/(?:apisix-(?:dashboard-)?)?\d+\.\d+(?:\.\d+)?/(.+)$" "$1/docs/docker/$2"
 RedirectMatch 301 "^(/zh)?/docs/apisix/2\.[1-5](?:\.\d+)?/(.+)$" "$1/docs/apisix/$2"
 

--- a/.htaccess
+++ b/.htaccess
@@ -77,31 +77,28 @@ Redirect 301 "/zh/blog/2021/11/30/use-apisix-ingress-in-kubesphere/httpbin.org/"
 Redirect 301 "/zh/blog/2021/08/25/Auth-with-Casbin-in-Apache-APISIX/" "/zh/blog/2021/08/18/auth-with-casbin-in-apache-apisix/"
 Redirect 301 "/zh/blog/2022/03/02/apisix-integration-graphql-plugin/" "/zh/blog/2022/03/02/apisix-integration-graphql/"
 
-Redirect 301 "/docs/ingress-controller/concepts/apisix_route/" "/docs/ingress-controller/1.8.0/concepts/apisix_route/"
-Redirect 301 "/docs/ingress-controller/concepts/apisix_upstream/" "/docs/ingress-controller/1.8.0/concepts/apisix_upstream/"
-Redirect 301 "/docs/ingress-controller/concepts/apisix_plugin_config/" "/docs/ingress-controller/1.8.0/concepts/apisix_plugin_config/"
-Redirect 301 "/docs/ingress-controller/concepts/apisix_tls/" "/docs/ingress-controller/1.8.0/concepts/apisix_tls/"
-Redirect 301 "/docs/ingress-controller/concepts/annotations/" "/docs/ingress-controller/1.8.0/concepts/annotations/"
-Redirect 301 "/docs/ingress-controller/concepts/apisix_consumer/" "/docs/ingress-controller/1.8.0/concepts/apisix_consumer/"
-Redirect 301 "/docs/ingress-controller/concepts/apisix_cluster_config/" "/docs/ingress-controller/1.8.0/concepts/apisix_cluster_config/"
-Redirect 301 "/docs/ingress-controller/concepts/apisix_global_rule/" "/docs/ingress-controller/1.8.0/concepts/apisix_global_rule/"
-Redirect 301 "/docs/ingress-controller/design/" "/docs/ingress-controller/1.8.0/design/"
-Redirect 301 "/docs/ingress-controller/composite/" "/docs/ingress-controller/1.8.0/composite/"
-Redirect 301 "/docs/ingress-controller/references/apisix_route_v2/" "/docs/ingress-controller/1.8.0/references/apisix_route_v2/"
-Redirect 301 "/docs/ingress-controller/references/apisix_upstream/" "/docs/ingress-controller/1.8.0/references/apisix_upstream/"
-Redirect 301 "/docs/ingress-controller/references/v2/" "/docs/ingress-controller/1.8.0/references/v2/"
-Redirect 301 "/docs/ingress-controller/references/apisix_tls_v2/" "/docs/ingress-controller/1.8.0/references/apisix_tls_v2/"
-Redirect 301 "/docs/ingress-controller/references/apisix_consumer_v2/" "/docs/ingress-controller/1.8.0/references/apisix_consumer_v2/"
-Redirect 301 "/docs/ingress-controller/references/apisix_route_v2beta3/" "/docs/ingress-controller/1.8.0/references/apisix_route_v2beta3/"
-RedirectMatch 301 "^/docs/ingress-controller/tutorials/(.*)$" "/docs/ingress-controller/1.8.0/tutorials/$1"
-Redirect 301 "/docs/ingress-controller/monitoring/" "/docs/ingress-controller/1.8.0/monitoring/"
-Redirect 301 "/docs/ingress-controller/plugins/prometheus/" "/docs/ingress-controller/1.8.0/plugins/prometheus/"
-RedirectMatch 301 "^/docs/ingress-controller/deployments/(.*)$" "/docs/ingress-controller/1.8.0/deployments/$1"
-Redirect 301 "/docs/ingress-controller/aeps/gateway-api/" "/docs/ingress-controller/1.8.0/aeps/gateway-api/"
-Redirect 301 "/docs/ingress-controller/contribute/" "/docs/ingress-controller/1.8.0/contribute/"
+# Ingress-controller pages from the pre-2.0 IA. These used to redirect to
+# 1.8.0, but only the newest release is built now, so 1.8.0 URLs 404 —
+# retarget to the closest page in the current IA. Keep these BEFORE the
+# generic version-stripping rules below: stripped old-version URLs land on
+# these paths as their second hop.
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/concepts/(apisix_route|apisix_upstream|apisix_plugin_config|apisix_tls|apisix_consumer|apisix_cluster_config|apisix_global_rule)/$" "$1/docs/ingress-controller/reference/apisix-ingress-controller/api-reference/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/concepts/annotations/$" "$1/docs/ingress-controller/reference/apisix-ingress-controller/annotation/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/design/$" "$1/docs/ingress-controller/concepts/deployment-architecture/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/composite/$" "$1/docs/ingress-controller/overview/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/references/(.+)$" "$1/docs/ingress-controller/reference/apisix-ingress-controller/api-reference/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/tutorials/proxy-the-httpbin-service(-with-ingress)?/$" "$1/docs/ingress-controller/getting-started/configure-routes/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/tutorials/proxy-grpc-service/$" "$1/docs/ingress-controller/getting-started/configure-routes/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/tutorials/enable-authentication-and-restriction/$" "$1/docs/ingress-controller/getting-started/key-authentication/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/tutorials/the-hard-way/$" "$1/docs/ingress-controller/getting-started/get-apisix-ingress-controller/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/tutorials/(.+)$" "$1/docs/ingress-controller/overview/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/monitoring/$" "$1/docs/ingress-controller/overview/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/plugins/prometheus/$" "$1/docs/ingress-controller/overview/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/deployments/(.+)$" "$1/docs/ingress-controller/install/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/aeps/gateway-api/$" "$1/docs/ingress-controller/concepts/gateway-api/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/contribute/$" "$1/docs/ingress-controller/developer-guide/"
 Redirect 301 "/docs/ingress-controller/reference/apisix-ingress-controller/crd-reference/" "/docs/ingress-controller/reference/apisix-ingress-controller/api-reference/"
-Redirect 301 "/docs/ingress-controller/FAQ/" "/docs/ingress-controller/1.8.0/FAQ/"
-Redirect 301 "/docs/ingress-controller/upgrade/" "/docs/ingress-controller/1.8.0/upgrade/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/upgrade/$" "$1/docs/ingress-controller/upgrade-guide/"
 
 Redirect 301 "/docs/ingress-controller/next/tutorials/the-hard-way/" "/docs/ingress-controller/getting-started/get-apisix-ingress-controller/"
 Redirect 301 "/docs/ingress-controller/next/tutorials/configure-ingress-with-gateway-api/" "/docs/ingress-controller/concepts/gateway-api/"
@@ -141,3 +138,29 @@ RedirectMatch 301 "^/docs/general/code-samples/?$" "/"
 RedirectMatch 301 "^/zh/docs/general/code-samples/?$" "/zh/"
 RedirectMatch 301 "^/help/?$" "/"
 RedirectMatch 301 "^/zh/help/?$" "/zh/"
+
+# --- Dead-URL cleanup (sourced from Matomo 404 inventory, 2026-06-14..07-11) ---
+
+# Old sub-project doc versions are no longer built (only the newest release is
+# published) — strip the version segment. Renamed pages then land on the
+# retargeting rules above as a second hop. The apisix project itself is NOT
+# covered here: its 3.10+ versions are still built, and 2.x/3.x legacy
+# redirects for it are handled at the infra layer.
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/[01]\.\d+\.\d+/(.+)$" "$1/docs/ingress-controller/$2"
+RedirectMatch 301 "^(/zh)?/docs/docker/(?:apisix-(?:dashboard-)?)?\d+\.\d+(?:\.\d+)?/(.+)$" "$1/docs/docker/$2"
+RedirectMatch 301 "^(/zh)?/docs/apisix/2\.[1-5](?:\.\d+)?/(.+)$" "$1/docs/apisix/$2"
+
+# Dashboard docs were removed from the site entirely
+RedirectMatch 301 "^(/zh)?/docs/dashboard(/.*)?$" "$1/docs/apisix/dashboard/"
+
+# Bare landing directories have no index page and return 403 — send visitors
+# to the real entry pages instead
+RedirectMatch 301 "^(/zh)?/docs/apisix/$" "$1/docs/apisix/getting-started/README/"
+RedirectMatch 301 "^(/zh)?/docs/apisix/plugins/$" "$1/plugins/"
+RedirectMatch 301 "^(/zh)?/docs/apisix/3\.\d+/getting-started/$" "$1/docs/apisix/getting-started/README/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/$" "$1/docs/ingress-controller/overview/"
+RedirectMatch 301 "^(/zh)?/docs/ingress-controller/(?:next/)?getting-started/$" "$1/docs/ingress-controller/getting-started/get-apisix-ingress-controller/"
+
+# Renamed docs and GitHub-repo-style paths that leak into search results
+RedirectMatch 301 "^(/zh)?/docs/apisix/stand-alone/?$" "$1/docs/apisix/deployment-modes/"
+RedirectMatch 301 "^(/zh)?/docs/apisix/en/latest/deployment-modes(\.md)?/?$" "$1/docs/apisix/deployment-modes/"


### PR DESCRIPTION
## Problem

Matomo (Apache Analytics, site 17) recorded **11,401 Page-Not-Found visits** in 2026-06-14..07-11 (+485% vs the prior period). Probing every URL in the top-120 404 inventory against the live site shows 92 are still broken today, in four classes:

1. **Self-inflicted:** the version-less ingress-controller rules in `.htaccess` still redirect to `1.8.0/...` — but 1.8.0 is no longer built (only the newest release is published since #2066-era pruning), so our own redirects generate 404s. They even hijack `/docs/ingress-controller/FAQ/` and `/upgrade/`, which exist again as real pages in the current IA.
2. **Removed sub-project doc versions:** ingress-controller 0.4.0–1.8.0, docker `apisix-*`/`apisix-dashboard-*`, apisix 2.1–2.5 — still linked from search results and external sites.
3. **Bare landing directories** (`/docs/apisix/`, `/docs/apisix/plugins/`, `/docs/ingress-controller/`, …) return 403 (no index page) while receiving real traffic.
4. **Removed/renamed pages:** the dashboard docs are gone from the site entirely; `/docs/apisix/stand-alone`; GitHub-style paths.

## Fix

- Retarget the stale version-less ingress rules to their closest pages in the current IA (concepts/references → api-reference, deployments → install, tutorials → per-page or overview, upgrade → upgrade-guide); delete the FAQ hijack.
- Add version-stripping 301s for removed sub-project versions — renamed pages chain onto the retargeting rules as a second hop. The apisix project itself is excluded (3.10+ are still built; its 2.x/3.x legacy redirects are handled at the infra layer).
- Redirect dashboard docs to `/docs/apisix/dashboard/`, bare landing dirs to real entry pages, plus two renamed-path fixes.

## Verification (local httpd, mod_alias + this exact .htaccess)

- **89 of 92** currently-broken URLs terminate at a **live-200** page within ≤2 hops.
- **Zero redirect loops** (5-hop chase on every URL).
- `/docs/ingress-controller/1.8.0/FAQ/` chains to `/FAQ/`, which becomes a real page once this deploys (the hijack rule is removed in the same change).
- A **38-URL control set** (all current sub-project pages from the sitemap + apisix latest/versioned/next docs + hub pages) passes through with no redirect — no false positives.
- Intentionally not covered: `/v2` (95 hits, ambiguous intent — no defensible target) and one single-hit CHANGELOG.md path.

Follows up on #2070 (versioned-docs canonical); together these address the two P0 technical-SEO items from the GSC/Matomo analysis.