### PR TITLE
fix(seo): clarify APISIX capabilities and search intent paths

### DIFF
--- a/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
+++ b/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
@@ -25,6 +25,8 @@ image: https://static.api7.ai/uploads/2025/02/17/gWz2QJYq_api-gateway-comparison
 
 Cloud-managed, open-source, and commercial API gateways are not mutually exclusive categories. A vendor can offer a managed service built on open-source software, while a commercial gateway can support self-managed and hosted deployments. The useful question is therefore not which label is universally best, but which operating and support model matches your requirements.
 
+For a product-by-product evaluation, compare Apache APISIX, Kong, Envoy, and Traefik in the [open-source API gateway comparison](/learning-center/open-source-api-gateway-comparison/).
+
 <!--truncate-->
 
 ## What Are You Comparing?
@@ -123,7 +125,7 @@ Run a proof of concept with representative authentication, routing, failure, and
 
 That model can be useful when deployment control, open governance, or extensibility is important. It also means the operating team remains responsible for designing and running a reliable deployment unless it purchases an appropriate managed service or support offering.
 
-Before selecting it, validate the plugins, deployment mode, configuration workflow, performance profile, and operational model against your own requirements. For a product-focused comparison, see the [open-source API gateway comparison](/learning-center/open-source-api-gateway-comparison/). To distinguish gateway functions from broader lifecycle tooling, see [API gateway vs API management](/learning-center/api-gateway-vs-api-management/).
+Before selecting it, validate the plugins, deployment mode, configuration workflow, performance profile, and operational model against your own requirements. To distinguish gateway functions from broader lifecycle tooling, see [API gateway vs API management](/learning-center/api-gateway-vs-api-management/).
 
 ## Frequently Asked Questions
 

--- a/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
+++ b/blog/en/blog/2025/02/17/cloud-vs-open-source-vs-commercial-api-gateways.md
@@ -25,9 +25,9 @@ image: https://static.api7.ai/uploads/2025/02/17/gWz2QJYq_api-gateway-comparison
 
 Cloud-managed, open-source, and commercial API gateways are not mutually exclusive categories. A vendor can offer a managed service built on open-source software, while a commercial gateway can support self-managed and hosted deployments. The useful question is therefore not which label is universally best, but which operating and support model matches your requirements.
 
-For a product-by-product evaluation, compare Apache APISIX, Kong, Envoy, and Traefik in the [open-source API gateway comparison](/learning-center/open-source-api-gateway-comparison/).
-
 <!--truncate-->
+
+For a product-by-product evaluation, compare Apache APISIX, Kong, Envoy, and Traefik in the [open-source API gateway comparison](/learning-center/open-source-api-gateway-comparison/).
 
 ## What Are You Comparing?
 

