### PR TITLE
fix(ci): check a generated blog Markdown twin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -417,7 +417,9 @@ jobs:
           # The agent index lives at the site root (the wave-1/2 subtrees carry
           # their own Markdown twins along with the cp -R above).
           cp next/dist/llms.txt website/build/llms.txt
-          test -f website/build/blog/index.md
+          # Section landing pages have no Markdown source; require a real post
+          # twin instead of the deliberately absent /blog/index.md.
+          test -n "$(find website/build/blog -mindepth 2 -name index.md -print -quit)"
           test -f website/build/docs/apisix/plugins/cors/index.md
           grep -q 'index.md' website/build/llms.txt
           test -f website/build/img/integrations/icon-prometheus.svg

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -419,7 +419,8 @@ jobs:
           cp next/dist/llms.txt website/build/llms.txt
           # Section landing pages have no Markdown source; require a real post
           # twin instead of the deliberately absent /blog/index.md.
-          test -n "$(find website/build/blog -mindepth 2 -name index.md -print -quit)"
+          blog_post_twin=$(find website/build/blog -mindepth 2 -type f -name index.md -print -quit)
+          test -n "$blog_post_twin"
           test -f website/build/docs/apisix/plugins/cors/index.md
           grep -q 'index.md' website/build/llms.txt
           test -f website/build/img/integrations/icon-prometheus.svg


### PR DESCRIPTION
Related: #2083

Changes:

- Replace the impossible blog section index.md assertion with a check for a generated blog post Markdown twin.
- Keep the deployment guard strict: it still fails when no blog post twin exists.

Validation:

- Reproduced the Astro content sync, build, and Markdown twin generation.
- Confirmed the old check fails and the new check passes on generated output.
- Confirmed the new check fails for an empty blog tree.
- Passed git diff --check, workflow YAML parsing, and the repository pre-commit hook.