### PR TITLE
fix(docs): restore collapsible sidebar categories

### DIFF
--- a/next/src/components/SidebarNodes.astro
+++ b/next/src/components/SidebarNodes.astro
@@ -17,15 +17,22 @@ const { nodes, active, titleById, urlById } = Astro.props;
 /** Keep anything that links somewhere or that still has renderable children. */
 const renderable = (n: SidebarNode): boolean =>
   Boolean(n.id) || (Array.isArray(n.items) && n.items.some(renderable));
+
+const hasChildren = (n: SidebarNode): boolean =>
+  Array.isArray(n.items) && n.items.some(renderable);
 ---
 <ul>
   {nodes.filter(renderable).map((node) => (
-    <li class={node.items ? 'cat' : ''}>
-      {node.id
-        ? <a href={urlById(node.id)} class={node.id === active ? 'active' : ''}>{titleById?.get(node.id) ?? node.id}</a>
-        : <span>{node.label}</span>}
-      {node.items && node.items.some(renderable) && (
-        <Astro.self nodes={node.items} active={active} titleById={titleById} urlById={urlById} />
+    <li class={hasChildren(node) ? 'cat' : ''}>
+      {hasChildren(node) ? (
+        <details class="sidebar-category">
+          <summary>{node.label ?? titleById?.get(node.id ?? '') ?? node.id}</summary>
+          <Astro.self nodes={node.items!} active={active} titleById={titleById} urlById={urlById} />
+        </details>
+      ) : node.id ? (
+        <a href={urlById(node.id)} class={node.id === active ? 'active' : ''}>{titleById?.get(node.id) ?? node.id}</a>
+      ) : (
+        <span>{node.label}</span>
       )}
     </li>
   ))}

--- a/next/src/styles/global.css
+++ b/next/src/styles/global.css
@@ -334,7 +334,25 @@ a.tag:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2
 .docs-sidebar a { display: block; color: var(--color-text-soft); padding: .22rem .5rem; border-radius: 6px; }
 .docs-sidebar a:hover { color: var(--color-primary); background: var(--color-surface-alt); text-decoration: none; }
 .docs-sidebar a.active { color: var(--color-primary); font-weight: 600; background: #fdeeee; }
-.docs-sidebar .cat > span { display: block; font-weight: 700; color: var(--color-text); padding: .5rem .5rem .2rem; }
+.docs-sidebar .sidebar-category > summary {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  padding: .5rem .5rem .2rem;
+  color: var(--color-text);
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+.docs-sidebar .sidebar-category > summary::-webkit-details-marker { display: none; }
+.docs-sidebar .sidebar-category > summary::before {
+  content: '▸';
+  color: var(--color-text-soft);
+  font-size: .8em;
+  transition: transform var(--dur) var(--ease);
+}
+.docs-sidebar .sidebar-category[open] > summary::before { transform: rotate(90deg); }
+.docs-sidebar .sidebar-category > summary:hover { color: var(--color-primary); }
 .docs-content { min-width: 0; padding-bottom: 3rem; }
 .docs-meta { border-top: 1px solid var(--color-border); margin-top: 2.5rem; padding-top: 1rem; font-size: .85rem; color: var(--color-text-soft); display: flex; gap: 1rem; flex-wrap: wrap; }
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- restore collapsible category groups in the Astro docs sidebar
- keep every category collapsed by default
- add an accessible disclosure indicator for open and closed states

## Verification
- `yarn --cwd next build`

> `yarn --cwd next lint` requires the generated `next/content` directory, which is not present in this checkout.