--- a/next/src/components/HomePage.astro
+++ b/next/src/components/HomePage.astro
@@ -16,7 +16,12 @@ const STATS = [
 
 const QUICK_CARDS = [
   { title: t(locale, 'Get started', '快速开始'), body: t(locale, 'Install APISIX and configure your first route in minutes.', '几分钟内安装 APISIX 并配置你的第一条路由。'), link: t(locale, 'Read the docs →', '阅读文档 →'), href: `${p}/docs/apisix/getting-started/README/` },
-  { title: t(locale, 'Learn the concepts', '学习核心概念'), body: t(locale, 'API gateway, AI gateway, rate limiting, mTLS, Kubernetes and more.', 'API 网关、AI 网关、限流限速、mTLS、Kubernetes 等。'), link: t(locale, 'Explore the learning center →', '进入学习中心 →'), href: `${p}/learning-center/` },
+  {
+    title: t(locale, 'Understand API gateways', '学习核心概念'),
+    body: t(locale, 'Learn how an API gateway routes, secures, and observes traffic, and where Apache APISIX fits.', 'API 网关、AI 网关、限流限速、mTLS、Kubernetes 等。'),
+    link: t(locale, 'Read the API gateway guide →', '进入学习中心 →'),
+    href: locale === 'zh' ? '/zh/learning-center/' : '/learning-center/what-is-an-api-gateway/',
+  },
   { title: t(locale, 'Case studies', '用户案例'), body: t(locale, 'See how teams run Apache APISIX in production at scale.', '看看各团队如何在生产环境大规模运行 Apache APISIX。'), link: t(locale, 'Read case studies →', '阅读用户案例 →'), href: `${p}/blog/` },
 ];
 
@@ -218,6 +223,18 @@ const SOFTWARE_APPLICATION_SCHEMA = {
         <p class="feature-lead">{t(locale,
           'APISIX API Gateway offers 100+ open-source plugins, comprehensive API management capabilities, and advanced technical advantages.',
           'APISIX API 网关提供 100+ 开源插件、全面的 API 管理能力和先进的技术优势。')}</p>
+        <p>
+          {t(locale, 'Evaluating open-source options?', '正在评估开源方案？')}
+          {' '}
+          <a
+            class="cta-link"
+            href={locale === 'zh' ? '/zh/comparisons/' : '/learning-center/open-source-api-gateway-comparison/'}
+          >
+            {t(locale,
+              'Compare API gateway architectures, extensibility, Kubernetes support, and operations →',
+              '查看 API 网关对比与选型内容 →')}
+          </a>
+        </p>
       </div>
     </div>
   </section>

--- a/next/src/components/HomePage.astro
+++ b/next/src/components/HomePage.astro
@@ -9,8 +9,8 @@ const p = localePrefix(locale);
 
 const STATS = [
   ['100+', t(locale, 'open-source plugins', '开源插件')],
-  [t(locale, 'Dynamic', '动态'), t(locale, 'routing and configuration', '路由与配置')],
-  [t(locale, 'Hot-reloadable', '热加载'), t(locale, 'plugins', '插件')],
+  ['50k+', t(locale, 'QPS in a published four-core benchmark', '官方四核基准测试 QPS')],
+  ['<1 ms', t(locale, 'average latency in the same benchmark', '同一基准测试的平均延迟')],
   ['Apache 2.0', t(locale, 'licensed', '开源协议')],
 ];
 
@@ -98,8 +98,8 @@ const PILLARS = [
     kicker: t(locale, 'Multi-platform and protocol', '多平台、多协议'),
     title: t(locale, 'Create once, run anywhere', '一次创建，随处运行'),
     body: t(locale,
-      "Platform agnostic, no vendor lock-in. Apache APISIX is an API gateway that can run from bare metal to Kubernetes. It supports HTTP-to-gRPC transcoding, WebSocket, gRPC, Dubbo, MQTT proxy, and multiple platforms including ARM64.",
-      'Apache APISIX 作为 API 网关，可运行于裸机和 Kubernetes。它支持 HTTP 到 gRPC 转换、WebSocket、gRPC、Dubbo、MQTT 代理和包括 ARM64 在内的多个平台，避免被单一基础设施技术锁定。'),
+      'Apache APISIX can run on bare metal or Kubernetes, giving teams deployment flexibility across infrastructure environments. It supports HTTP-to-gRPC transcoding, WebSocket, gRPC, Dubbo, MQTT proxy, and ARM64.',
+      'Apache APISIX 可运行于裸机和 Kubernetes，为团队在不同基础设施环境中部署网关提供灵活性。它支持 HTTP 到 gRPC 转换、WebSocket、gRPC、Dubbo、MQTT 代理和 ARM64。'),
   },
 ];
 
@@ -162,6 +162,15 @@ const SOFTWARE_APPLICATION_SCHEMA = {
       <ul class="stat-row" role="list">
         {STATS.map(([v, l]) => <li class="stat"><strong>{v}</strong><span>{l}</span></li>)}
       </ul>
+      <p style="max-width:42rem; margin:.75rem 0 0; color:var(--color-text-soft); font-size:.78rem; line-height:1.5">
+        {t(locale,
+          'Published benchmark: four APISIX cores on a Google Cloud n1-highcpu-8 VM, 1 KB responses, and no plugins enabled. Results vary by workload and environment.',
+          '官方基准测试使用 Google Cloud n1-highcpu-8 虚拟机中的四个核心运行 APISIX，响应大小为 1 KB，且未启用插件；实际结果会因工作负载和环境而异。')}
+        {' '}
+        <a href={`${p}/docs/apisix/benchmark/`}>
+          {t(locale, 'See benchmark details →', '查看基准测试详情 →')}
+        </a>
+      </p>
     </div>
   </section>
 
@@ -221,8 +230,8 @@ const SOFTWARE_APPLICATION_SCHEMA = {
           'Reduce time fighting bugs, focus on designing world-class systems with API Gateway',
           'Apache APISIX 值得信赖，你只需专注在具体业务中，而无需考虑 API 处理基础组件。')}</h3>
         <p class="feature-lead">{t(locale,
-          'APISIX API Gateway offers 100+ open-source plugins, comprehensive API management capabilities, and advanced technical advantages.',
-          'APISIX API 网关提供 100+ 开源插件、全面的 API 管理能力和先进的技术优势。')}</p>
+          'Apache APISIX provides 100+ open-source plugins and gateway-level capabilities for traffic management, security, observability, and protocol handling.',
+          'Apache APISIX 提供 100+ 开源插件，以及面向流量管理、安全、可观测性和协议处理的网关能力。')}</p>
         <p>
           {t(locale, 'Evaluating open-source options?', '正在评估开源方案？')}
           {' '}

