### PR TITLE
fix(llms): keep the curated index, put the generated one after it

### DIFF
--- a/next/scripts/generate-md-twins.mjs
+++ b/next/scripts/generate-md-twins.mjs
@@ -150,6 +150,20 @@ const group = (items, frag) => {
   return items.filter((p) => prefix.test(p.url));
 };
 
+/**
+ * The site ships a hand-curated llms.txt (website/static/llms.txt): ~48 entries
+ * grouped by topic, each with a sentence on what it is for. That editorial
+ * judgement is worth more to an agent than a flat list, so it stays at the top
+ * — trimmed of its own heading — and the generated full index follows it.
+ */
+const curatedFile = path.join(root, '..', 'website', 'static', 'llms.txt');
+const curated = fs.existsSync(curatedFile)
+  ? fs.readFileSync(curatedFile, 'utf8')
+    .replace(/^#[^\n]*\n+/, '')            // drop its H1; ours is the page title
+    .replace(/^>.*\n+/m, '')               // and its blurb; ours carries one
+    .trim()
+  : '';
+
 const llms = [
   '# Apache APISIX',
   '',
@@ -157,6 +171,8 @@ const llms = [
   '',
   'Every page below is available as Markdown — append `index.md` to any page URL.',
   '',
+  ...(curated ? [curated, ''] : []),
+  ...(curated ? ['# Full index', ''] : []),
   ...section('Documentation', group(en, '/docs/')),
   ...section('Learning center', group(en, '/learning-center/')),
   ...section('Blog', group(en, '/blog/')),


### PR DESCRIPTION
Replaces #2080, which conflicted wholesale: it was branched before wave 3 was squashed into master, so it carried the entire wave-3 history as separate commits. Same 16-line change, cut from current master.

## What

Wave 3 added a generated `llms.txt` indexing all 1,186 Markdown twins. It was overwriting the hand-curated `website/static/llms.txt` during the overlay — I didn't notice that file existed until I checked what was live after the merge.

The curated list is better at the job an index is for: ~48 entries grouped by topic (Core Documentation, Authentication & Security, Traffic Control, AI Gateway, Observability, Kubernetes, Learning Center), each with a sentence saying what the page is for. An agent gets more from that than from 1,186 URLs in alphabetical order.

## Change

The curated list now leads the file; the generated full index follows under a `# Full index` heading. Both survive: editorial guidance first, complete coverage after. `website/static/llms.txt` remains the place to edit the front section.

## Verification

Built against current master: 7 curated sections with 52 annotated entries at the top, then the full index (600 en + 586 zh). Twin/index parity still 1:1 at 1,186, and the duplicate-entry assertion still passes.
