### PR TITLE
fix(ci): validate full deploy before merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ name: Test and Deploy Website
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   schedule:
     # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
     - cron: '0 5 * * *'
@@ -392,11 +394,12 @@ jobs:
           # The version-less pages are built by Astro, so this is the only
           # place their cross-site canonical can be checked — the Docusaurus
           # assertion earlier in this job covers the versioned pages.
-          for f in website/build/docs/apisix/plugins/cors/index.html \
-                   website/build/zh/docs/apisix/plugins/cors/index.html; do
-            test "$(grep -o 'rel="canonical"' "$f" | wc -l)" -eq 1
-            grep -q 'rel="canonical" href="https://docs.api7.ai/hub/cors"' "$f"
-          done
+          f=website/build/docs/apisix/plugins/cors/index.html
+          test "$(grep -o 'rel="canonical"' "$f" | wc -l)" -eq 1
+          grep -q 'rel="canonical" href="https://docs.api7.ai/hub/cors"' "$f"
+          f=website/build/zh/docs/apisix/plugins/cors/index.html
+          test "$(grep -o 'rel="canonical"' "$f" | wc -l)" -eq 1
+          grep -q 'rel="canonical" href="https://docs.apiseven.com/hub/cors"' "$f"
           grep -q 'property="og:url" content="https://apisix.apache.org/docs/apisix/plugins/cors/"' \
             website/build/docs/apisix/plugins/cors/index.html
           # Fail the deploy if the landing pages are not the Astro build, or

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,18 @@ on:
         required: true
         default: 'master'
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Build and validate with read-only permissions; publish only from trusted events.
 jobs:
-  # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -479,24 +485,32 @@ jobs:
           PLAYWRIGHT_WEB_SERVER_COMMAND: python3 -m http.server 4321 --bind 127.0.0.1 --directory ../website/build
           EXPECT_DOCUSARUS_ROUTES: 'true'
 
-      - name: Deploy to Netlify
-        uses: ./.github/actions/actions-netlify
-        if: ${{ false }}
+      - name: Upload final site for publishing
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@v4
         with:
-          publish-dir: './website/build'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: '${{ github.event.pull_request.title }}, Deploy from GitHub Actions'
-          enable-pull-request-comment: true
-          enable-commit-comment: true
-          overwrites-pull-request-comment: true
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 10
+          name: website-build
+          path: website/build
+          include-hidden-files: true
+          retention-days: 1
+
+  publish:
+    needs: build
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download final site
+        uses: actions/download-artifact@v4
+        with:
+          name: website-build
+          path: website/build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3.9.0
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'schedule'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build


### PR DESCRIPTION
## Summary

- assert the English APISIX plugin canonical against `docs.api7.ai` and the Chinese canonical against `docs.apiseven.com`
- run the complete `Test and Deploy Website` workflow for pull requests targeting `master`
- keep the actual `asf-site` deployment restricted to `master` pushes and schedules

## Root cause

The post-#2089 main run passed URL parity, then failed silently in the overlay step because it still required the Chinese `cors` page canonical to use `docs.api7.ai`. #2087 intentionally rewrites Chinese hub canonicals to `docs.apiseven.com`.

The full Docusaurus + Astro overlay pipeline only ran after merge. The existing PR checks build Astro alone, so they could not exercise synced project docs or the final overlay assertions.

## Verification

- source contract: `DocPage.astro` rewrites `docs.api7.ai` canonicals to `docs.apiseven.com` for `locale === zh`
- repository pre-commit `lint-staged` / ESLint hook passed
- this PR itself triggers the complete deployment dry-run; the publishing step remains guarded from PR events