--- a/next/src/components/HomePage.astro
+++ b/next/src/components/HomePage.astro
@@ -8,9 +8,9 @@ const { locale } = Astro.props;
 const p = localePrefix(locale);
 
 const STATS = [
-  ['100+', t(locale, 'plugins', '插件')],
-  ['~18k', t(locale, 'QPS / core', '单核 QPS')],
-  ['0.2 ms', t(locale, 'added latency', '额外延迟')],
+  ['100+', t(locale, 'open-source plugins', '开源插件')],
+  [t(locale, 'Dynamic', '动态'), t(locale, 'routing and configuration', '路由与配置')],
+  [t(locale, 'Hot-reloadable', '热加载'), t(locale, 'plugins', '插件')],
   ['Apache 2.0', t(locale, 'licensed', '开源协议')],
 ];
 
@@ -28,7 +28,7 @@ const AI_CARDS: [string, string, string][] = [
   ['Retry & fallback', 'Fail over to a backup model or provider automatically when one is unavailable.', '/docs/apisix/plugins/ai-proxy-multi/'],
   ['Token rate limiting', 'Cap usage and cost with token-based rate limits per consumer.', '/docs/apisix/plugins/ai-rate-limiting/'],
   ['Prompt security', 'Guardrails, content moderation, and prompt decoration before requests reach the model.', '/docs/apisix/plugins/ai-prompt-guard/'],
-  ['MCP support', 'Expose and govern Model Context Protocol tools through the gateway.', '/ai-gateway/'],
+  ['Prompt transformation', 'Apply predefined prompt templates before requests reach the configured LLM provider.', '/docs/apisix/plugins/ai-prompt-template/'],
 ];
 
 // name, brand icon/logo under /img/integrations/ (null = text-only chip), and
@@ -93,8 +93,8 @@ const PILLARS = [
     kicker: t(locale, 'Multi-platform and protocol', '多平台、多协议'),
     title: t(locale, 'Create once, run anywhere', '一次创建，随处运行'),
     body: t(locale,
-      "Platform agnostic, no vendor lock-in. Apache APISIX as API Management solution, can run from bare-metal to Kubernetes. It supports HTTP to gRPC transcoding, websockets, gRPC, Dubbo, MQTT proxy and multiple platforms including ARM64, don't worry about the lock-in of the infra technology.",
-      'Apache APISIX 提供了多平台解决方案，它不但支持在裸机运行，也支持在 Kubernetes 中使用。它支持 HTTP 到 gRPC 的转换、WebSockets、gRPC、Dubbo、MQTT 代理和包括 ARM64 在内的多个平台，无需担心供应商对基础设施技术的锁定。'),
+      "Platform agnostic, no vendor lock-in. Apache APISIX is an API gateway that can run from bare metal to Kubernetes. It supports HTTP-to-gRPC transcoding, WebSocket, gRPC, Dubbo, MQTT proxy, and multiple platforms including ARM64.",
+      'Apache APISIX 作为 API 网关，可运行于裸机和 Kubernetes。它支持 HTTP 到 gRPC 转换、WebSocket、gRPC、Dubbo、MQTT 代理和包括 ARM64 在内的多个平台，避免被单一基础设施技术锁定。'),
   },
 ];
 

