### PR TITLE
fix(css): restore container padding and surface the mobile docs nav

### DIFF
--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -206,7 +206,7 @@ a.tag:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2
 .pagination a:hover { border-color: var(--color-primary); text-decoration: none; }
 
 /* ---------- article / prose ---------- */
-.article-wrap { display: grid; grid-template-columns: minmax(0, 720px); justify-content: center; padding: 2.5rem 0; }
+.article-wrap { display: grid; grid-template-columns: minmax(0, 720px); justify-content: center; padding-block: 2.5rem; }
 
 /* ---------- article side rails (wide screens) ---------- */
 /* Left: tags + back. Right: on-this-page TOC. Both sticky, both hidden below
@@ -321,7 +321,7 @@ a.tag:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2
 .admonition-important { border-color: #a25ddc; background: #f4eefb; }
 
 /* ---------- docs layout ---------- */
-.docs-layout { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 2.5rem; align-items: start; padding: 2rem 0; }
+.docs-layout { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: 2.5rem; align-items: start; padding-block: 2rem; }
 .docs-sidebar {
   position: sticky; top: calc(var(--header-height) + 1rem);
   max-height: calc(100vh - var(--header-height) - 2rem);
@@ -338,11 +338,13 @@ a.tag:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2
 .docs-content { min-width: 0; padding-bottom: 3rem; }
 .docs-meta { border-top: 1px solid var(--color-border); margin-top: 2.5rem; padding-top: 1rem; font-size: .85rem; color: var(--color-text-soft); display: flex; gap: 1rem; flex-wrap: wrap; }
 @media (max-width: 960px) {
-  /* Content first on phones: the full link tree is ~7 screens tall, so it
-     moves below the article (grid order) and scrolls within a capped box.
-     minmax(0,1fr) keeps long code lines from inflating the column. */
+  /* The nav stays in document order, above the article. It used to be pushed
+     below it, which put the link tree — and the version picker inside it —
+     roughly seven screens down, with only ~4% of the tree visible once you got
+     there. Capping the box at 30vh keeps the article's own heading on the
+     first screen. minmax(0,1fr) keeps long code lines from inflating the column. */
   .docs-layout { grid-template-columns: minmax(0, 1fr); }
-  .docs-sidebar { order: 2; position: static; max-height: 45vh; max-height: 45dvh; overflow-y: auto; border: 1px solid var(--color-border); border-radius: 8px; padding: .75rem; }
+  .docs-sidebar { position: static; max-height: 30vh; max-height: 30dvh; overflow-y: auto; border: 1px solid var(--color-border); border-radius: 8px; padding: .75rem; }
 }
 
 /* ---------- homepage extras ---------- */

--- a/next/tests/e2e/docs-mobile-layout.spec.mjs
+++ b/next/tests/e2e/docs-mobile-layout.spec.mjs
@@ -30,8 +30,7 @@ async function assertDocsLayout(page, url) {
   expect(pad.right).toBeGreaterThan(0);
 
   // The header was always correct, so it is the reference the article should
-  // match. Only meaningful below the 1140px container cap, where both are full
-  // width; above it the centred container makes the comparison meaningless.
+  // match — but only once the layout stacks; see the breakpoint note below.
   const geom = await page.evaluate(() => ({
     viewport: window.innerWidth,
     h1Left: document.querySelector('.docs-content h1').getBoundingClientRect().left,
@@ -43,7 +42,8 @@ async function assertDocsLayout(page, url) {
   expect(geom.h1Left, `${url}: article text must not touch the viewport edge`).toBeGreaterThan(0);
 
   // Both remaining checks are breakpoint-dependent, and 960px is the line
-  // (global.css:340) where .docs-layout collapses to one column.
+  // where .docs-layout collapses to one column (the max-width: 960px media
+  // query in global.css).
   if (geom.viewport <= 960) {
     // Stacked: the article shares the container's inline padding with the
     // header, so their left edges line up.

--- a/next/tests/e2e/docs-mobile-layout.spec.mjs
+++ b/next/tests/e2e/docs-mobile-layout.spec.mjs
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+
+/** Computed horizontal padding of the first element matching `selector`. */
+async function inlinePadding(page, selector) {
+  return page.locator(selector).first().evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return { left: parseFloat(cs.paddingLeft), right: parseFloat(cs.paddingRight) };
+  });
+}
+
+/**
+ * Discover a post from the blog index rather than naming one. A hardcoded URL
+ * turns an unrelated content change into a broken test; the index is the same
+ * thing a reader would follow. `/blog/20…` matches dated post URLs only —
+ * `/blog/page/`, `/blog/archive/` and `/blog/tags/` do not start that way.
+ */
+async function firstBlogPost(page) {
+  await page.goto('/blog/');
+  const href = await page.locator('a[href^="/blog/20"]').first().getAttribute('href');
+  expect(href, 'the blog index must list at least one post').toBeTruthy();
+  return href;
+}
+
+// `/edit/` is the one .article-wrap page present in every build, including the
+// content-less local one, so this check needs no gate and runs everywhere.
+test('the edit page keeps its horizontal padding', async ({ page }) => {
+  await page.goto('/edit/');
+  const pad = await inlinePadding(page, '.article-wrap');
+  expect(pad.left, '.article-wrap must not zero out .container padding').toBeGreaterThan(0);
+  expect(pad.right).toBeGreaterThan(0);
+});
+
+// Docs and blog article pages only exist in the assembled tree, so the rest is
+// gated the same way main-pages.spec.mjs:141 gates its overlay checks.
+test('docs pages keep horizontal padding and put the nav above the article', async ({ page }) => {
+  test.skip(
+    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
+    'Docs pages only exist in the final overlaid tree',
+  );
+
+  await page.goto('/docs/apisix/getting-started/README/');
+
+  const pad = await inlinePadding(page, '.docs-layout');
+  expect(pad.left, '.docs-layout must not zero out .container padding').toBeGreaterThan(0);
+  expect(pad.right).toBeGreaterThan(0);
+
+  // The header was always correct, so it is the reference the article should
+  // match. Only meaningful below the 1140px container cap, where both are full
+  // width; above it the centred container makes the comparison meaningless.
+  const geom = await page.evaluate(() => ({
+    viewport: window.innerWidth,
+    h1Left: document.querySelector('.docs-content h1').getBoundingClientRect().left,
+    brandLeft: document.querySelector('.site-header .brand').getBoundingClientRect().left,
+    navTop: document.querySelector('.docs-sidebar').offsetTop,
+    articleTop: document.querySelector('.docs-content').offsetTop,
+  }));
+
+  expect(geom.h1Left, 'article text must not touch the viewport edge').toBeGreaterThan(0);
+  if (geom.viewport <= 1140) {
+    expect(Math.abs(geom.h1Left - geom.brandLeft),
+      'article should line up with the header brand').toBeLessThanOrEqual(1);
+  }
+  expect(geom.navTop, 'the docs nav must come before the article').toBeLessThan(geom.articleTop);
+});
+
+test('blog posts keep their horizontal padding', async ({ page }) => {
+  test.skip(
+    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
+    'Blog posts only exist in the final overlaid tree',
+  );
+
+  await page.goto(await firstBlogPost(page));
+  const pad = await inlinePadding(page, '.article-wrap');
+  expect(pad.left, 'blog posts share the .article-wrap defect').toBeGreaterThan(0);
+  expect(pad.right).toBeGreaterThan(0);
+});
+
+test('desktop keeps the three-column article rails', async ({ page }) => {
+  test.skip(
+    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
+    'Blog posts only exist in the final overlaid tree',
+  );
+  test.skip(test.info().project.name !== 'desktop-chrome', 'Rails only exist at >=1240px');
+
+  await page.goto(await firstBlogPost(page));
+
+  // Assert the rails exist before measuring them, so a post that legitimately
+  // has none fails loudly here instead of silently passing a vacuous check.
+  const rails = page.locator('.article-wrap.with-rails');
+  await expect(rails, 'the discovered post should render the rails layout').toHaveCount(1);
+
+  // Restoring the inline padding narrows the content box by 2.5rem. The rails
+  // grid needs 1276px of a 1340px cap, so this is the assertion that catches a
+  // miscalculation squeezing it from three columns down to fewer.
+  const columns = await rails.evaluate(
+    (el) => getComputedStyle(el).gridTemplateColumns.split(/\s+/).filter(Boolean).length,
+  );
+  expect(columns, 'the rails grid must stay three columns').toBe(3);
+});

--- a/next/tests/e2e/docs-mobile-layout.spec.mjs
+++ b/next/tests/e2e/docs-mobile-layout.spec.mjs
@@ -21,27 +21,12 @@ async function firstBlogPost(page) {
   return href;
 }
 
-// `/edit/` is the one .article-wrap page present in every build, including the
-// content-less local one, so this check needs no gate and runs everywhere.
-test('the edit page keeps its horizontal padding', async ({ page }) => {
-  await page.goto('/edit/');
-  const pad = await inlinePadding(page, '.article-wrap');
-  expect(pad.left, '.article-wrap must not zero out .container padding').toBeGreaterThan(0);
-  expect(pad.right).toBeGreaterThan(0);
-});
-
-// Docs and blog article pages only exist in the assembled tree, so the rest is
-// gated the same way main-pages.spec.mjs:141 gates its overlay checks.
-test('docs pages keep horizontal padding and put the nav above the article', async ({ page }) => {
-  test.skip(
-    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
-    'Docs pages only exist in the final overlaid tree',
-  );
-
-  await page.goto('/docs/apisix/getting-started/README/');
+/** Padding restored and nav ahead of the article, for any docs page. */
+async function assertDocsLayout(page, url) {
+  await page.goto(url);
 
   const pad = await inlinePadding(page, '.docs-layout');
-  expect(pad.left, '.docs-layout must not zero out .container padding').toBeGreaterThan(0);
+  expect(pad.left, `${url}: .docs-layout must not zero out .container padding`).toBeGreaterThan(0);
   expect(pad.right).toBeGreaterThan(0);
 
   // The header was always correct, so it is the reference the article should
@@ -55,20 +40,32 @@ test('docs pages keep horizontal padding and put the nav above the article', asy
     articleTop: document.querySelector('.docs-content').offsetTop,
   }));
 
-  expect(geom.h1Left, 'article text must not touch the viewport edge').toBeGreaterThan(0);
+  expect(geom.h1Left, `${url}: article text must not touch the viewport edge`).toBeGreaterThan(0);
   if (geom.viewport <= 1140) {
     expect(Math.abs(geom.h1Left - geom.brandLeft),
-      'article should line up with the header brand').toBeLessThanOrEqual(1);
+      `${url}: article should line up with the header brand`).toBeLessThanOrEqual(1);
   }
-  expect(geom.navTop, 'the docs nav must come before the article').toBeLessThan(geom.articleTop);
+  expect(geom.navTop, `${url}: the docs nav must come before the article`)
+    .toBeLessThan(geom.articleTop);
+}
+
+// docs/general/** ships from this repo, so it exists in the PR CI build too —
+// no gate, and the fix is verified before anything is deployed.
+test('general docs keep padding and put the nav above the article', async ({ page }) => {
+  await assertDocsLayout(page, '/docs/general/contributor-guide/');
+});
+
+// Same assertions over the 200-link apisix tree that motivated the report.
+// Gated: apisix docs need .sync/ checkouts only the deploy pipeline has.
+test('apisix docs keep padding and put the nav above the article', async ({ page }) => {
+  test.skip(
+    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
+    'apisix docs only exist in the final overlaid tree',
+  );
+  await assertDocsLayout(page, '/docs/apisix/getting-started/README/');
 });
 
 test('blog posts keep their horizontal padding', async ({ page }) => {
-  test.skip(
-    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
-    'Blog posts only exist in the final overlaid tree',
-  );
-
   await page.goto(await firstBlogPost(page));
   const pad = await inlinePadding(page, '.article-wrap');
   expect(pad.left, 'blog posts share the .article-wrap defect').toBeGreaterThan(0);
@@ -76,10 +73,6 @@ test('blog posts keep their horizontal padding', async ({ page }) => {
 });
 
 test('desktop keeps the three-column article rails', async ({ page }) => {
-  test.skip(
-    process.env.EXPECT_DOCUSARUS_ROUTES !== 'true',
-    'Blog posts only exist in the final overlaid tree',
-  );
   test.skip(test.info().project.name !== 'desktop-chrome', 'Rails only exist at >=1240px');
 
   await page.goto(await firstBlogPost(page));

--- a/next/tests/e2e/docs-mobile-layout.spec.mjs
+++ b/next/tests/e2e/docs-mobile-layout.spec.mjs
@@ -41,12 +41,27 @@ async function assertDocsLayout(page, url) {
   }));
 
   expect(geom.h1Left, `${url}: article text must not touch the viewport edge`).toBeGreaterThan(0);
-  if (geom.viewport <= 1140) {
+
+  // Both remaining checks are breakpoint-dependent, and 960px is the line
+  // (global.css:340) where .docs-layout collapses to one column.
+  if (geom.viewport <= 960) {
+    // Stacked: the article shares the container's inline padding with the
+    // header, so their left edges line up.
     expect(Math.abs(geom.h1Left - geom.brandLeft),
       `${url}: article should line up with the header brand`).toBeLessThanOrEqual(1);
+    // Stacked: the nav must precede the article. This is the defect — `order: 2`
+    // used to push it below.
+    expect(geom.navTop, `${url}: the docs nav must come before the article`)
+      .toBeLessThan(geom.articleTop);
+  } else {
+    // Side by side: nav and article are grid items on the same row, so their
+    // offsetTop is EQUAL. Measured on production at 1440px: both 132.
+    // Asserting `toBeLessThan` here would be unsatisfiable — and asserting
+    // equality is the guard that catches `order` leaking out of the media
+    // query and stacking the desktop layout.
+    expect(geom.navTop, `${url}: nav and article should share a grid row`)
+      .toBe(geom.articleTop);
   }
-  expect(geom.navTop, `${url}: the docs nav must come before the article`)
-    .toBeLessThan(geom.articleTop);
 }
 
 // docs/general/** ships from this repo, so it exists in the PR CI build too —
@@ -82,11 +97,19 @@ test('desktop keeps the three-column article rails', async ({ page }) => {
   const rails = page.locator('.article-wrap.with-rails');
   await expect(rails, 'the discovered post should render the rails layout').toHaveCount(1);
 
-  // Restoring the inline padding narrows the content box by 2.5rem. The rails
-  // grid needs 1276px of a 1340px cap, so this is the assertion that catches a
-  // miscalculation squeezing it from three columns down to fewer.
-  const columns = await rails.evaluate(
-    (el) => getComputedStyle(el).gridTemplateColumns.split(/\s+/).filter(Boolean).length,
-  );
-  expect(columns, 'the rails grid must stay three columns').toBe(3);
+  const tracks = await rails.evaluate((el) =>
+    getComputedStyle(el).gridTemplateColumns.split(/\s+/).filter(Boolean).map(parseFloat));
+
+  expect(tracks.length, 'the rails grid must stay three columns').toBe(3);
+
+  // The count alone is VACUOUS and must not be the only assertion here.
+  // `.with-rails` uses an explicit template (190px minmax(0,760px) 230px), so
+  // computed gridTemplateColumns always reports three tracks no matter how
+  // narrow the container gets. Measured on production: forcing the wrapper to
+  // 600px still reports 3 tracks — as "190px 44px 230px", with the reading
+  // column crushed. Restoring the inline padding shrinks the middle track, it
+  // never removes one, so track WIDTH is the only thing worth guarding.
+  // Design target is 760px; the rule's own comment allows ~680px at 1240.
+  expect(tracks[1], 'the reading column must not be squeezed by the padding fix')
+    .toBeGreaterThan(700);
 });


### PR DESCRIPTION
Changes:

Two layout defects, both in `next/src/styles/global.css`.

<img width="332" height="716" alt="image" src="https://github.com/user-attachments/assets/71355718-f2cb-453f-a0ae-3c3919e4519d" />


### 1. Body text ran flush against the viewport edge

`.container` sets `padding: 0 1.25rem`, but `.article-wrap` and `.docs-layout` are applied to the **same elements** (`class="container article-wrap"`, `class="container docs-layout"`) and re-declared the `padding` **shorthand** later in the sheet:

```css
.container    { … padding: 0 1.25rem }   /* line 38  */
.article-wrap { … padding: 2.5rem 0  }   /* line 209 — resets the inline axis */
.docs-layout  { … padding: 2rem 0    }   /* line 324 — same */
```

Same specificity, later rule wins, so the horizontal padding became `0`. Measured on production: the article `<h1>` sat at `x=0` while the header brand — which was always correct — sat at `x=20`.

This affected **every viewport narrower than the 1140px container cap**, and not only docs: `Article.astro` composes its class with a template literal, so blog posts, articles and the Learning Center share the defect.

Both rules now declare `padding-block` and leave the inline axis to `.container`. Restating `padding: 2rem 1.25rem` would have copied `.container`'s value into two more places, free to drift; the bug was a shorthand overriding an axis it had no opinion about, so the fix is to stop expressing one. Logical properties are already used in this sheet (`margin-inline`, line 447).

### 2. The mobile docs nav sat about seven screens below the article

`@media (max-width: 960px)` set `.docs-sidebar{order: 2}`. Measured on a 900px-wide viewport:

- the nav began at **4743px of a 5566px page** — 7.3 screens down;
- its `45vh` box then showed **4.1%** of its 7090px of content, about 7 of 200 links;
- the version picker lives inside that box, so switching doc versions cost the same 7.3 screens.

The DOM already places `<nav>` before `<article>`; only that `order` moved it. Dropping it restores document order, and the cap goes 45vh → 30vh so the article's own heading still lands on the first screen.

**Why the nav is repositioned rather than collapsed.** A `<details>` disclosure was the first design. It cannot work: `<details>`'s open state is a single DOM attribute, and a media query cannot set it — mobile needs it closed while desktop needs it open. Two CSS workarounds were prototyped and both failed in Chrome 150, verified with `Element.checkVisibility()`: forcing the content `display:block` with the summary hidden, and giving the `<details>` itself `display:contents`. Browsers do not hide collapsed `<details>` content with `display:none`, so author CSS cannot override it. (`getComputedStyle().display` reports `block` in both cases and is misleading; only `checkVisibility()` reflects reality.) A checkbox-hack collapse did work in all four states, but a screen reader announces it as a checkbox rather than a disclosure control. Repositioning reaches the same goal with no markup change, no JavaScript, and no semantics traded away.

### Deliberate costs

Restoring the inline padding narrows each grid's content box by 2.5rem:

| Grid | Before | After |
|---|---|---|
| `.docs-layout` | content column 820px | 780px |
| `.article-wrap` (<1240px) | 720px cap | unchanged |
| `.article-wrap.with-rails` (≥1240px) | needs 1276px, had 1340px | has 1300px (headroom 64px → 24px) |

At exactly 1240px the reading column goes 724px → 684px. That rule's own comment predicts "~680px at 1240", so this stays inside the author's stated envelope.

### Testing

`next/tests/e2e/docs-mobile-layout.spec.mjs` asserts computed layout values on both the desktop (1440×900) and mobile (390×844) Playwright projects.

Three of the four tests are **ungated and run in PR CI**: `docs/general/**` and blog posts both ship from this repo, so they exist once `sync-content.mjs` has run — which is what `lint.yml` does. Only the `docs/apisix/**` case is gated on `EXPECT_DOCUSARUS_ROUTES`, because that tree needs `.sync/` checkouts only the deploy pipeline has.

Two assertions are deliberately shaped against false greens:

- The nav-order check is scoped to ≤960px. Above it, the nav and article are grid items on the same row with **equal** `offsetTop` (measured: both 132 at 1440px), so the desktop branch asserts equality instead — which is what catches `order` escaping the media query.
- The rails check asserts the reading column's **width**, not the track count. `.with-rails` uses an explicit template, so computed `gridTemplateColumns` always reports three tracks: forcing the wrapper to 600px still reports three, as `190px 44px 230px`, with the reading column crushed.

Verified red against production before the fix, and green locally against a full 875-page build (5 passed / 3 skipped; the apisix test skips without the env gate, the rails test skips on mobile by design).

Honest limits: the apisix-docs assertion will first actually execute in the deploy pipeline, not in PR CI. And `max-height: 30vh` is a chosen value asserted by no test — a test asserting it would only mirror the CSS and calcify a tunable.

### Merge order

No `.astro` file is touched, so this and #2095 merge cleanly in either order. Verified with `git merge-tree` against both `upstream/master` and that branch.

Screenshots of the change:

Mobile, before: article text flush against both edges, docs nav 7.3 screens below the article with 4.1% of the link tree visible. After: 20px inline padding matching the header, nav above the article in a 30vh scrolling box. Desktop is unchanged apart from the intended 40px inset.
