### PR TITLE
fix(homepage): consistent plugin-count copy on the landing page

### DIFF
--- a/next/src/components/HomePage.astro
+++ b/next/src/components/HomePage.astro
@@ -125,8 +125,8 @@ const PILLAR_IMGS = [
       <h1>{t(locale, 'The open-source API Gateway & AI Gateway', '开源 API 网关与 AI 网关')}</h1>
       <p class="lead">
         {t(locale,
-          'High-performance traffic management for APIs, microservices, and LLM workloads — dynamic routing, load balancing, authentication, observability, and 100+ plugins.',
-          '面向 API、微服务与 LLM 工作负载的高性能流量管理——动态路由、负载均衡、身份认证、可观测性与 100+ 插件。')}
+          'High-performance traffic management for APIs, microservices, and LLM workloads — dynamic routing, load balancing, authentication, and observability.',
+          '面向 API、微服务与 LLM 工作负载的高性能流量管理——动态路由、负载均衡、身份认证与可观测性。')}
       </p>
       <div class="btn-row">
         <a class="btn" href={`${p}/docs/apisix/getting-started/README/`}>{t(locale, 'Get started', '快速开始')}</a>
@@ -194,8 +194,8 @@ const PILLAR_IMGS = [
           'Reduce time fighting bugs, focus on designing world-class systems with API Gateway',
           'Apache APISIX 值得信赖，你只需专注在具体业务中，而无需考虑 API 处理基础组件。')}</h3>
         <p class="feature-lead">{t(locale,
-          'APISIX API Gateway offers nearly 100 open-source plugins, comprehensive API management capabilities, and advanced technical advantages.',
-          'APISIX API 网关提供近百个开源插件、全面的 API 管理能力和先进的技术优势。')}</p>
+          'APISIX API Gateway offers 100+ open-source plugins, comprehensive API management capabilities, and advanced technical advantages.',
+          'APISIX API 网关提供 100+ 开源插件、全面的 API 管理能力和先进的技术优势。')}</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What

Two copy-consistency fixes on the Astro landing page (EN and ZH), follow-up to #2073:

1. **Hero lead** — "100+ plugins" appeared three times in one viewport: the lead sentence, the "Browse 100+ plugins" button right below it, and the stat row. The lead now ends at "observability"; the number stays on the button and the metric strip.
2. **Why-APISIX lead** — "nearly 100 open-source plugins" contradicted the "100+" claim used everywhere else on the page. Now "100+ open-source plugins".

## Scope

One file, +4/−4: `next/src/components/HomePage.astro`. Copy only — no layout, style, or asset changes. Verified with a local Astro build: both landing pages render the new copy, still zero JS.