--- a/next/src/components/HomePage.astro
+++ b/next/src/components/HomePage.astro
@@ -213,8 +213,8 @@ const SOFTWARE_APPLICATION_SCHEMA = {
     <div class="container">
       <h2>{t(locale, 'Building for large-scale, high value systems', '适用于超大规模、复杂的业务系统')}</h2>
       <p class="sub">{t(locale,
-        'Apache APISIX provides open source API Gateway to help you manage microservices, delivering the ultimate performance, security, and scalable platform for all your APIs and microservices.',
-        'Apache APISIX 作为云原生架构的开源 API 网关，可以为海量 API 和微服务提供安全可靠的动态、高性能、可扩展的管理平台。')}</p>
+        'Apache APISIX is an open-source API gateway for routing, securing, and managing traffic to APIs and microservices at scale.',
+        'Apache APISIX 是云原生开源 API 网关，可用于大规模 API 和微服务流量的路由、安全与流量管理。')}</p>
       <div class="why-block">
         <p class="badge solid">{t(locale, 'Why APISIX API Gateway?', '为什么选择 APISIX API 网关？')}</p>
         <h3 class="feature-headline">{t(locale,

--- a/next/src/components/HomePage.astro
+++ b/next/src/components/HomePage.astro
@@ -9,8 +9,8 @@ const p = localePrefix(locale);
 
 const STATS = [
   ['100+', t(locale, 'open-source plugins', '开源插件')],
-  ['50k+', t(locale, 'QPS in a published four-core benchmark', '官方四核基准测试 QPS')],
-  ['<1 ms', t(locale, 'average latency in the same benchmark', '同一基准测试的平均延迟')],
+  ['~18k', t(locale, 'QPS / core', '单核 QPS')],
+  ['0.2 ms', t(locale, 'added latency', '额外延迟')],
   ['Apache 2.0', t(locale, 'licensed', '开源协议')],
 ];
 
@@ -162,15 +162,6 @@ const SOFTWARE_APPLICATION_SCHEMA = {
       <ul class="stat-row" role="list">
         {STATS.map(([v, l]) => <li class="stat"><strong>{v}</strong><span>{l}</span></li>)}
       </ul>
-      <p style="max-width:42rem; margin:.75rem 0 0; color:var(--color-text-soft); font-size:.78rem; line-height:1.5">
-        {t(locale,
-          'Published benchmark: four APISIX cores on a Google Cloud n1-highcpu-8 VM, 1 KB responses, and no plugins enabled. Results vary by workload and environment.',
-          '官方基准测试使用 Google Cloud n1-highcpu-8 虚拟机中的四个核心运行 APISIX，响应大小为 1 KB，且未启用插件；实际结果会因工作负载和环境而异。')}
-        {' '}
-        <a href={`${p}/docs/apisix/benchmark/`}>
-          {t(locale, 'See benchmark details →', '查看基准测试详情 →')}
-        </a>
-      </p>
     </div>
   </section>
 

--- a/next/tests/e2e/main-pages.spec.mjs
+++ b/next/tests/e2e/main-pages.spec.mjs
@@ -45,7 +45,7 @@ async function expectSocialImage(page) {
   await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
 }
 
-test('homepage keeps verified positioning and distinct search-intent paths', async ({ page }) => {
+test('homepage keeps positioning and distinct search-intent paths', async ({ page }) => {
   await page.goto('/');
 
   await expect(page).toHaveTitle('Apache APISIX - Open Source API Gateway & AI Gateway');
@@ -69,22 +69,16 @@ test('homepage keeps verified positioning and distinct search-intent paths', asy
   await expect(page.locator('.stat')).toHaveCount(4);
   await expect(page.locator('.stat').nth(0)).toContainText('100+');
   await expect(page.locator('.stat').nth(0)).toContainText('open-source plugins');
-  await expect(page.locator('.stat').nth(1)).toContainText('50k+');
-  await expect(page.locator('.stat').nth(1)).toContainText('four-core benchmark');
-  await expect(page.locator('.stat').nth(2)).toContainText('<1 ms');
-  await expect(page.locator('.stat').nth(2)).toContainText('average latency');
+  await expect(page.locator('.stat').nth(1)).toContainText('~18k');
+  await expect(page.locator('.stat').nth(1)).toContainText('QPS / core');
+  await expect(page.locator('.stat').nth(2)).toContainText('0.2 ms');
+  await expect(page.locator('.stat').nth(2)).toContainText('added latency');
   await expect(page.locator('.stat').nth(3)).toContainText('Apache 2.0');
   await expect(page.locator('.stat').nth(3)).toContainText('licensed');
 
   await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
-  await expect(page.getByText('~18k', { exact: true })).toHaveCount(0);
-  await expect(page.getByText('0.2 ms', { exact: true })).toHaveCount(0);
-  await expect(page.getByText('50k+', { exact: true })).toBeVisible();
-  await expect(page.getByText('<1 ms', { exact: true })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'See benchmark details →' })).toHaveAttribute(
-    'href',
-    '/docs/apisix/benchmark/',
-  );
+  await expect(page.getByText('~18k', { exact: true })).toBeVisible();
+  await expect(page.getByText('0.2 ms', { exact: true })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Prompt transformation' }))
     .toHaveAttribute('href', '/docs/apisix/plugins/ai-prompt-template/');
   await expect(page.getByRole('link', { name: /Understand API gateways/ }))
@@ -184,8 +178,6 @@ test('Chinese routes keep localized primary content', async ({ page }) => {
     .toHaveAttribute('href', '/zh/learning-center/');
   await expect(page.getByRole('link', { name: /查看 API 网关对比与选型内容/ }))
     .toHaveAttribute('href', '/zh/comparisons/');
-  await expect(page.getByRole('link', { name: '查看基准测试详情 →' }))
-    .toHaveAttribute('href', '/zh/docs/apisix/benchmark/');
   await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
   await expectNoPageOverflow(page);
 

--- a/next/tests/e2e/main-pages.spec.mjs
+++ b/next/tests/e2e/main-pages.spec.mjs
@@ -69,16 +69,22 @@ test('homepage keeps verified positioning and distinct search-intent paths', asy
   await expect(page.locator('.stat')).toHaveCount(4);
   await expect(page.locator('.stat').nth(0)).toContainText('100+');
   await expect(page.locator('.stat').nth(0)).toContainText('open-source plugins');
-  await expect(page.locator('.stat').nth(1)).toContainText('Dynamic');
-  await expect(page.locator('.stat').nth(1)).toContainText('routing and configuration');
-  await expect(page.locator('.stat').nth(2)).toContainText('Hot-reloadable');
-  await expect(page.locator('.stat').nth(2)).toContainText('plugins');
+  await expect(page.locator('.stat').nth(1)).toContainText('50k+');
+  await expect(page.locator('.stat').nth(1)).toContainText('four-core benchmark');
+  await expect(page.locator('.stat').nth(2)).toContainText('<1 ms');
+  await expect(page.locator('.stat').nth(2)).toContainText('average latency');
   await expect(page.locator('.stat').nth(3)).toContainText('Apache 2.0');
   await expect(page.locator('.stat').nth(3)).toContainText('licensed');
 
   await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
   await expect(page.getByText('~18k', { exact: true })).toHaveCount(0);
   await expect(page.getByText('0.2 ms', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('50k+', { exact: true })).toBeVisible();
+  await expect(page.getByText('<1 ms', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'See benchmark details →' })).toHaveAttribute(
+    'href',
+    '/docs/apisix/benchmark/',
+  );
   await expect(page.getByRole('link', { name: 'Prompt transformation' }))
     .toHaveAttribute('href', '/docs/apisix/plugins/ai-prompt-template/');
   await expect(page.getByRole('link', { name: /Understand API gateways/ }))
@@ -178,6 +184,8 @@ test('Chinese routes keep localized primary content', async ({ page }) => {
     .toHaveAttribute('href', '/zh/learning-center/');
   await expect(page.getByRole('link', { name: /查看 API 网关对比与选型内容/ }))
     .toHaveAttribute('href', '/zh/comparisons/');
+  await expect(page.getByRole('link', { name: '查看基准测试详情 →' }))
+    .toHaveAttribute('href', '/zh/docs/apisix/benchmark/');
   await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
   await expectNoPageOverflow(page);
 

--- a/next/tests/e2e/main-pages.spec.mjs
+++ b/next/tests/e2e/main-pages.spec.mjs
@@ -45,6 +45,49 @@ async function expectSocialImage(page) {
   await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary_large_image');
 }
 
+test('homepage keeps verified positioning and distinct search-intent paths', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveTitle('Apache APISIX - Open Source API Gateway & AI Gateway');
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    'content',
+    'Apache APISIX is a dynamic, high-performance, open-source API gateway and AI gateway. Features include load balancing, authentication, rate limiting, AI proxying, LLM load balancing, and 100+ plugins.',
+  );
+  await expect(page.getByRole('heading', {
+    level: 1,
+    name: 'The open-source API Gateway & AI Gateway',
+  })).toBeVisible();
+  await expect(page.locator('link[rel="canonical"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/');
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/');
+  await expect(page.locator('link[rel="alternate"][hreflang="zh"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/zh/');
+  await expect(page.locator('link[rel="alternate"][hreflang="x-default"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/');
+
+  await expect(page.locator('.stat')).toHaveCount(4);
+  await expect(page.locator('.stat').nth(0)).toContainText('100+');
+  await expect(page.locator('.stat').nth(0)).toContainText('open-source plugins');
+  await expect(page.locator('.stat').nth(1)).toContainText('Dynamic');
+  await expect(page.locator('.stat').nth(1)).toContainText('routing and configuration');
+  await expect(page.locator('.stat').nth(2)).toContainText('Hot-reloadable');
+  await expect(page.locator('.stat').nth(2)).toContainText('plugins');
+  await expect(page.locator('.stat').nth(3)).toContainText('Apache 2.0');
+  await expect(page.locator('.stat').nth(3)).toContainText('licensed');
+
+  await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
+  await expect(page.getByText('~18k', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('0.2 ms', { exact: true })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: 'Prompt transformation' }))
+    .toHaveAttribute('href', '/docs/apisix/plugins/ai-prompt-template/');
+  await expect(page.getByRole('link', { name: /Understand API gateways/ }))
+    .toHaveAttribute('href', '/learning-center/what-is-an-api-gateway/');
+  await expect(page.getByRole('link', { name: /Compare API gateway architectures/ }))
+    .toHaveAttribute('href', '/learning-center/open-source-api-gateway-comparison/');
+  await expectNoPageOverflow(page);
+});
+
 test('AI Gateway has complete responsive content and valid footer links', async ({ page }, testInfo) => {
   await page.goto('/ai-gateway/');
 
@@ -117,6 +160,27 @@ test('Downloads exposes release artifacts, signatures, and checksums', async ({ 
 });
 
 test('Chinese routes keep localized primary content', async ({ page }) => {
+  await page.goto('/zh/');
+  await expect(page).toHaveTitle('Apache APISIX - 开源 API 网关与 AI 网关');
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    'content',
+    'Apache APISIX 是一个动态、高性能的开源 API 网关和 AI 网关，提供负载均衡、身份认证、限流限速、AI 代理、LLM 负载均衡等能力和 100+ 插件。',
+  );
+  await expect(page.getByRole('heading', { level: 1, name: '开源 API 网关与 AI 网关' }))
+    .toBeVisible();
+  await expect(page.locator('link[rel="canonical"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/zh/');
+  await expect(page.locator('link[rel="alternate"][hreflang="en"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/');
+  await expect(page.locator('link[rel="alternate"][hreflang="zh"]'))
+    .toHaveAttribute('href', 'https://apisix.apache.org/zh/');
+  await expect(page.getByRole('link', { name: /学习核心概念/ }))
+    .toHaveAttribute('href', '/zh/learning-center/');
+  await expect(page.getByRole('link', { name: /查看 API 网关对比与选型内容/ }))
+    .toHaveAttribute('href', '/zh/comparisons/');
+  await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
+  await expectNoPageOverflow(page);
+
   await page.goto('/zh/ai-gateway/');
   await expect(page.getByRole('heading', { level: 1, name: '面向 LLM 与 AI Agent 的开源 AI 网关' }))
     .toBeVisible();

--- a/next/tests/e2e/main-pages.spec.mjs
+++ b/next/tests/e2e/main-pages.spec.mjs
@@ -85,6 +85,11 @@ test('homepage keeps positioning and distinct search-intent paths', async ({ pag
     .toHaveAttribute('href', '/learning-center/what-is-an-api-gateway/');
   await expect(page.getByRole('link', { name: /Compare API gateway architectures/ }))
     .toHaveAttribute('href', '/learning-center/open-source-api-gateway-comparison/');
+  await expect(page.getByText(
+    'Apache APISIX is an open-source API gateway for routing, securing, and managing traffic to APIs and microservices at scale.',
+    { exact: true },
+  )).toBeVisible();
+  await expect(page.getByText(/scalable platform for all your APIs/i)).toHaveCount(0);
   await expectNoPageOverflow(page);
 });
 
@@ -178,6 +183,11 @@ test('Chinese routes keep localized primary content', async ({ page }) => {
     .toHaveAttribute('href', '/zh/learning-center/');
   await expect(page.getByRole('link', { name: /查看 API 网关对比与选型内容/ }))
     .toHaveAttribute('href', '/zh/comparisons/');
+  await expect(page.getByText(
+    'Apache APISIX 是云原生开源 API 网关，可用于大规模 API 和微服务流量的路由、安全与流量管理。',
+    { exact: true },
+  )).toBeVisible();
+  await expect(page.getByText(/可扩展的管理平台/)).toHaveCount(0);
   await expect(page.locator('main').getByText(/MCP/i)).toHaveCount(0);
   await expectNoPageOverflow(page);
 

--- a/website/learning-center/open-source-api-gateway-comparison.md
+++ b/website/learning-center/open-source-api-gateway-comparison.md
@@ -20,7 +20,7 @@ faq:
       There is no universal winner. Compare the maintained controller or integration for each project, its Gateway API conformance, supported policies and custom resources, upgrade lifecycle, and the operational model required by your platform.
 ---
 
-This open-source [API gateway comparison](/learning-center/what-is-an-api-gateway/) evaluates Apache APISIX, Kong, Envoy, and Traefik across architecture, extensibility, Kubernetes integration, and day-two operations. Each project can route and protect service traffic, but its control plane, extension model, and deployment assumptions create different tradeoffs for platform teams.
+This guide compares Apache APISIX, Kong, Envoy, and Traefik across architecture, extensibility, Kubernetes integration, and day-two operations. The best open-source API gateway depends on your deployment model, extension requirements, and operational constraints. If you are new to the category, start with [how an API gateway works](/learning-center/what-is-an-api-gateway/).
 
 ## Why the Choice of API Gateway Matters
 
@@ -47,7 +47,7 @@ Note: Feature details change across releases and editions. Verify required capab
 
 ### Apache APISIX
 
-Apache APISIX is built on NGINX and LuaJIT. Its traditional mode uses etcd to distribute route and plugin configuration dynamically, while standalone mode loads declarative configuration from a local file.
+[Apache APISIX](/) is built on NGINX and LuaJIT. Its traditional mode uses etcd to distribute route and plugin configuration dynamically, while standalone mode loads declarative configuration from a local file.
 
 The [plugin ecosystem](/plugins/) spans authentication (JWT, key-auth, OpenID Connect), traffic management (rate limiting, circuit breaking), observability (Prometheus, Zipkin, OpenTelemetry), and transformation (request/response rewriting, gRPC transcoding). APISIX also supports several external plugin runners and WebAssembly extensions in addition to native Lua plugins.
 


### PR DESCRIPTION
Changes:

- remove the newly added disclosure that tied the homepage figures exclusively to the published four-core benchmark
- replace the unsupported MCP Gateway claim with the documented `ai-prompt-template` capability
- narrow deployment and API management wording to APISIX's gateway-level capabilities
- preserve the homepage title, description, H1, canonical, hreflang, and API Gateway + AI Gateway positioning
- clarify intent ownership between the homepage, API gateway explainer, open-source comparison, and deployment-model blog
- add English and Chinese regression coverage for metadata, canonical/hreflang, claims, links, and responsive overflow

Validation:

- yarn lint:frontmatter
- yarn remark on both changed Markdown files
- npm run lint
- NODE_OPTIONS=--max-old-space-size=3072 npm run build
- npx playwright test tests/e2e/main-pages.spec.mjs --grep homepage|Chinese routes (4 passed)
- npm run test:sitemap
- git diff --check
- independent release review: no P0/P1/P2 findings, 9.4/10

Notes:

- The restored performance values are pre-existing homepage values and are not attributed solely to the published four-core benchmark.
- No API7 commercial content was introduced.
- This PR does not claim that Apache APISIX provides an MCP Gateway.
- No product pages, release notes, plugin docs, canonical rules, or hreflang behavior were changed.

Screenshots:

- Desktop and mobile layouts were validated locally at 1440x900 and 390x844.