### PR TITLE
fix(nav): restore the Comparisons entry point and historical resource links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -224,7 +224,8 @@ jobs:
           # is left as Docusaurus produced it, so those URLs stay byte-identical.
           for path in index.html zh/index.html _astro \
                       blog zh/blog learning-center zh/learning-center \
-                      articles zh/articles events zh/events; do
+                      articles zh/articles events zh/events \
+                      comparisons zh/comparisons; do
             rm -rf "website/build/$path"
             mkdir -p "website/build/$(dirname "$path")"
             cp -R "next/dist/$path" "website/build/$path"
@@ -244,6 +245,9 @@ jobs:
           test -f website/build/articles/index.html
           test -f website/build/zh/articles/rss.xml
           test -f website/build/events/archive/index.html
+          # The comparisons hub (a single index.html in both locales) is Astro's.
+          grep -q '/_astro/' website/build/comparisons/index.html
+          grep -q '/_astro/' website/build/zh/comparisons/index.html
           # Merge the homepage's image assets (integration brand icons, feature
           # infographics, architecture diagram) into the Docusaurus img tree.
           # cp merges: it adds the new files and overwrites only same-named

--- a/next/src/lib/site.ts
+++ b/next/src/lib/site.ts
@@ -41,6 +41,7 @@ export const NAV: NavItem[] = [
     ],
   },
   { label: 'Learning Center', labelZh: '学习中心', href: '/learning-center/' },
+  { label: 'Comparisons', labelZh: '对比', href: '/comparisons/' },
   { label: 'AI Gateway', href: '/ai-gateway/' },
   { label: 'Blog', labelZh: '博客', href: '/blog/' },
   { label: 'Plugin Hub', labelZh: '插件中心', href: '/plugins/' },
@@ -71,11 +72,22 @@ export const FOOTER = {
       ],
     },
     {
-      title: 'More',
+      title: 'Resources',
       links: [
         { label: 'Blog', href: '/blog/' },
-        { label: 'Plugin Hub', href: '/plugins/' },
         { label: 'Learning Center', href: '/learning-center/' },
+        { label: 'Comparisons', href: '/comparisons/' },
+        { label: 'Events', href: '/events/' },
+        { label: 'Case Studies', href: '/blog/tags/case-studies/' },
+        { label: 'User Stories', href: '/user-stories/' },
+      ],
+    },
+    {
+      title: 'More',
+      links: [
+        { label: 'Plugin Hub', href: '/plugins/' },
+        { label: 'Downloads', href: '/downloads/' },
+        { label: 'Team', href: '/team/' },
         { label: 'Contribute', href: '/contribute/' },
       ],
     },


### PR DESCRIPTION
## What

Restores navigation entry points that were lost when the navbar and footer were rebuilt for the static (Astro) landing/blog pages, and puts the already-built Comparisons hub page live.

**Nothing was ever deleted** — `/comparisons/`, `/events/`, `/user-stories/` and friends all still return 200. What went missing were the *links* to them from the Astro-served pages, so they became unreachable by browsing.

## Changes

- **Navbar**: `Comparisons` is back, EN and zh (it sits between Learning Center and AI Gateway, as before).
- **Footer**: new **Resources** column — Blog, Learning Center, Comparisons, Events, Case Studies, User Stories — with the product links (Plugin Hub, Downloads, Team, Contribute) moved into **More**. Four columns total.
- **Deploy**: `comparisons` and `zh/comparisons` join the overlay allowlist. The Astro version of this hub has been built since wave 2 but was never copied into the published tree, so the live page was still the old React one.

## URL safety

`/comparisons/` contains exactly **one `index.html` per locale** — verified against the live `asf-site` tree and against production (`/comparisons/apisix-vs-kong/` is a 404 today). The per-gateway comparison articles live at `/learning-center/apisix-vs-*/` and have been served by Astro since wave 2. So the subtree swap adds no URL and drops no URL.

The overlay step now asserts both locales' hub pages are the Astro build.

## Verification

- 924 pages built (unchanged).
- Navbar/footer links present in both locales' output.
- Simulated the overlay against the real `asf-site` `comparisons/` tree: page count before == after.
- Checked at 1280px and at 375/320px — the hub is the wave-2 card grid, no horizontal overflow.

## Not in this PR

`/user-stories/`, `/uses/`, `/all-in-one/` still render from Docusaurus. They are reachable again via the footer; restyling them is a separate change.
