### PR TITLE
fix(ci): stop the docs overlay exiting 1 on a page with no Markdown twin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,9 +337,14 @@ jobs:
               dest="website/build/${locale_prefix}docs/$rel"
               mkdir -p "$(dirname "$dest")"
               cp "$src/$rel" "$dest"
-              # Ship the Markdown twin next to the page it mirrors.
+              # Ship the Markdown twin next to the page it mirrors. Written as
+              # if/fi, not `[ -f … ] && cp …`: the latter is the loop body's
+              # last command, so a page without a twin makes the whole pipeline
+              # exit 1 under `set -e` — silently skipping every assertion below.
               twin="${rel%index.html}index.md"
-              [ -f "$src/$twin" ] && cp "$src/$twin" "website/build/${locale_prefix}docs/$twin"
+              if [ -f "$src/$twin" ]; then
+                cp "$src/$twin" "website/build/${locale_prefix}docs/$twin"
+              fi
             done
           done
           # The version archives must survive untouched.


### PR DESCRIPTION
## The failure

The redeploy after #2081 got further — canonical assertions passed, the Astro build ran, the docs were copied — then died in **Overlay the Astro pages onto the Docusaurus build**.

The copy loop ended with:

```bash
[ -f "$src/$twin" ] && cp "$src/$twin" …
```

Not every docs page has a Markdown twin. For those, that test is false, the `&&` yields 1, and because it is the loop body's **last command** the whole pipeline exits 1. Under `set -e` the step aborts — after the files are copied, but before any of the assertions below it run.

That is why the log shows the route-manifest check printing its success line and the step dying immediately afterwards: it wasn't the next assertion failing, it was the loop's exit status. I spent a while looking at the canonical assertion because of it.

## The fix

`if`/`fi` instead of `&&`. The loop now ends 0 and the assertions execute.

Reproduced both the break and the fix in an isolated script: with `&&` the loop exits 1 despite copying every file; with `if`/`fi` it exits 0 and the following assertion runs.

I also grepped the workflow for the same shape elsewhere — the only other instance (line 230) already has `|| true`, so it is safe.

## Blast radius

Safe again: the step precedes the publish, so `asf-site` still holds the previous build and the live site is unaffected. But master has not been able to deploy since wave 3 merged, so wave 3 is still not live.
