### PR TITLE
blog: add 2026 August monthly report

### DIFF
--- a/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
@@ -78,7 +78,7 @@ PR: https://github.com/apache/apisix/pull/13773
 
 Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
 
-This PR adds `request_check_roles` and `request_check_mode` to `ai-aws-content-moderation`, so operators can choose which user, tool, and system content to moderate and whether to inspect all turns or only the latest relevant block. The defaults preserve the plugin's existing coverage, while selective checks can avoid repeatedly scoring and billing for conversation history.
+This PR adds `request_check_roles` and `request_check_mode` to `ai-aws-content-moderation`, so operators can choose which user, tool, and system content to moderate and whether to inspect all turns or only the latest relevant block. The defaults preserve the previous coverage for user, tool, and system messages, but assistant messages previously included by the generic extractor are no longer moderated. Selective checks can avoid repeatedly scoring and billing for conversation history.
 
 #### 7. Send LLM Requests Through `ngx_http_ffi_client`
 
@@ -124,4 +124,4 @@ This PR allows `chaitin-waf` to report response status, headers, and a configura
 
 ## Conclusion
 
-The [official website](https://apisix.apache.org/) and [GitHub Issues](https://github.com/apache/apisix/issues) of Apache APISIX provide a wealth of documentation of tutorials, and real-world use cases. If you encounter any issues, you can refer to the documentation, search for keywords in Issues, or participate in discussions on Issues to share your ideas and practical experiences.
+The Apache APISIX [official website](https://apisix.apache.org/) and [GitHub Issues](https://github.com/apache/apisix/issues) offer extensive documentation, tutorials, and real-world use cases. If you encounter any issues, you can refer to the documentation, search for keywords in Issues, or participate in discussions on Issues to share your ideas and practical experiences.

--- a/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
@@ -3,7 +3,7 @@ title: "2026 Monthly Report (August 01 - August 31)"
 keywords: ["Apache APISIX", "API Gateway", "Monthly Report", "Contributor"]
 description: Our monthly Apache APISIX community report generates insights into the project's monthly developments. The reports provide a pathway into the Apache APISIX community, ensuring that you stay well-informed and actively involved.
 tags: [Community]
-image: /TODO_COVER_IMAGE_EN
+image: https://static.api7.ai/uploads/2026/09/01/fnMEaJFl_2026-aug-monthly-report-cover-en.webp
 ---
 
 > Recently, we've introduced and updated some new features, including advanced LDAP and OIDC authentication, stronger encryption and upstream TLS verification, faster and more resilient AI traffic, and richer traffic governance and observability. For more details, please read this month's newsletter.
@@ -14,13 +14,13 @@ image: /TODO_COVER_IMAGE_EN
 
 From its inception, the Apache APISIX project has embraced the ethos of open-source community collaboration, propelling it into the ranks of the most active global open-source API gateway projects. The proverbial wisdom of 'teamwork makes the dream work' rings true in our way and is made possible by the collective effort of our community.
 
-From August 1st to August 31st, 10 contributors made 69 commits to Apache APISIX. We sincerely appreciate your contributions to Apache APISIX.
+From August 1st to August 31st, 13 contributors made 117 commits to Apache APISIX. We sincerely appreciate your contributions to Apache APISIX.
 
 ## Contributor Statistics
 
-<img alt="Apache APISIX Contributors List" src="/TODO_CONTRIBUTOR_LIST_IMAGE" />
+![Apache APISIX Contributors List](https://static.api7.ai/uploads/2026/09/01/N8c2DgwP_2026-aug-contributor-list.webp)
 
-<img alt="New Contributors List" src="/TODO_NEW_CONTRIBUTORS_IMAGE" />
+![New Contributors List](https://static.api7.ai/uploads/2026/09/01/xxM9t0jy_2026-aug-new-contributors.webp)
 
 ## Feature Highlights
 

--- a/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
@@ -3,7 +3,7 @@ title: "2026 Monthly Report (August 01 - August 31)"
 keywords: ["Apache APISIX", "API Gateway", "Monthly Report", "Contributor"]
 description: Our monthly Apache APISIX community report generates insights into the project's monthly developments. The reports provide a pathway into the Apache APISIX community, ensuring that you stay well-informed and actively involved.
 tags: [Community]
-image: TODO_COVER_IMAGE_EN
+image: /TODO_COVER_IMAGE_EN
 ---
 
 > Recently, we've introduced and updated some new features, including advanced LDAP and OIDC authentication, stronger encryption and upstream TLS verification, faster and more resilient AI traffic, and richer traffic governance and observability. For more details, please read this month's newsletter.
@@ -18,9 +18,9 @@ From August 1st to August 31st, 10 contributors made 69 commits to Apache APISIX
 
 ## Contributor Statistics
 
-![Apache APISIX Contributors List](TODO_CONTRIBUTOR_LIST_IMAGE)
+<img alt="Apache APISIX Contributors List" src="/TODO_CONTRIBUTOR_LIST_IMAGE" />
 
-![New Contributors List](TODO_NEW_CONTRIBUTORS_IMAGE)
+<img alt="New Contributors List" src="/TODO_NEW_CONTRIBUTORS_IMAGE" />
 
 ## Feature Highlights
 

--- a/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/en/blog/2026/08/31/2026-aug-monthly-report.md
@@ -1,0 +1,127 @@
+---
+title: "2026 Monthly Report (August 01 - August 31)"
+keywords: ["Apache APISIX", "API Gateway", "Monthly Report", "Contributor"]
+description: Our monthly Apache APISIX community report generates insights into the project's monthly developments. The reports provide a pathway into the Apache APISIX community, ensuring that you stay well-informed and actively involved.
+tags: [Community]
+image: TODO_COVER_IMAGE_EN
+---
+
+> Recently, we've introduced and updated some new features, including advanced LDAP and OIDC authentication, stronger encryption and upstream TLS verification, faster and more resilient AI traffic, and richer traffic governance and observability. For more details, please read this month's newsletter.
+
+<!--truncate-->
+
+## Introduction
+
+From its inception, the Apache APISIX project has embraced the ethos of open-source community collaboration, propelling it into the ranks of the most active global open-source API gateway projects. The proverbial wisdom of 'teamwork makes the dream work' rings true in our way and is made possible by the collective effort of our community.
+
+From August 1st to August 31st, 10 contributors made 69 commits to Apache APISIX. We sincerely appreciate your contributions to Apache APISIX.
+
+## Contributor Statistics
+
+![Apache APISIX Contributors List](TODO_CONTRIBUTOR_LIST_IMAGE)
+
+![New Contributors List](TODO_NEW_CONTRIBUTORS_IMAGE)
+
+## Feature Highlights
+
+Here are the key updates from this month, grouped by capability area.
+
+### Authentication and Credential Protection
+
+#### 1. Add the `ldap-auth-advanced` Plugin for Core Authentication
+
+PR: https://github.com/apache/apisix/pull/13762
+
+Contributor: [janiussyafiq](https://github.com/janiussyafiq)
+
+This PR adds the `ldap-auth-advanced` plugin with LDAP search-then-bind, service-account or anonymous search, `user_dn` Consumer association, LDAPS/StartTLS, and protection against LDAP filter injection. It also upgrades `lua-resty-ldap` so `tls_verify: true` performs actual certificate verification and separates authentication failures from directory or transport errors.
+
+#### 2. Support PAR and DPoP Client Options in `openid-connect`
+
+PR: https://github.com/apache/apisix/pull/13649
+
+Contributor: [kevinlzw](https://github.com/kevinlzw)
+
+This PR exposes OAuth 2.0 Pushed Authorization Requests, DPoP proof generation for token and userinfo requests, and client assertion algorithm and audience options through the `openid-connect` plugin. The new settings are opt-in, DPoP private keys are encrypted in etcd, and existing configurations retain their previous behavior.
+
+#### 3. Hide LDAP Credentials from Upstreams
+
+PR: https://github.com/apache/apisix/pull/13832
+
+Contributor: [nic-6443](https://github.com/nic-6443)
+
+This PR adds a `hide_credentials` option to `ldap-auth`, allowing APISIX to remove the LDAP Basic Authentication header before proxying a request upstream. The option defaults to `false` for backward compatibility while helping operators avoid exposing reusable organization-wide credentials to backend services.
+
+### Encryption and Upstream Security
+
+#### 4. Support AES-256 Keys in the Encryption Keyring
+
+PR: https://github.com/apache/apisix/pull/13756
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR lets APISIX data encryption use either 16-byte AES-128 keys or 32-byte AES-256 keys and rejects unsupported key lengths. A keyring can contain both sizes, enabling operators to rotate from AES-128 to AES-256 without losing access to data encrypted with an older key.
+
+#### 5. Verify Upstream Certificates Against Configurable CAs
+
+PR: https://github.com/apache/apisix/pull/13863
+
+Contributor: [nic-6443](https://github.com/nic-6443)
+
+This PR makes `upstream.tls.verify` enforce certificate verification for HTTPS and gRPCS upstreams and introduces `upstream.tls.ca_certs` for per-upstream trust anchors. Leaving `verify` unset preserves the existing NGINX configuration behavior, while operators can now explicitly validate private or custom-CA upstreams.
+
+### AI Gateway Efficiency and Resilience
+
+#### 6. Select Which Request Content AWS Moderation Checks
+
+PR: https://github.com/apache/apisix/pull/13773
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR adds `request_check_roles` and `request_check_mode` to `ai-aws-content-moderation`, so operators can choose which user, tool, and system content to moderate and whether to inspect all turns or only the latest relevant block. The defaults preserve the plugin's existing coverage, while selective checks can avoid repeatedly scoring and billing for conversation history.
+
+#### 7. Send LLM Requests Through `ngx_http_ffi_client`
+
+PR: https://github.com/apache/apisix/pull/13778
+
+Contributor: [shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+This PR makes the NGINX C-based `ngx_http_ffi_client` the default transport for outbound requests from `ai-proxy`, `ai-proxy-multi`, and `ai-request-rewrite`, reducing HTTP client CPU overhead. Operators can explicitly select the previous `lua-resty-http` transport, and both clients continue to honor APISIX's resolver, streaming, keepalive, and error-handling behavior.
+
+#### 8. Configure Status-Based AI Fallbacks
+
+PR: https://github.com/apache/apisix/pull/13852
+
+Contributor: [nic-6443](https://github.com/nic-6443)
+
+This PR lets operators configure additional upstream HTTP statuses, such as 401 for an expired API key or 402 for exhausted quota, to trigger an in-flight `ai-proxy-multi` fallback. Retries remain bounded by the existing retry settings, and responses keep their previous behavior when no additional status is configured.
+
+### Traffic Governance and Observability
+
+#### 9. Add Stream Connection and Bandwidth Metrics
+
+PR: https://github.com/apache/apisix/pull/13796
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds Prometheus metrics for active TCP and UDP connections, stream session outcomes, and bandwidth in both directions. Shared-memory counters update while sessions remain open, while a new session reason distinguishes clean closes from timeouts, resets, and plugin rejections that previously appeared as the same status.
+
+#### 10. Rate Limit GraphQL Requests by Query Cost
+
+PR: https://github.com/apache/apisix/pull/13840
+
+Contributor: [AlinsRan](https://github.com/AlinsRan)
+
+This PR adds `complexity` and `node_quantifier` cost strategies to `graphql-limit-count`, allowing quotas to reflect query width, fan-out, pagination arguments, and per-field weights instead of only nesting depth. Service-scoped cost decorations, schema introspection, `max_cost`, and `score_factor` provide a configurable cost model, while `depth` remains the backward-compatible default.
+
+#### 11. Report Responses to Chaitin SafeLine WAF
+
+PR: https://github.com/apache/apisix/pull/13763
+
+Contributor: [blaisewang](https://github.com/blaisewang)
+
+This PR allows `chaitin-waf` to report response status, headers, and a configurable amount of body content to SafeLine for detecting data leaks and successful exploit output. Reporting runs asynchronously after the client response, remains advisory rather than blocking, and skips responses whose content types are configured as binary or otherwise ignored.
+
+## Conclusion
+
+The [official website](https://apisix.apache.org/) and [GitHub Issues](https://github.com/apache/apisix/issues) of Apache APISIX provide a wealth of documentation of tutorials, and real-world use cases. If you encounter any issues, you can refer to the documentation, search for keywords in Issues, or participate in discussions on Issues to share your ideas and practical experiences.

--- a/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
@@ -3,7 +3,7 @@ title: "2026 社区月报 (08.01 - 08.31)"
 keywords: ["Apache APISIX", "API 网关", "社区月报", "贡献者"]
 description: Apache APISIX 社区的月报旨在帮助社区成员更全面地了解社区的最新动态，方便大家参与到 Apache APISIX 社区中来。
 tags: [Community]
-image: TODO_COVER_IMAGE_ZH
+image: /TODO_COVER_IMAGE_ZH
 ---
 
 > 最近，我们引入并更新了一些新功能，包括增强 LDAP 与 OIDC 身份认证、强化数据加密与上游 TLS 校验、提升 AI 流量处理效率与容错能力，以及完善流量治理和可观测性等。有关更多细节，请阅读本期月报。
@@ -18,9 +18,9 @@ Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便
 
 ## 贡献者统计
 
-![贡献者名单](TODO_CONTRIBUTOR_LIST_IMAGE)
+<img alt="贡献者名单" src="/TODO_CONTRIBUTOR_LIST_IMAGE" />
 
-![新晋贡献者](TODO_NEW_CONTRIBUTORS_IMAGE)
+<img alt="新晋贡献者" src="/TODO_NEW_CONTRIBUTORS_IMAGE" />
 
 ## 近期亮点功能
 

--- a/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
@@ -78,7 +78,7 @@ Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便
 
 贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
 
-该 PR 为 `ai-aws-content-moderation` 新增 `request_check_roles` 和 `request_check_mode`，可选择审核用户、工具及系统消息，并决定检查全部历史还是最近一组相关消息。默认配置保留插件原有的审核范围，而按需选择内容可避免在每轮对话中重复审核历史消息并产生额外费用。
+该 PR 为 `ai-aws-content-moderation` 新增 `request_check_roles` 和 `request_check_mode`，可选择审核用户、工具及系统消息，并决定检查全部历史还是最近一组相关消息。默认配置保留对用户、工具和系统消息的原有审核范围，但此前由通用提取逻辑覆盖的 assistant 消息不再接受审核。按需选择内容可避免在每轮对话中重复审核历史消息并产生额外费用。
 
 #### 7. 通过 `ngx_http_ffi_client` 发送 LLM 请求
 

--- a/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
@@ -1,0 +1,127 @@
+---
+title: "2026 社区月报 (08.01 - 08.31)"
+keywords: ["Apache APISIX", "API 网关", "社区月报", "贡献者"]
+description: Apache APISIX 社区的月报旨在帮助社区成员更全面地了解社区的最新动态，方便大家参与到 Apache APISIX 社区中来。
+tags: [Community]
+image: TODO_COVER_IMAGE_ZH
+---
+
+> 最近，我们引入并更新了一些新功能，包括增强 LDAP 与 OIDC 身份认证、强化数据加密与上游 TLS 校验、提升 AI 流量处理效率与容错能力，以及完善流量治理和可观测性等。有关更多细节，请阅读本期月报。
+
+<!--truncate-->
+
+## 导语
+
+Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便崭露头角，如今已经成为全球最活跃的开源 API 网关项目之一。正如谚语所言，"众人拾柴火焰高"，这一辉煌成就，得益于整个社区伙伴的协同努力。
+
+从 2026.08.01 至 2026.08.31，有 10 名开发者提交了 69 个 commits，为 Apache APISIX 做出了重要贡献。感谢这些伙伴们对 Apache APISIX 的无私支持！正是因为你们的付出，才能让 Apache APISIX 项目不断改进、提升和壮大。
+
+## 贡献者统计
+
+![贡献者名单](TODO_CONTRIBUTOR_LIST_IMAGE)
+
+![新晋贡献者](TODO_NEW_CONTRIBUTORS_IMAGE)
+
+## 近期亮点功能
+
+以下是本月的重点更新，并按功能方向进行归类。
+
+### 身份认证与凭据保护
+
+#### 1. 新增 `ldap-auth-advanced` 核心认证能力
+
+相关 PR：https://github.com/apache/apisix/pull/13762
+
+贡献者：[janiussyafiq](https://github.com/janiussyafiq)
+
+该 PR 新增 `ldap-auth-advanced` 插件，支持 LDAP 先搜索后绑定、服务账号或匿名搜索、通过 `user_dn` 关联 Consumer、LDAPS/StartTLS，并防范 LDAP 过滤器注入。此次更新还升级了 `lua-resty-ldap`，使 `tls_verify: true` 真正执行证书校验，并将认证失败与目录服务或传输异常明确区分。
+
+#### 2. 为 `openid-connect` 支持 PAR 与 DPoP 客户端选项
+
+相关 PR：https://github.com/apache/apisix/pull/13649
+
+贡献者：[kevinlzw](https://github.com/kevinlzw)
+
+该 PR 在 `openid-connect` 插件中开放 OAuth 2.0 推送授权请求（PAR）、针对令牌和用户信息请求的 DPoP 证明生成，以及客户端断言算法和受众选项。新能力均需显式启用，DPoP 私钥会在 etcd 中加密存储，现有配置的行为保持不变。
+
+#### 3. 避免将 LDAP 凭据转发给上游
+
+相关 PR：https://github.com/apache/apisix/pull/13832
+
+贡献者：[nic-6443](https://github.com/nic-6443)
+
+该 PR 为 `ldap-auth` 增加 `hide_credentials` 选项，可在请求转发至上游前移除携带 LDAP 用户名和密码的 Basic Authentication 请求头。该选项默认关闭以保持向后兼容，同时帮助用户避免将可在组织内复用的凭据暴露给后端服务。
+
+### 数据加密与上游安全
+
+#### 4. 加密密钥环支持 AES-256 密钥
+
+相关 PR：https://github.com/apache/apisix/pull/13756
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+该 PR 让 APISIX 数据加密同时支持 16 字节的 AES-128 密钥和 32 字节的 AES-256 密钥，并拒绝其他不受支持的密钥长度。一个密钥环可混合使用两种长度，便于用户从 AES-128 平滑轮换至 AES-256，同时继续解密使用旧密钥保护的数据。
+
+#### 5. 使用可配置 CA 校验上游证书
+
+相关 PR：https://github.com/apache/apisix/pull/13863
+
+贡献者：[nic-6443](https://github.com/nic-6443)
+
+该 PR 让 `upstream.tls.verify` 对 HTTPS 和 gRPCS 上游真正执行证书校验，并新增 `upstream.tls.ca_certs`，支持为每个上游单独配置可信 CA。未设置 `verify` 时仍沿用现有 NGINX 配置行为，显式启用后则可校验使用私有 CA 或自定义 CA 的上游服务。
+
+### AI 网关效率与容错
+
+#### 6. 精细选择 AWS 内容审核的请求范围
+
+相关 PR：https://github.com/apache/apisix/pull/13773
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+该 PR 为 `ai-aws-content-moderation` 新增 `request_check_roles` 和 `request_check_mode`，可选择审核用户、工具及系统消息，并决定检查全部历史还是最近一组相关消息。默认配置保留插件原有的审核范围，而按需选择内容可避免在每轮对话中重复审核历史消息并产生额外费用。
+
+#### 7. 通过 `ngx_http_ffi_client` 发送 LLM 请求
+
+相关 PR：https://github.com/apache/apisix/pull/13778
+
+贡献者：[shreemaan-abhishek](https://github.com/shreemaan-abhishek)
+
+该 PR 将基于 NGINX C 模块的 `ngx_http_ffi_client` 设为 `ai-proxy`、`ai-proxy-multi` 和 `ai-request-rewrite` 发起上游请求时的默认传输实现，以降低 HTTP 客户端的 CPU 开销。用户仍可显式选择原有的 `lua-resty-http`，两种实现都会继续遵循 APISIX 的域名解析、流式传输、连接复用与错误处理逻辑。
+
+#### 8. 按配置的 HTTP 状态码触发 `ai-proxy-multi` 回退
+
+相关 PR：https://github.com/apache/apisix/pull/13852
+
+贡献者：[nic-6443](https://github.com/nic-6443)
+
+该 PR 支持配置更多上游 HTTP 状态码来触发 `ai-proxy-multi` 的请求内回退，例如密钥过期时的 401 或配额耗尽时的 402。回退次数仍受现有重试配置约束；若未配置额外状态码，响应处理行为保持不变。
+
+### 流量治理与可观测性
+
+#### 9. 监控 Stream 活跃连接、会话状态与带宽
+
+相关 PR：https://github.com/apache/apisix/pull/13796
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+该 PR 新增 Prometheus 指标，用于统计 TCP 和 UDP 活跃连接、Stream 会话结果以及双向带宽。共享内存中的计数器会在长连接存续期间持续更新，新增的会话结束原因还能区分正常关闭、超时、连接重置和插件拒绝，解决这些情况此前显示为相同状态的问题。
+
+#### 10. 按 GraphQL 查询成本执行限流
+
+相关 PR：https://github.com/apache/apisix/pull/13840
+
+贡献者：[AlinsRan](https://github.com/AlinsRan)
+
+该 PR 为 `graphql-limit-count` 新增 `complexity` 和 `node_quantifier` 两种成本策略，使限额能够反映查询宽度、扇出规模、分页参数及字段权重，而不再只依据嵌套深度。基于 Service 的成本规则、Schema 内省、`max_cost` 与 `score_factor` 可共同构建灵活的成本模型，同时 `depth` 仍是向后兼容的默认策略。
+
+#### 11. 将响应信息上报至长亭雷池 WAF
+
+相关 PR：https://github.com/apache/apisix/pull/13763
+
+贡献者：[blaisewang](https://github.com/blaisewang)
+
+该 PR 支持 `chaitin-waf` 将响应状态、响应头和指定大小的响应体上报至长亭雷池，用于发现数据泄露或成功攻击产生的异常输出。上报会在客户端收到响应后异步执行，仅用于检测而不会拦截或修改响应，并会跳过配置为二进制或其他忽略类型的内容。
+
+## 结语
+
+Apache APISIX 的项目[官网](https://apisix.apache.org/zh/)和 GitHub 上的 [Issues](https://github.com/apache/apisix/issues) 上已经积累了比较丰富的文档教程和使用经验，如果您遇到问题可以翻阅文档，用关键词在 Issues 中搜索，也可以参与 Issues 上的讨论，提出自己的想法和实践经验。

--- a/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
+++ b/blog/zh/blog/2026/08/31/2026-aug-monthly-report.md
@@ -3,7 +3,7 @@ title: "2026 社区月报 (08.01 - 08.31)"
 keywords: ["Apache APISIX", "API 网关", "社区月报", "贡献者"]
 description: Apache APISIX 社区的月报旨在帮助社区成员更全面地了解社区的最新动态，方便大家参与到 Apache APISIX 社区中来。
 tags: [Community]
-image: /TODO_COVER_IMAGE_ZH
+image: https://static.api7.ai/uploads/2026/09/01/rWYKjvhI_2026-aug-monthly-report-cover-cn.webp
 ---
 
 > 最近，我们引入并更新了一些新功能，包括增强 LDAP 与 OIDC 身份认证、强化数据加密与上游 TLS 校验、提升 AI 流量处理效率与容错能力，以及完善流量治理和可观测性等。有关更多细节，请阅读本期月报。
@@ -14,13 +14,13 @@ image: /TODO_COVER_IMAGE_ZH
 
 Apache APISIX 项目始终秉承着开源社区协作的精神，自问世起便崭露头角，如今已经成为全球最活跃的开源 API 网关项目之一。正如谚语所言，"众人拾柴火焰高"，这一辉煌成就，得益于整个社区伙伴的协同努力。
 
-从 2026.08.01 至 2026.08.31，有 10 名开发者提交了 69 个 commits，为 Apache APISIX 做出了重要贡献。感谢这些伙伴们对 Apache APISIX 的无私支持！正是因为你们的付出，才能让 Apache APISIX 项目不断改进、提升和壮大。
+从 2026.08.01 至 2026.08.31，有 13 名开发者提交了 117 个 commits，为 Apache APISIX 做出了重要贡献。感谢这些伙伴们对 Apache APISIX 的无私支持！正是因为你们的付出，才能让 Apache APISIX 项目不断改进、提升和壮大。
 
 ## 贡献者统计
 
-<img alt="贡献者名单" src="/TODO_CONTRIBUTOR_LIST_IMAGE" />
+![贡献者名单](https://static.api7.ai/uploads/2026/09/01/N8c2DgwP_2026-aug-contributor-list.webp)
 
-<img alt="新晋贡献者" src="/TODO_NEW_CONTRIBUTORS_IMAGE" />
+![新晋贡献者](https://static.api7.ai/uploads/2026/09/01/xxM9t0jy_2026-aug-new-contributors.webp)
 
 ## 近期亮点功能
 


### PR DESCRIPTION
## Summary

Add the August 2026 community monthly report in English and Simplified Chinese.

## Feature Highlights Covered

### Authentication and Credential Protection

1. **Add the `ldap-auth-advanced` Plugin for Core Authentication** - PR #13762
2. **Support PAR and DPoP Client Options in `openid-connect`** - PR #13649
3. **Hide LDAP Credentials from Upstreams** - PR #13832

### Encryption and Upstream Security

4. **Support AES-256 Keys in the Encryption Keyring** - PR #13756
5. **Verify Upstream Certificates Against Configurable CAs** - PR #13863

### AI Gateway Efficiency and Resilience

6. **Select Which Request Content AWS Moderation Checks** - PR #13773
7. **Send LLM Requests Through `ngx_http_ffi_client`** - PR #13778
8. **Configure Status-Based AI Fallbacks** - PR #13852

### Traffic Governance and Observability

9. **Add Stream Connection and Bandwidth Metrics** - PR #13796
10. **Rate Limit GraphQL Requests by Query Cost** - PR #13840
11. **Report Responses to Chaitin SafeLine WAF** - PR #13763

## Contributor Statistics

- **13** contributors and **117** commits
- Contributors: `AlinsRan`, `Arjen10`, `kevinlzw`, `DanielWu-star`, `moonming`, `kayx23`, `lxbme`, `Yilialinn`, `shreemaan-abhishek`, `nic-6443`, `blaisewang`, `janiussyafiq`, `suryaparua-official`
- **2** new contributors: `kevinlzw`, `DanielWu-star`

## Data Scope and Snapshot

- Target month: August 2026, the previous complete calendar month for the first-workday run on September 1, 2026 (Asia/Shanghai)
- Commit interval: `2026-08-01T00:00:00Z` through `2026-08-31T23:59:59Z`, inclusive, on the `apache/apisix` default branch (`master`)
- Feature-data snapshot: `apache/apisix@bd8ac3a86dd9753e4e4c17b0d28abfd01b68021f`, collected on September 1, 2026; the August interval runs from `5f33466e26c8224ca5fc7fb092b6d4f6aa0690c3` through `10e61e0fdad296fe89368e73e9b0dbdb452e6197`
- Contributor statistics and login lists use the user-confirmed values supplied on September 1, 2026, verbatim; they were not recalculated or reinterpreted
- Feature selection keeps every August commit whose subject begins with `feat`, except `feat(test):` and `feat(seo):`; 11 qualified and none matched the exclusions
- No open `good first issue` created or labeled during August qualified, so that section is omitted

## Validation

- `git diff --check`
- `markdownlint` on both report files
- `yarn remark` on both report files: no issues found
- `yarn lint:frontmatter`
- Local blog builds were not started because dependency installation reduced free disk space to 43 GiB, below the repository host's 45 GiB safety threshold for heavy builds
- GitHub Actions passed the full website build, Astro build, desktop/mobile final-site test, Markdown, Frontmatter, YAML, and broken-link checks on the previously validated head `2a735bc14e988aa47b97f5953b0a074c59bca1a1`; current head `e17bb3a88b5a9498f4796c802e085c257126438b` has the same checks queued after addressing all three Copilot review comments

## Images

- Added the final English and Chinese cover images
- Added the final contributor-list and new-contributor images
- All four WebP URLs returned HTTP 200 with `image/webp` on September 1, 2026
