### PR TITLE
fix(ci): align zh learning-center deployment checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -245,7 +245,7 @@ jobs:
           # (blog tag pages are deliberately additive); it must never drop one.
           ROOT="$PWD"
           fail=0
-          for prefix in blog zh/blog learning-center zh/learning-center articles zh/articles events zh/events; do
+          for prefix in blog zh/blog learning-center articles zh/articles events zh/events; do
             [ -d "website/build/$prefix" ] || continue
             missing=$(cd "website/build/$prefix" && find . -name index.html | sort | while read -r f; do
               [ -f "$ROOT/next/dist/$prefix/$f" ] || echo "$prefix/$f"
@@ -267,6 +267,12 @@ jobs:
               echo "NON-HTML files not in the Astro tree and not in the feed-carry list:"; echo "$unhandled"; fail=1
             fi
           done
+          # zh/learning-center intentionally keeps only its localized landing
+          # page. Its English-only article, tag, archive, and pagination URLs
+          # redirect to the English tree instead of being rebuilt as duplicate
+          # pages, so exact Docusaurus parity does not apply to this subtree.
+          test -f next/dist/zh/learning-center/index.html
+          test "$(find next/dist/zh/learning-center -name index.html | wc -l)" -eq 1
           # Latest-version docs: Docusaurus no longer builds them (see
           # onlyIncludeVersions in doc/docusaurus.config.js), so the reference
           # is the LIVE SITE. Every version-less docs URL currently published
@@ -449,7 +455,11 @@ jobs:
         run: |
           node next/scripts/generate-sitemaps.mjs --dist website/build
           grep -q '<loc>https://apisix.apache.org/learning-center/mcp-protocol-ai-gateway/</loc>' website/build/sitemap.xml
-          grep -q '<loc>https://apisix.apache.org/zh/learning-center/what-is-an-api-gateway/</loc>' website/build/zh/sitemap.xml
+          grep -q '<loc>https://apisix.apache.org/zh/learning-center/</loc>' website/build/zh/sitemap.xml
+          if grep -q '<loc>https://apisix.apache.org/zh/learning-center/what-is-an-api-gateway/</loc>' website/build/zh/sitemap.xml; then
+            echo 'Retired English-only Chinese learning-center URL remains in the sitemap.'
+            exit 1
+          fi
           if grep -Eq '<loc>https://apisix\.apache\.org/(zh/)?(blog/(tags|page|archive)|learning-center/(tags|page|archive)|articles/(page|archive)|events/archive)/' website/build/sitemap.xml website/build/zh/sitemap.xml; then
             echo 'Low-value aggregation URLs remain in the final sitemap.'
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -245,11 +245,14 @@ jobs:
           # (blog tag pages are deliberately additive); it must never drop one.
           ROOT="$PWD"
           fail=0
-          for prefix in blog zh/blog learning-center articles zh/articles events zh/events; do
+          for prefix in blog zh/blog learning-center zh/learning-center articles zh/articles events zh/events; do
             [ -d "website/build/$prefix" ] || continue
-            missing=$(cd "website/build/$prefix" && find . -name index.html | sort | while read -r f; do
-              [ -f "$ROOT/next/dist/$prefix/$f" ] || echo "$prefix/$f"
-            done)
+            missing=""
+            if [ "$prefix" != "zh/learning-center" ]; then
+              missing=$(cd "website/build/$prefix" && find . -name index.html | sort | while read -r f; do
+                [ -f "$ROOT/next/dist/$prefix/$f" ] || echo "$prefix/$f"
+              done)
+            fi
             if [ -n "$missing" ]; then
               echo "MISSING in Astro build:"; echo "$missing"; fail=1
             fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,18 @@ jobs:
       - name: Build Astro site
         working-directory: next
         run: npm run build
+      - name: Assert Chinese learning-center retirement contract
+        working-directory: next
+        run: |
+          set -euo pipefail
+          node scripts/generate-md-twins.mjs
+          test -f dist/zh/learning-center/index.html
+          test "$(find dist/zh/learning-center -name index.html | wc -l)" -eq 1
+          test "$(find dist/zh/learning-center -name index.md | wc -l)" -eq 0
+          if grep -Eq 'https://apisix\.apache\.org/zh/learning-center/.+/index\.md' dist/llms.txt; then
+            echo 'Retired Chinese learning-center Markdown URL remains in llms.txt.'
+            exit 1
+          fi
       - name: Test main pages on desktop and mobile
         working-directory: next
         run: npm run test:e2e

--- a/next/scripts/generate-md-twins.mjs
+++ b/next/scripts/generate-md-twins.mjs
@@ -31,7 +31,9 @@ const SITE = 'https://apisix.apache.org';
 const COLLECTIONS = [
   ['blog-en', ['/blog']],
   ['blog-zh', ['/zh/blog']],
-  ['learning-center', ['/learning-center', '/zh/learning-center']],
+  // Learning-center articles are English-only. The Chinese landing page links
+  // to these URLs directly; retired /zh/learning-center/<slug>/ pages redirect.
+  ['learning-center', ['/learning-center']],
   ['articles', ['/articles', '/zh/articles']],
   ['docs-general', ['/docs/general', '/zh/docs/general']],
   // The zh APISIX docs fall back to the English source where no translation
@@ -178,7 +180,6 @@ const llms = [
   ...section('Blog', group(en, '/blog/')),
   ...section('Articles', group(en, '/articles/')),
   ...section('中文文档', group(zh, '/docs/')),
-  ...section('中文学习中心', group(zh, '/learning-center/')),
   ...section('中文博客', group(zh, '/blog/')),
   ...section('中文技术文章', group(zh, '/articles/')),
 ].join('\n');

--- a/next/scripts/generate-sitemaps.test.mjs
+++ b/next/scripts/generate-sitemaps.test.mjs
@@ -42,7 +42,7 @@ const pages = [
   'docs/apisix/upgrade-guide-from-2.15.x-to-3.0.0',
   'search',
   'zh',
-  'zh/learning-center/what-is-an-api-gateway',
+  'zh/learning-center',
   'zh/learning-center/tags/api-gateway',
   'zh/articles/page/2',
   'zh/events/archive',
@@ -94,7 +94,8 @@ try {
   assert.match(en, /docs\/general\/blog\/page\/overview/);
   assert.match(en, /docs\/apisix\/upgrade-guide-from-2\.15\.x-to-3\.0\.0/);
   assert.match(en, /apisix-unity-group-q&amp;a/);
-  assert.match(zh, /zh\/learning-center\/what-is-an-api-gateway/);
+  assert.match(zh, /zh\/learning-center\/<\/loc>/);
+  assert.doesNotMatch(zh, /zh\/learning-center\/what-is-an-api-gateway/);
   assert.match(zh, /bi-weekly%20report/);
 
   assert.ok(en.includes('<loc>https://apisix.apache.org/</loc><changefreq>weekly</changefreq><priority>1.0</priority>'));

--- a/next/scripts/generate-sitemaps.test.mjs
+++ b/next/scripts/generate-sitemaps.test.mjs
@@ -95,7 +95,6 @@ try {
   assert.match(en, /docs\/apisix\/upgrade-guide-from-2\.15\.x-to-3\.0\.0/);
   assert.match(en, /apisix-unity-group-q&amp;a/);
   assert.match(zh, /zh\/learning-center\/<\/loc>/);
-  assert.doesNotMatch(zh, /zh\/learning-center\/what-is-an-api-gateway/);
   assert.match(zh, /bi-weekly%20report/);
 
   assert.ok(en.includes('<loc>https://apisix.apache.org/</loc><changefreq>weekly</changefreq><priority>1.0</priority>'));


### PR DESCRIPTION
## Summary

- exempt the intentionally retired `zh/learning-center/*` pages from exact Docusaurus URL parity while requiring the localized landing page
- stop generating Markdown twins for retired Chinese learning-center article URLs
- update sitemap checks to require the Chinese landing page and reject the retired article URL

## Root cause

#2087 intentionally removed English-only pages under `/zh/learning-center/` and redirected them to their English equivalents. The main-only deployment workflow still required exact parity with the old Docusaurus subtree, so `Assert URL parity for the wave-2 subtrees` failed after merge. The PR checks did not run this deployment workflow.

## Verification

- `node scripts/generate-sitemaps.test.mjs`
- full Astro sync/build plus `generate-md-twins.mjs`
- Chinese learning-center contract: exactly one HTML landing page, no retired sitemap entry, no retired Markdown twins
- Playwright: 8 passed, 2 expected skips (final-overlay-only tests)
- repository pre-commit `lint-staged` / ESLint hook