### PR TITLE
fix(docs): link version picker entries to each version's landing doc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -468,7 +468,8 @@ jobs:
           # The picker used to link version roots (/docs/apisix/3.15/), which
           # have no index.html — ASF httpd answers 403 via Options -Indexes.
           # Check at the filesystem level: the e2e static server directory-lists
-          # instead of 403ing, so only this step can tell a page from a hole.
+          # instead of 403ing, and only this step covers every emitted href
+          # rather than a handful of sampled pages.
           # This is also the only layer that catches APISIX_ARCHIVED_VERSIONS
           # drifting from what is actually published, because the Astro build
           # never sees archived-version content.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -509,10 +509,23 @@ jobs:
           # helm-chart is not version-published, so it must offer no next entry.
           # It also renders no <details class="version-picker"> at all (one
           # version means a plain label), so the walk above cannot cover it.
-          if grep -rq 'href="/docs/helm-chart/next/' website/build/docs/helm-chart/; then
-            echo "helm-chart links to a next/ tree that does not exist"
-            exit 1
-          fi
+          #
+          # BOTH locales. zh/docs/helm-chart/ is Astro-built too and shipped
+          # the identical dead link (verified on asf-site: 5 pages, each with
+          # href="/zh/docs/helm-chart/next/"), so checking only English would
+          # leave the Chinese side unguarded against the same regression.
+          for prefix in "" "/zh"; do
+            dir="website/build${prefix}/docs/helm-chart"
+            # A missing tree must fail loudly rather than silently satisfy the
+            # assertion: `grep -r` on an absent path exits 2, which inside `if`
+            # reads as "no match", so a build that shipped no helm-chart docs
+            # at all would pass this check.
+            test -d "$dir"
+            if grep -rq "href=\"${prefix}/docs/helm-chart/next/" "$dir"; then
+              echo "helm-chart links to a next/ tree that does not exist: ${prefix}/docs/helm-chart"
+              exit 1
+            fi
+          done
 
       - name: Generate final sitemaps
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -463,6 +463,57 @@ jobs:
           test -f website/build/img/integrations/icon-prometheus.svg
           test -f website/build/img/architecture.svg
 
+      - name: Assert every version-picker link resolves
+        run: |
+          # The picker used to link version roots (/docs/apisix/3.15/), which
+          # have no index.html — ASF httpd answers 403 via Options -Indexes.
+          # Check at the filesystem level: the e2e static server directory-lists
+          # instead of 403ing, so only this step can tell a page from a hole.
+          # This is also the only layer that catches APISIX_ARCHIVED_VERSIONS
+          # drifting from what is actually published, because the Astro build
+          # never sees archived-version content.
+          node -e '
+            const fs = require("fs"), path = require("path");
+            const roots = ["website/build/docs", "website/build/zh/docs"];
+            const walk = (dir, out = []) => {
+              for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+                const p = path.join(dir, e.name);
+                if (e.isDirectory()) walk(p, out);
+                else if (e.name === "index.html") out.push(p);
+              }
+              return out;
+            };
+            const seen = new Map();
+            for (const root of roots) {
+              if (!fs.existsSync(root)) continue;
+              for (const file of walk(root)) {
+                const block = fs.readFileSync(file, "utf8")
+                  .match(/<details class="version-picker"[\s\S]*?<\/details>/);
+                if (!block) continue;
+                for (const m of block[0].matchAll(/href="([^"]+)"/g)) {
+                  if (!seen.has(m[1])) seen.set(m[1], file);
+                }
+              }
+            }
+            if (!seen.size) { console.error("no version pickers found — the docs overlay is broken"); process.exit(1); }
+            let fail = false;
+            for (const [href, from] of seen) {
+              if (!fs.existsSync(path.join("website/build", href, "index.html"))) {
+                console.error(`dead version link ${href} (emitted by ${from})`);
+                fail = true;
+              }
+            }
+            if (fail) process.exit(1);
+            console.log(`version picker: ${seen.size} distinct links, all resolve`);
+          '
+          # helm-chart is not version-published, so it must offer no next entry.
+          # It also renders no <details class="version-picker"> at all (one
+          # version means a plain label), so the walk above cannot cover it.
+          if grep -rq 'href="/docs/helm-chart/next/' website/build/docs/helm-chart/; then
+            echo "helm-chart links to a next/ tree that does not exist"
+            exit 1
+          fi
+
       - name: Generate final sitemaps
         run: |
           node next/scripts/generate-sitemaps.mjs --dist website/build

