### PR TITLE
fix(nav): keep the header brand on one line at desktop widths

### DIFF
--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -47,8 +47,10 @@ a:hover { text-decoration: underline; }
   border-bottom: 1px solid var(--color-border);
   height: var(--header-height);
 }
-.site-header .container { display: flex; align-items: center; gap: 1rem; height: 100%; }
-.brand { display: flex; align-items: center; gap: .5rem; font-weight: 700; color: var(--color-text); font-size: 1.05rem; }
+/* Full-bleed like the pre-Astro navbar: the desktop nav plus DocSearch
+   (~1210px on docs pages) is wider than the 1140px page column. */
+.site-header .container { display: flex; align-items: center; gap: 1rem; height: 100%; max-width: none; }
+.brand { display: flex; align-items: center; gap: .5rem; font-weight: 700; color: var(--color-text); font-size: 1.05rem; flex-shrink: 0; white-space: nowrap; }
 .brand img { height: 30px; width: auto; }
 .brand:hover { text-decoration: none; }
 .main-nav { margin-left: auto; display: flex; align-items: center; gap: .25rem; }
@@ -70,8 +72,22 @@ a:hover { text-decoration: underline; }
 .nav-drop .menu a:hover { background: var(--color-surface-alt); text-decoration: none; }
 .mobile-toggle { display: none; }
 
-/* 996px matches production's collapse point; below ~1000px the desktop nav
-   only fits by wrapping the brand wordmark onto two lines. */
+/* The brand never wraps (flex-shrink: 0 above); instead the header sheds
+   chrome as the viewport narrows. Budget at the default font metrics:
+   brand 175px + gap 16px + nav ~870px + DocSearch button 155px ≈ 1215px. */
+@media (min-width: 997px) and (max-width: 1365px) {
+  .main-nav { gap: .125rem; }
+  .main-nav > a, .nav-drop > summary { padding: .4rem .5rem; }
+  /* icon-only search button (the button keeps its aria-label) */
+  .site-header .DocSearch-Button-Placeholder,
+  .site-header .DocSearch-Button-Keys { display: none; }
+}
+@media (min-width: 997px) and (max-width: 1139px) {
+  .brand span { display: none; }
+}
+
+/* 996px matches production's collapse point: the desktop nav gives way to
+   the burger menu. */
 @media (max-width: 996px) {
   .main-nav { display: none; }
   .mobile-toggle { display: block; margin-left: auto; }


### PR DESCRIPTION
## What

On every desktop width, the header brand wrapped onto two lines and the wordmark overlapped the **Docs** nav item — most visibly on docs pages, e.g. https://apisix.apache.org/docs/apisix/getting-started/README/:

- the `site-header` row is capped at the 1140px page column (1100px usable), while the desktop nav has outgrown it: brand 175px + gap 16px + nav ~870px + DocSearch button 155px ≈ **1215px** on docs pages;
- every nav link is `white-space: nowrap`, so flexbox squeezed the only shrinkable item — the brand link. `Apache APISIX®` broke onto two lines and its overflow sat under the Docs entry.

Non-search pages (~1055px) fit by luck; adding one more nav item would have broken them too.

## Fix

All in `next/src/styles/global.css`:

1. **The brand never shrinks or wraps** (`flex-shrink: 0; white-space: nowrap`) — the invariant whose absence caused the bug.
2. **The header row spans the full viewport again**, like the pre-Astro Docusaurus navbar, instead of the 1140px column.
3. **997–1365px**: nav links tighten (`gap .125rem`, `padding-inline .5rem`) and the DocSearch button collapses to its icon (the button keeps its `aria-label`; the overrides out-specify DocSearch's own `.DocSearch-Button-Keys { display: flex }`).
4. **997–1139px**: the brand wordmark hides, leaving the 36px logo mark.
5. **≤996px**: the burger collapse is untouched and the wordmark stays visible on mobile.

## Verification

Measured against the live docs-page markup (real DocSearch button, production fonts) by injecting exactly this CSS and resizing:

| viewport (CSS px) | tier | brand | nav overflow | slack |
|---|---|---|---|---|
| 1440 | full | one line | 0 | 172px |
| 1366 (tier edge) | full | one line | 0 | 113px |
| 1280 | icon search | one line | 0 | 199px |
| 1140 (tier edge) | icon search | one line | 0 | 59px |
| 1139 (tier edge) | logo mark | one line | 0 | 198px |
| 997 (tier edge) | logo mark | one line | 0 | 56px |
| 996 / 375 | burger | wordmark visible | — | — |

zh locale is wider-margined than en (CJK labels are shorter; slack 355px at 1185px).

Local checks in `next/`: `astro build` passes; the Playwright e2e suite shows no new failures (the 3 failures on Plugin Hub / Downloads / zh-routes reproduce identically on a clean checkout without the content sync, both projects).