--- a/next/src/layouts/DocPage.astro
+++ b/next/src/layouts/DocPage.astro
@@ -2,7 +2,7 @@
 import Base from './Base.astro';
 import SidebarNodes from '../components/SidebarNodes.astro';
 import { SITE, type Locale } from '../lib/site';
-import type { DocEntry, SidebarNode } from '../lib/content';
+import type { DocEntry, SidebarNode, VersionEntry } from '../lib/content';
 
 interface Props {
   entry: DocEntry;
@@ -13,20 +13,15 @@ interface Props {
   urlById?: (id: string) => string;
   editUrl?: string;
   versionLabel?: string;
-  /** Archived versions to offer alongside the current one, newest first. */
-  archivedVersions?: string[];
-  /** URL prefix the version dirs hang off, e.g. "/docs/apisix/". */
-  versionBase?: string;
-  /** Explicit link to the unreleased docs, for projects with no archives. */
-  nextUrl?: string;
+  /** Version picker entries, current version first. Built by the caller. */
+  versions?: VersionEntry[];
   /** Sidebar id of the current page (path-derived); defaults to entry.id. */
   activeId?: string;
 }
 const {
   entry, locale, path, sidebar = [], titleById, urlById, editUrl, versionLabel,
-  archivedVersions = [], versionBase = '', nextUrl,
+  versions = [],
 } = Astro.props;
-const nextHref = nextUrl ?? (versionBase ? `${versionBase}next/` : undefined);
 const active = Astro.props.activeId ?? entry.id;
 const { Content } = entry.mod;
 
@@ -66,14 +61,14 @@ const canonicalOverride = locale === 'zh' && rawCanonical?.startsWith('https://d
     {sidebar.length > 0 && (
       <nav class="docs-sidebar" aria-label="Docs sidebar">
         {versionLabel && (
-          (archivedVersions.length > 0 || nextHref)
+          versions.length > 1
             ? (
               <details class="version-picker">
                 <summary>{versionLabel}</summary>
                 <ul>
-                  {versionBase && <li><a href={versionBase} aria-current="page">{versionLabel}</a></li>}
-                  {archivedVersions.map((v) => <li><a href={`${versionBase}${v}/`}>{v}</a></li>)}
-                  {nextHref && <li><a href={nextHref}>{locale === 'zh' ? '开发版 (next)' : 'Next (unreleased)'}</a></li>}
+                  {versions.map((v) => (
+                    <li><a href={v.href} aria-current={v.current ? 'true' : undefined}>{v.label}</a></li>
+                  ))}
                 </ul>
               </details>
             )

--- a/next/src/lib/content.ts
+++ b/next/src/lib/content.ts
@@ -382,3 +382,56 @@ export const APISIX_ARCHIVED_VERSIONS: string[] = (() => {
   const known = ['3.16', '3.15', '3.14', '3.13', '3.12', '3.11', '3.10'];
   return known.filter((v) => v !== cur);
 })();
+
+/** An entry in the docs version picker. */
+export interface VersionEntry {
+  label: string;
+  href: string;
+  current?: boolean;
+}
+
+/**
+ * First leaf of a sidebar tree — the project's landing doc id. Verified to
+ * reproduce config/docs.js's firstDocPath for all seven projects, and for
+ * apisix it yields the trap-free "getting-started/README".
+ */
+export function sidebarLandingId(nodes: SidebarNode[]): string | undefined {
+  for (const node of nodes) {
+    if (node.id) return node.id;
+    if (node.items) {
+      const found = sidebarLandingId(node.items);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Insert a version segment into the landing doc's version-less URL.
+ *
+ * This replaces linking the version ROOT (".../3.15/"), which has no
+ * index.html — ASF httpd answers 403 through Options -Indexes. Linking
+ * ".../3.15/getting-started/" is equally wrong: .htaccess:160 301s it to the
+ * LATEST version, silently defeating the switch. Only the full landing path
+ * is safe.
+ *
+ * Returns undefined when landingUrl does not sit under versionBase; the
+ * caller drops that entry. src/ degrades and never throws — the deploy.yml
+ * assertion is what fails loudly.
+ */
+export function versionedLandingHref(
+  versionBase: string,
+  version: string,
+  landingUrl: string,
+): string | undefined {
+  if (!landingUrl.startsWith(versionBase)) return undefined;
+  return `${versionBase}${version}/${landingUrl.slice(versionBase.length)}`;
+}
+
+/**
+ * Projects Docusaurus does not version-publish. With no versions.json it
+ * serves their docs straight from /docs/<project>/ and emits no next/ tree,
+ * so an unreleased entry would link to a 403. Astro syncs only the latest
+ * release and cannot observe this, hence the explicit list.
+ */
+export const NO_NEXT_DOCS = new Set(['helm-chart']);

--- a/next/src/pages/docs/[project]/[...id].astro
+++ b/next/src/pages/docs/[project]/[...id].astro
@@ -1,6 +1,6 @@
 ---
 import DocPage from '../../../layouts/DocPage.astro';
-import { SUBPROJECTS, getSubprojectDocs, getSubprojectSidebar, docEditUrl, subprojectVersion } from '../../../lib/content';
+import { SUBPROJECTS, getSubprojectDocs, getSubprojectSidebar, docEditUrl, subprojectVersion, sidebarLandingId, versionedLandingHref, NO_NEXT_DOCS, type VersionEntry } from '../../../lib/content';
 
 export function getStaticPaths() {
   return Object.keys(SUBPROJECTS).flatMap((project) => {
@@ -19,6 +19,19 @@ const sidebar = getSubprojectSidebar(project);
 const urlById = (id: string) => urlByPathId.get(id) ?? `/docs/${project}/${id}/`;
 const repo = SUBPROJECTS[project].repo;
 const version = subprojectVersion(project);
+
+const versionBase = `/docs/${project}/`;
+const landingId = sidebarLandingId(sidebar);
+const landingUrl = landingId ? urlById(landingId) : undefined;
+const nextHref = landingUrl && !NO_NEXT_DOCS.has(project)
+  ? versionedLandingHref(versionBase, 'next', landingUrl)
+  : undefined;
+const versions: VersionEntry[] = version && landingUrl
+  ? [
+      { label: `v${version}`, href: landingUrl, current: true },
+      ...(nextHref ? [{ label: 'Next (unreleased)', href: nextHref }] : []),
+    ]
+  : [];
 ---
 <DocPage
   entry={entry}
@@ -30,6 +43,5 @@ const version = subprojectVersion(project);
   urlById={urlById}
   editUrl={docEditUrl(project, repo, entry)}
   versionLabel={version ? `v${version}` : undefined}
-  archivedVersions={[]}
-  nextUrl={`/docs/${project}/next/`}
+  versions={versions}
 />

--- a/next/src/pages/docs/apisix/[...id].astro
+++ b/next/src/pages/docs/apisix/[...id].astro
@@ -1,6 +1,6 @@
 ---
 import DocPage from '../../../layouts/DocPage.astro';
-import { getApisixDocs, getApisixSidebar, docEditUrl, APISIX_DOCS_VERSION, APISIX_ARCHIVED_VERSIONS } from '../../../lib/content';
+import { getApisixDocs, getApisixSidebar, docEditUrl, APISIX_DOCS_VERSION, APISIX_ARCHIVED_VERSIONS, sidebarLandingId, versionedLandingHref, type VersionEntry } from '../../../lib/content';
 
 export function getStaticPaths() {
   const docs = getApisixDocs('en');
@@ -16,6 +16,17 @@ const { entry, titleById, urlByPathId } = Astro.props;
 const sidebar = getApisixSidebar();
 const urlById = (id: string) => urlByPathId.get(id) ?? `/docs/apisix/${id}/`;
 const editUrl = docEditUrl('apisix', 'apisix', entry);
+
+const versionBase = '/docs/apisix/';
+const landingId = sidebarLandingId(sidebar);
+const landingUrl = landingId ? urlById(landingId) : undefined;
+const versions: VersionEntry[] = landingUrl
+  ? [
+      { label: `APISIX ${APISIX_DOCS_VERSION}`, href: landingUrl, current: true },
+      ...APISIX_ARCHIVED_VERSIONS.map((v) => ({ label: v, href: versionedLandingHref(versionBase, v, landingUrl) })),
+      { label: 'Next (unreleased)', href: versionedLandingHref(versionBase, 'next', landingUrl) },
+    ].flatMap((e) => (e.href ? [{ ...e, href: e.href }] : []))
+  : [];
 ---
 <DocPage
   entry={entry}
@@ -27,6 +38,5 @@ const editUrl = docEditUrl('apisix', 'apisix', entry);
   urlById={urlById}
   editUrl={editUrl}
   versionLabel={`APISIX ${APISIX_DOCS_VERSION}`}
-  archivedVersions={APISIX_ARCHIVED_VERSIONS}
-  versionBase="/docs/apisix/"
+  versions={versions}
 />

--- a/next/src/pages/zh/docs/[project]/[...id].astro
+++ b/next/src/pages/zh/docs/[project]/[...id].astro
@@ -1,6 +1,6 @@
 ---
 import DocPage from '../../../../layouts/DocPage.astro';
-import { SUBPROJECTS, getSubprojectDocs, getSubprojectSidebar, docEditUrl, subprojectVersion } from '../../../../lib/content';
+import { SUBPROJECTS, getSubprojectDocs, getSubprojectSidebar, docEditUrl, subprojectVersion, sidebarLandingId, versionedLandingHref, NO_NEXT_DOCS, type VersionEntry } from '../../../../lib/content';
 
 export function getStaticPaths() {
   return Object.keys(SUBPROJECTS).flatMap((project) => {
@@ -19,6 +19,19 @@ const sidebar = getSubprojectSidebar(project);
 const urlById = (id: string) => urlByPathId.get(id) ?? `/zh/docs/${project}/${id}/`;
 const repo = SUBPROJECTS[project].repo;
 const version = subprojectVersion(project);
+
+const versionBase = `/zh/docs/${project}/`;
+const landingId = sidebarLandingId(sidebar);
+const landingUrl = landingId ? urlById(landingId) : undefined;
+const nextHref = landingUrl && !NO_NEXT_DOCS.has(project)
+  ? versionedLandingHref(versionBase, 'next', landingUrl)
+  : undefined;
+const versions: VersionEntry[] = version && landingUrl
+  ? [
+      { label: `v${version}`, href: landingUrl, current: true },
+      ...(nextHref ? [{ label: '开发版 (next)', href: nextHref }] : []),
+    ]
+  : [];
 ---
 <DocPage
   entry={entry}
@@ -30,6 +43,5 @@ const version = subprojectVersion(project);
   urlById={urlById}
   editUrl={docEditUrl(project, repo, entry)}
   versionLabel={version ? `v${version}` : undefined}
-  archivedVersions={[]}
-  nextUrl={`/zh/docs/${project}/next/`}
+  versions={versions}
 />

--- a/next/src/pages/zh/docs/apisix/[...id].astro
+++ b/next/src/pages/zh/docs/apisix/[...id].astro
@@ -1,6 +1,6 @@
 ---
 import DocPage from '../../../../layouts/DocPage.astro';
-import { getApisixDocs, getApisixSidebar, docEditUrl, APISIX_DOCS_VERSION, APISIX_ARCHIVED_VERSIONS } from '../../../../lib/content';
+import { getApisixDocs, getApisixSidebar, docEditUrl, APISIX_DOCS_VERSION, APISIX_ARCHIVED_VERSIONS, sidebarLandingId, versionedLandingHref, type VersionEntry } from '../../../../lib/content';
 
 export function getStaticPaths() {
   const docs = getApisixDocs('zh');
@@ -16,6 +16,17 @@ const { entry, titleById, urlByPathId } = Astro.props;
 const sidebar = getApisixSidebar();
 const urlById = (id: string) => urlByPathId.get(id) ?? `/zh/docs/apisix/${id}/`;
 const editUrl = docEditUrl('apisix', 'apisix', entry);
+
+const versionBase = '/zh/docs/apisix/';
+const landingId = sidebarLandingId(sidebar);
+const landingUrl = landingId ? urlById(landingId) : undefined;
+const versions: VersionEntry[] = landingUrl
+  ? [
+      { label: `APISIX ${APISIX_DOCS_VERSION}`, href: landingUrl, current: true },
+      ...APISIX_ARCHIVED_VERSIONS.map((v) => ({ label: v, href: versionedLandingHref(versionBase, v, landingUrl) })),
+      { label: '开发版 (next)', href: versionedLandingHref(versionBase, 'next', landingUrl) },
+    ].flatMap((e) => (e.href ? [{ ...e, href: e.href }] : []))
+  : [];
 ---
 <DocPage
   entry={entry}
@@ -27,6 +38,5 @@ const editUrl = docEditUrl('apisix', 'apisix', entry);
   urlById={urlById}
   editUrl={editUrl}
   versionLabel={`APISIX ${APISIX_DOCS_VERSION}`}
-  archivedVersions={APISIX_ARCHIVED_VERSIONS}
-  versionBase="/zh/docs/apisix/"
+  versions={versions}
 />

--- a/next/tests/e2e/docs-version-picker.spec.mjs
+++ b/next/tests/e2e/docs-version-picker.spec.mjs
@@ -38,8 +38,15 @@ for (const pagePath of DOC_PAGES) {
       // this to a bare `h1` — the 404 page that a 403 renders has exactly
       // one h1 (text "404"), so a bare h1 would pass on precisely the URLs
       // this test exists to reject.
+      //
+      // .first() is required, not cosmetic: some docs pages legitimately
+      // render multiple h1s (python-plugin-runner's next/getting-started
+      // already does), and toBeVisible() on a multi-element locator is a
+      // Playwright strict-mode violation. Without it, an upstream doc gaining
+      // a second `#` heading would fail the site deploy. A zero-match locator
+      // still fails toBeVisible, so 404 pages and listings stay red.
       await expect(
-        page.locator('.docs-content h1, .theme-doc-markdown h1'),
+        page.locator('.docs-content h1, .theme-doc-markdown h1').first(),
         `${href} must be a docs page, not a directory listing`,
       ).toBeVisible();
     }
@@ -60,6 +67,6 @@ test('helm-chart offers no unreleased entry', async ({ page }) => {
   // page's own heading proves the docs page actually rendered before we
   // assert the unreleased link is absent. This page is Astro-built, so
   // .docs-content is the right container here.
-  await expect(page.locator('.docs-content h1')).toBeVisible();
+  await expect(page.locator('.docs-content h1').first()).toBeVisible();
   await expect(page.locator('a[href^="/docs/helm-chart/next/"]')).toHaveCount(0);
 });

--- a/next/tests/e2e/docs-version-picker.spec.mjs
+++ b/next/tests/e2e/docs-version-picker.spec.mjs
@@ -31,8 +31,15 @@ for (const pagePath of DOC_PAGES) {
       // (python3 -m http.server) answers an index-less directory with 200
       // plus a directory listing, so a status assertion would pass on the
       // exact build this test exists to reject. Production returns 403.
+      //
+      // Both selectors are required: current-version pages are Astro-built
+      // and wrap content in .docs-content, while archived versions are still
+      // Docusaurus-built and use .theme-doc-markdown instead. Do NOT relax
+      // this to a bare `h1` — the 404 page that a 403 renders has exactly
+      // one h1 (text "404"), so a bare h1 would pass on precisely the URLs
+      // this test exists to reject.
       await expect(
-        page.locator('.docs-content h1'),
+        page.locator('.docs-content h1, .theme-doc-markdown h1'),
         `${href} must be a docs page, not a directory listing`,
       ).toBeVisible();
     }
@@ -48,5 +55,11 @@ test('helm-chart offers no unreleased entry', async ({ page }) => {
   // Docusaurus does not version-publish helm-chart, so /docs/helm-chart/next/
   // has never existed and any link to it is a 403 by construction.
   await page.goto('/docs/helm-chart/apisix/');
+  // Positive anchor first: a 404, a redirect, or a blank page would all
+  // satisfy toHaveCount(0), letting the test pass vacuously. Requiring the
+  // page's own heading proves the docs page actually rendered before we
+  // assert the unreleased link is absent. This page is Astro-built, so
+  // .docs-content is the right container here.
+  await expect(page.locator('.docs-content h1')).toBeVisible();
   await expect(page.locator('a[href^="/docs/helm-chart/next/"]')).toHaveCount(0);
 });

--- a/next/tests/e2e/docs-version-picker.spec.mjs
+++ b/next/tests/e2e/docs-version-picker.spec.mjs
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+// One representative page per project and locale. A project's version picker
+// markup is identical on every one of its pages, so walking all 249 pages
+// would only make the suite slow.
+const DOC_PAGES = [
+  '/docs/apisix/getting-started/README/',
+  '/zh/docs/apisix/getting-started/README/',
+  '/docs/ingress-controller/overview/',
+  '/docs/docker/build/',
+];
+
+for (const pagePath of DOC_PAGES) {
+  test(`version links on ${pagePath} open real docs pages`, async ({ page }) => {
+    test.setTimeout(120_000);
+    test.skip(
+      process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
+      'Archived versions only exist in the final overlaid tree',
+    );
+
+    await page.goto(pagePath);
+    const hrefs = await page
+      .locator('.version-picker a')
+      .evaluateAll((anchors) => anchors.map((a) => a.getAttribute('href')));
+
+    expect(hrefs.length, `${pagePath} should render a version picker`).toBeGreaterThan(0);
+
+    for (const href of hrefs) {
+      await page.goto(href);
+      // Assert on CONTENT, never on HTTP status. The e2e static server
+      // (python3 -m http.server) answers an index-less directory with 200
+      // plus a directory listing, so a status assertion would pass on the
+      // exact build this test exists to reject. Production returns 403.
+      await expect(
+        page.locator('.docs-content h1'),
+        `${href} must be a docs page, not a directory listing`,
+      ).toBeVisible();
+    }
+  });
+}
+
+test('helm-chart offers no unreleased entry', async ({ page }) => {
+  test.skip(
+    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
+    'Sub-project docs only exist in the final overlaid tree',
+  );
+
+  // Docusaurus does not version-publish helm-chart, so /docs/helm-chart/next/
+  // has never existed and any link to it is a 403 by construction.
+  await page.goto('/docs/helm-chart/apisix/');
+  await expect(page.locator('a[href^="/docs/helm-chart/next/"]')).toHaveCount(0);
+});


### PR DESCRIPTION

<img width="1435" height="801" alt="fix" src="https://github.com/user-attachments/assets/616f98ed-3d58-4bf8-bb56-e53b63dcacdb" />

Changes:

The docs version picker linked every entry to a **version root directory** (`/docs/apisix/3.16/`). Those directories contain no `index.html`, and `.htaccess` sets `Options -Indexes`, so ASF httpd answers **HTTP 403**, which `ErrorDocument 403 /404.html` then renders as the 404 page. The status code is 403 rather than 404, which reads to crawlers as access-denied rather than gone.

Measured against the published `asf-site` tree:

| Picker link | Result today |
|---|---|
| `/docs/apisix/` | 200 — rescued by the `301` at `.htaccess:158` |
| `/docs/apisix/3.10/` … `/docs/apisix/3.16/` | **403** (7 links) |
| `/docs/apisix/next/` | **403** |
| `/docs/{ingress-controller,helm-chart,docker,java-,go-,python-plugin-runner}/next/` | **403** (6 links) |

That is 8 dead links on each of the 249 English version-less docs pages, plus the Chinese mirror.

This is the same class of bug `.htaccess:156-160` already fixes for `/docs/apisix/` and `/docs/ingress-controller/`, under the comment *"Bare landing directories have no index page and return 403"*. The versioned directories were simply missed.

### The fix

Each entry now links **that version's landing doc**, derived from the first leaf of the project's sidebar — no new data, and it tracks upstream sidebar changes automatically. URL construction moves out of `DocPage.astro` into two pure functions in `content.ts`; the layout receives a prepared `versions[]` array and only renders it. Splitting that knowledge across the layout and its callers is what allowed the bug.

The full landing path is required, not just the version segment: `.htaccess:160` redirects `/docs/apisix/3.<n>/getting-started/` to the **latest** version, so emitting the shorter form would silently defeat the version switch. `versionedLandingHref`'s doc comment records this so a future simplification is pre-refuted.

`helm-chart` now renders no "Next (unreleased)" entry at all. Docusaurus does not version-publish it — there is no `/docs/helm-chart/next/` tree and never has been — so that entry was a 403 by construction. With one version left, the picker collapses to a plain label instead of a one-item dropdown.

Two small corrections on lines already being touched: the current-version entry links its landing doc directly (one less redirect hop, one less dependency on `.htaccess`), and its `aria-current` becomes `"true"` instead of `"page"` — it marks the current *version*, so on any page other than the landing doc `"page"` told screen readers something false.

### Failure handling

`next/src/**` degrades rather than throwing, matching this project's split between a degrading render path and hard-failing validators: an unresolvable entry is dropped, an empty sidebar renders no picker. The new `deploy.yml` step is where failure is loud — after the overlay, it walks every built docs page, collects each `.version-picker` href, and fails the deploy if any has no file behind it. That is the only layer that can catch `APISIX_ARCHIVED_VERSIONS` (a hardcoded list) drifting from what is actually published, because the Astro build never sees archived-version content.

**This gate is deliberately deploy-blocking.** If a listed archived version is ever unpublished, the site deploy fails until the list is corrected. That is the point, but it is worth knowing before merging.

### Testing

`next/tests/e2e/docs-version-picker.spec.mjs` collects every picker href and asserts each opens a real docs page.

It asserts on page **content**, never on HTTP status, because the e2e static server (`python3 -m http.server`) answers an index-less directory with `200` plus a directory listing where production returns `403` — a status assertion would have passed on the exact build the test exists to reject. It accepts both `.docs-content h1` and `.theme-doc-markdown h1`, because version-less pages are Astro-built and archived versions are still Docusaurus-built. A bare `h1` would not work either: the 404 page a 403 renders has exactly one `h1`, with the text `404`.

Verified against production before the fix: 5 failures, each on the intended assertion, naming `/docs/apisix/3.16/`, `/zh/docs/apisix/3.16/`, `/docs/ingress-controller/next/`, `/docs/docker/next/`, and the helm-chart `next` link.

### Known limitations, disclosed

- **Switching versions now lands on that version's landing doc, not the equivalent page.** Deliberate: it carries zero 403 risk and is fully verifiable at build time. The cost is losing the reader's position.
- **Direct access to a version root (`/docs/apisix/3.16/`) still returns 403.** This PR fixes the links that produce those URLs; bookmarks and already-indexed URLs need an `.htaccess` redirect, which is intentionally out of scope here.
- **Sub-project archived versions remain unreachable from the picker** (ingress-controller 2.1.0, java 0.6.0, go 0.5.0, python 0.2.0). Pre-existing and unchanged — a missing feature, not a broken link.
- **The e2e spec skips in PR CI** (`EXPECT_DOCUSARUS_ROUTES` is unset) and runs fully only in the deploy pipeline against the overlaid tree. It is red against production until the first post-merge deploy. I have not claimed a green run here, because the archived pages it needs exist only in that assembled tree.

Screenshots of the change:

No visual change to the docs layout. The one user-visible difference is on `/docs/helm-chart/*`, where the version picker becomes a plain label instead of a dropdown whose only entry was broken.
